### PR TITLE
Changes in this commit:

### DIFF
--- a/hdf5/hdf5-1.14.6/src/H5CL.c
+++ b/hdf5/hdf5-1.14.6/src/H5CL.c
@@ -27,8 +27,11 @@
 /* Headers */
 /***********/
 #include "H5private.h"   /* Generic Functions                        */
-#include "H5CLpkg.h"   /* VFD Configuration language               */
+#include "H5Iprivate.h"  /* IDs                                      */
+#include "H5CLpkg.h"     /* VFD Configuration language               */
+#include "H5Pprivate.h"  /* Property lists                           */
 #include "H5Eprivate.h"  /* Error handling                           */
+#include "H5FDprivate.h" /* VFDs                                     */
 
 
 /****************/
@@ -62,6 +65,282 @@
 
 /*******************************************************************************
  *
+ * Function:    H5CL_load_vfd_config_str_into_fapl
+ *
+ * Purpose:     Given a vfd configuration string, and possibly a fapl_id, 
+ *              
+ *              1) parse the top level of the input string to determine 
+ *                 the name of the target vfd.
+ *
+ *              2) Verify that the vfd name is valid
+ *
+ *              3) Load the vfd name and associated configuration string into 
+ *                 the supplied fapl.
+ *
+ *                                              JRM -- 1/8/26
+ *
+ * Return:      Success:        non-negative
+ *              Failure:        negative
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+herr_t
+H5CL_load_vfd_config_str_into_fapl(hid_t fapl_id, char * vfd_config_str_ptr)
+{
+    char * vfd_name = NULL;
+    bool vfd_ref_inc = false;
+    H5P_genplist_t *plist;               /* Property list pointer */
+    htri_t vfd_is_registered;
+    hid_t  vfd_id = H5I_INVALID_HID; 
+    H5CL_nv_pair_t top_pair;
+    H5CL_lex_vars_t lex_vars = {
+        /* struct_tag        = */ H5CL_LEX_VARS_STRUCT_TAG,
+        /* input_str_ptr     = */ NULL, 
+        /* next_char_ptr     = */ NULL,
+        /* end_of_input      = */ false, 
+        /* err_ctx           = */ "",
+        /* token             = */ {
+        /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
+        /* token.code        = */    H5CL_ERROR_TOK,
+        /* token.str_ptr     = */    NULL,
+        /* token.str_len     = */    0,
+        /* token.max_str_len = */    0,
+        /* token.int_val     = */    1,    /* should be overwritten on init */
+        /* token.f_val       = */    1.0,  /* should be overwritten on init */
+        /* token.bb_ptr      = */    NULL,
+        /* token.bb_len      = */    0
+        /* end of token        */ }
+    }; 
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    assert( vfd_config_str_ptr );
+   
+
+    top_pair.struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
+
+    if ( H5CL_init_nv_pair(&top_pair) < 0 )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't initialize top_pair.");
+
+    /* setup lex_vars for the parsing the expected top level name value pair */
+    if ( H5CL__init_lex_vars(vfd_config_str_ptr, &lex_vars) < 0 )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't initialize lex_vars.");
+
+    /* parse the top level name value pair */
+    if ( H5CL__parse_name_value_pair(&top_pair, &lex_vars) < 0 )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't parse top level name val pair.");
+
+    /* verify that the value of the top level name value pair is a name value pair list */
+    if ( top_pair.val_type != H5CL_VAL_LIST )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "value of top level name value pair is not a list.");
+
+    /* top_pair.name will be discarded when we call H5CL_take_down_nv_pair().  Thus delay 
+     * this call until closing so as to avoid deleting the string out from under us..
+     */
+    vfd_name = top_pair.name_ptr;
+
+    assert(vfd_name);
+
+    /* now look up the ID associated with the VFD name, registering it in passing 
+     * if appropriate.  Note that this section of the function is adapted from 
+     * H5P__facc_set_def_driver() in H5Pfapl.c
+     */
+    if ( (vfd_is_registered = H5FD_is_driver_registered_by_name(vfd_name, &vfd_id)) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL, "can't check if vfd is already registered");
+
+    if ( vfd_is_registered ) {
+
+        assert( vfd_id >= 0 );
+
+        if (H5I_inc_ref(vfd_id, true) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTINC, FAIL, "unable to increment ref count on VFD");
+
+        vfd_ref_inc = true;
+
+    } else {
+
+        /* Check for VFDs that ship with the library */
+
+        if ( H5P_facc_set_def_driver_check_predefined(vfd_name, &vfd_id) < 0 ) {
+
+            HGOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL, "can't check for predefined VFL driver name");
+
+        } else if (vfd_id > 0) {
+
+            if (H5I_inc_ref(vfd_id, true) < 0)
+                HGOTO_ERROR(H5E_VFL, H5E_CANTINC, FAIL, "can't increment VFL driver refcount");
+
+            vfd_ref_inc = true;
+
+        } else {
+
+            /* Register the VFL driver */
+
+            if ((vfd_id = H5FD_register_driver_by_name(vfd_name, true)) < 0)
+                HGOTO_ERROR(H5E_VFL, H5E_CANTREGISTER, FAIL, "can't register VFL driver");
+
+            vfd_ref_inc = true;
+
+        } 
+    }
+
+    if (NULL == (plist = (H5P_genplist_t *)H5I_object_verify(fapl_id, H5I_GENPROP_LST)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a property list");
+
+    if (H5P_set_driver(plist, vfd_id, NULL, vfd_config_str_ptr) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, "can't set vfd configuration string");
+
+done:
+
+    /* take down lex_vars */
+    if ( H5CL__take_down_lex_vars(&lex_vars) < 0 )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't take down lex_vars.");
+
+    /* take down top_pair */
+
+    if ( H5CL_take_down_nv_pair(&top_pair) < 0 )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't take down top_pair.");
+
+    /* Clean up on error */
+    if (ret_value < 0) {
+        if (vfd_id >= 0 && vfd_ref_inc && H5I_dec_app_ref(vfd_id) < 0)
+            HDONE_ERROR(H5E_PLIST, H5E_CANTDEC, FAIL, "unable to unregister VFL driver");
+    }
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5CL_load_vfd_config_str_into_fapl() */
+
+
+/*******************************************************************************
+ *
+ * Function:    H5CL_parse_config()
+ *
+ * Purpose:     Given an input string containing a name value pair, whose
+ *              value is a name value list:
+ *
+ *              1) Parse the name value pair, and verify that the name 
+ *                 of the value matches the supplied value.
+ *
+ *              2) Parse the name value list, loading the names and values 
+ *                 of each entry in the into the supplied array of 
+ *                 H5CL_nv_pair_t
+ *
+ *              Note that this function allocates strings in the array of 
+ *              H5CL_nv_pair_t.  These strings must be freed by the caller
+ *              via calls to H5CL_take_down_nv_pair().
+ * 
+ *                                              JRM -- 12/5/25
+ *
+ * Return:      Success:        non-negative
+ *              Failure:        negative
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+herr_t
+H5CL_parse_config(const char * input_str_ptr, char * expected_name_ptr, H5CL_nv_pair_t nv_pairs[],
+                  int num_pairs)
+{
+    int i;
+    H5CL_nv_pair_t top_pair;
+    H5CL_lex_vars_t lex_vars = {
+        /* struct_tag        = */ H5CL_LEX_VARS_STRUCT_TAG,
+        /* input_str_ptr     = */ NULL, 
+        /* next_char_ptr     = */ NULL,
+        /* end_of_input      = */ false, 
+        /* err_ctx           = */ "",
+        /* token             = */ {
+        /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
+        /* token.code        = */    H5CL_ERROR_TOK,
+        /* token.str_ptr     = */    NULL,
+        /* token.str_len     = */    0,
+        /* token.max_str_len = */    0,
+        /* token.int_val     = */    1,    /* should be overwritten on init */
+        /* token.f_val       = */    1.0,  /* should be overwritten on init */
+        /* token.bb_ptr      = */    NULL,
+        /* token.bb_len      = */    0
+        /* end of token        */ }
+    }; 
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    assert( input_str_ptr );
+    assert( expected_name_ptr );
+    assert( num_pairs >= 0 );
+
+    top_pair.struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
+
+    if ( H5CL_init_nv_pair(&top_pair) < 0 )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't initialize top_pair.");
+
+    for ( i = 0; i < num_pairs; i++ ) {
+
+        if ( H5CL_init_nv_pair(&(nv_pairs[i])) < 0 )
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't initialize the pairs array.");
+    }
+
+
+    /* setup lex_vars for parsing the expected top level name value pair */
+    if ( H5CL__init_lex_vars(input_str_ptr, &lex_vars) < 0 )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't initialize lex_vars 1.");
+
+    /* parse the top level name value pair */
+    if ( H5CL__parse_name_value_pair(&top_pair, &lex_vars) < 0 )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't parse top level name val pair.");
+
+    /* verify that the name in the top level name value pair matches the expected_name */
+    if ( 0 != strcmp(top_pair.name_ptr, expected_name_ptr) ) 
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "top level name value pair mismatch.");
+
+    /* verify that the value of the top level name value pair is a name value pair list */
+    if ( top_pair.val_type != H5CL_VAL_LIST )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "value of top level name value pair is not a list.");
+
+    /* take down lex_vars in preparation for parsing the name value pair list */
+    if ( H5CL__take_down_lex_vars(&lex_vars) < 0 )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't take down lex_vars 1.");
+
+
+    /* setup lex_vars for the parsing the list in the top level name value pair.
+     * Since we are re-using lex_vars, we must re-initialize the struct tag since
+     * it was set to an invalid value by H5CL__take_down_lex_vars()..
+     */
+    lex_vars.struct_tag = H5CL_LEX_VARS_STRUCT_TAG;
+    if ( H5CL__init_lex_vars((char *)(top_pair.vlen_val_ptr), &lex_vars) < 0 )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't initialize lex_vars 2.");
+
+    /* parse the name value pair list from the top level name value pair */
+    if ( H5CL__parse_name_value_pair_list(nv_pairs, num_pairs, &lex_vars) < 0 )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't parse name val pair list.");
+
+done:
+
+    /* take down lex_vars after parsing the name value pair list */
+    if ( H5CL__take_down_lex_vars(&lex_vars) < 0 )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't take down lex_vars 1.");
+
+    /* take down top_pair */
+    if ( H5CL_take_down_nv_pair(&top_pair) < 0 )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't take down top_pair.");
+
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5CL_parse_config() */
+
+
+/*******************************************************************************
+ *
  * Function:    H5CL__init_lex_vars()
  *
  * Purpose:     Initialize the supplied instance of struct_H5CL_lex_vars_t 
@@ -88,6 +367,7 @@
 herr_t
 H5CL__init_lex_vars(const char * input_str_ptr, H5CL_lex_vars_t * lex_vars_ptr)
 {
+    int i;
     size_t input_str_len;
     herr_t ret_value = SUCCEED; /* Return value */
 
@@ -114,13 +394,14 @@ H5CL__init_lex_vars(const char * input_str_ptr, H5CL_lex_vars_t * lex_vars_ptr)
     /* next_char_ptr to the first character in the input string */
     lex_vars_ptr->next_char_ptr = lex_vars_ptr->input_str_ptr;
 
-    /* Set line_num and char_num to zero.  Note that line and char
-     * numbers are relative to the supplied input string, which 
-     * may be a subset of the externally supplied configuration 
-     * string.
-     */
-    lex_vars_ptr->line_num = 0;
-    lex_vars_ptr->char_num = 9;
+    /* set end_of_input to false */
+    lex_vars_ptr->end_of_input = false;
+
+    /* Null the err_ctx array */
+    for ( i = 0; i < H5CL_ERR_CTX_LEN; i++ ) {
+
+        lex_vars_ptr->err_ctx[i] = '\0';
+    } 
 
     /* now set up the token. */
 
@@ -205,6 +486,100 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 
 } /* H5CL__init_lex_vars() */
+
+
+/*******************************************************************************
+ *
+ * Function:    H5CL__construct_err_ctx()
+ *
+ * Purpose:     Using the current value of next_char_ptr as the point
+ *              at which the error was detected, construct the error 
+ *              context string with the error roughtly centered.
+ *
+ *              The error context string is used to construct the error 
+ *              messages.
+ *
+ *              Note that thus function should not be called unless 
+ *              lex vars has been successfully setup.
+ *
+ *                                                    JRM - 1/08/26
+ *
+ * Parameters:
+ *
+ *    lex_vars_ptr: Pointer to the instance of H5CL_lex_vars_t containing 
+ *              the input string.
+ *
+ * Return:      Success:        non-negative
+ *              Failure:        negative
+ *
+ *  Changes:
+ *
+ *        - None.
+ *
+ *******************************************************************************/
+
+herr_t
+H5CL__construct_err_ctx(H5CL_lex_vars_t * lex_vars_ptr)
+{
+    char * ctx_start;
+    char * char_ptr;
+    int i = 0;
+    int prefix_len = 3;
+
+    FUNC_ENTER_NOAPI_NOINIT_NOERR
+
+    assert(lex_vars_ptr);
+    assert(H5CL_LEX_VARS_STRUCT_TAG == lex_vars_ptr->struct_tag);
+    assert(H5CL_TOKEN_STRUCT_TAG == lex_vars_ptr->token.struct_tag);
+    assert(lex_vars_ptr->input_str_ptr);
+    assert(lex_vars_ptr->next_char_ptr);
+
+    if ( (lex_vars_ptr->next_char_ptr - lex_vars_ptr->input_str_ptr) <= 
+         (H5CL_ERR_CTX_LEN / 2) ) {
+
+        ctx_start = lex_vars_ptr->input_str_ptr;
+
+    } else {
+
+        ctx_start = lex_vars_ptr->next_char_ptr - (H5CL_ERR_CTX_LEN / 2);
+    }
+
+    if ( ctx_start == lex_vars_ptr->input_str_ptr ) {
+
+        prefix_len = 0;
+
+    } else { /* write the prefix */
+
+        (lex_vars_ptr->err_ctx)[i++] = '.';
+        (lex_vars_ptr->err_ctx)[i++] = '.';
+        (lex_vars_ptr->err_ctx)[i++] = '.';
+    }
+
+    char_ptr = ctx_start;
+
+    while ( ( i < (H5CL_ERR_CTX_LEN + prefix_len) ) && ( '\0' != *char_ptr ) ) {
+
+        (lex_vars_ptr->err_ctx)[i] = *char_ptr;
+        char_ptr++;
+        i++;
+    }
+
+    if ( ( (H5CL_ERR_CTX_LEN + prefix_len) == i ) && ( '\0' != *char_ptr ) ) {
+
+        /* write the postfix */
+
+        (lex_vars_ptr->err_ctx)[i++] = '.';
+        (lex_vars_ptr->err_ctx)[i++] = '.';
+        (lex_vars_ptr->err_ctx)[i++] = '.';
+    }
+
+    assert ( i <= H5CL_ERR_CTX_LEN + 6 );
+
+    (lex_vars_ptr->err_ctx)[i] = '\0';
+
+    FUNC_LEAVE_NOAPI(SUCCEED)
+
+} /* H5CL__construct_err_ctx() */
 
 
 /*******************************************************************************
@@ -332,10 +707,38 @@ H5CL__lex_get_non_blank(H5CL_lex_vars_t * lex_vars_ptr)
 
             } else {
 
-                /* We have encountered an illegal character.  Throw an error. */
+                char err_str[H5CL_MAX_ERR_MSG_LEN + 1];
 
-                /* replace with error call */
-                assert(false); 
+                /* increment lex_vars_ptr->next_char_ptr.  For normal operation,
+                 * this serves no purpose, as any error will abort the parse.
+                 * However, incrementing next_char_ptr allows us perform multiple 
+                 * invalid character error checks on a single input string.
+                 */
+                lex_vars_ptr->next_char_ptr++;
+
+                /* We have encountered an illegal character.  Construct an 
+                 * error message and report an error.
+                 */
+
+                if ( H5CL__construct_err_ctx(lex_vars_ptr) < 0 ) {
+
+                    snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                             "Ileagal char \'%c\' in input string.  Error constructing context.",
+                             next_char);
+
+                } else if ( '%' == next_char ) {
+
+                    snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                             "Percent sign in input string.  Context: %s",
+                             lex_vars_ptr->err_ctx);
+                } else {
+
+                    snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                             "Illagal char \'%c\' in input string.  Context: %s",
+                             next_char, lex_vars_ptr->err_ctx);
+                }
+
+                HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, err_str);
             }
 
         } /* while */
@@ -457,8 +860,8 @@ done:
  *******************************************************************************/
 
 herr_t
-H5CL__lex_read_token(bool value_expected, H5CL_token_t **token_ptr_ptr, 
-                       H5CL_lex_vars_t * lex_vars_ptr)
+H5CL__lex_read_token(bool value_expected, bool eoi_expected, 
+                     H5CL_token_t **token_ptr_ptr, H5CL_lex_vars_t * lex_vars_ptr)
 {
     char next_char;
     herr_t ret_value = SUCCEED; /* Return value */
@@ -469,7 +872,7 @@ H5CL__lex_read_token(bool value_expected, H5CL_token_t **token_ptr_ptr,
     assert(lex_vars_ptr);
     assert(H5CL_LEX_VARS_STRUCT_TAG == lex_vars_ptr->struct_tag);
     assert(H5CL_TOKEN_STRUCT_TAG == lex_vars_ptr->token.struct_tag);
-    
+
     if ( lex_vars_ptr->end_of_input )
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "Attempt to read past end of input string.");
 
@@ -504,6 +907,8 @@ H5CL__lex_read_token(bool value_expected, H5CL_token_t **token_ptr_ptr,
 
             do {
 
+                assert(lex_vars_ptr->token.str_len < lex_vars_ptr->token.max_str_len);
+
                 if ( '(' == next_char ) {
 
                     paren_depth++;
@@ -517,9 +922,33 @@ H5CL__lex_read_token(bool value_expected, H5CL_token_t **token_ptr_ptr,
                 lex_vars_ptr->next_char_ptr++;
                 next_char = *(lex_vars_ptr->next_char_ptr);
 
-                assert(lex_vars_ptr->token.str_len < lex_vars_ptr->token.max_str_len);
+                assert(lex_vars_ptr->token.str_len <= lex_vars_ptr->token.max_str_len);
 
             } while ( ( '\0' != next_char ) && ( paren_depth > 0 ) );
+
+            if ( ( paren_depth > 0 ) && ( '\0' == next_char ) )  {
+
+                char err_str[H5CL_MAX_ERR_MSG_LEN + 1];
+
+                /* We have read of the end of the input string.  Flag an un-terminated 
+                 * list error.
+                 */
+
+                if ( H5CL__construct_err_ctx(lex_vars_ptr) < 0 ) {
+
+                    snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                             "Un-terminated list in input string.  Error constructing context.");
+
+                } else {
+
+                    snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                             "Un-terminated list in input string.  Context: %s",
+                             lex_vars_ptr->err_ctx);
+                }
+                HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, err_str);
+            }
+
+            assert(lex_vars_ptr->token.str_len <= lex_vars_ptr->token.max_str_len);
 
             (lex_vars_ptr->token.str_ptr)[lex_vars_ptr->token.str_len] = '\0';
         }
@@ -560,7 +989,7 @@ H5CL__lex_read_token(bool value_expected, H5CL_token_t **token_ptr_ptr,
         lex_vars_ptr->next_char_ptr++;
         next_char = *(lex_vars_ptr->next_char_ptr);
 
-        while ( ( '"' != next_char ) && ( ! escape ) ) {
+        while ( ( '\0' != next_char ) && ( ( '"' != next_char ) || ( escape ) ) ) {
 
             if ( '\\' == next_char ) {
 
@@ -579,7 +1008,27 @@ H5CL__lex_read_token(bool value_expected, H5CL_token_t **token_ptr_ptr,
 
         (lex_vars_ptr->token.str_ptr)[lex_vars_ptr->token.str_len] = '\0';
 
-        assert( '"' == next_char );
+        if ( '\0' == next_char ) {
+
+            char err_str[H5CL_MAX_ERR_MSG_LEN + 1];
+
+            /* We have read of the end of the input string.  Flag an un-terminated 
+             * quote string error.
+             */
+
+            if ( H5CL__construct_err_ctx(lex_vars_ptr) < 0 ) {
+
+                snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                         "Un-terminated quote string in input string.  Error constructing context.");
+
+            } else {
+
+                snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                         "Un-terminate quote string in input string.  Context: %s",
+                         lex_vars_ptr->err_ctx);
+            }
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, err_str);
+        }
 
         lex_vars_ptr->next_char_ptr++;
 
@@ -647,7 +1096,7 @@ H5CL__lex_read_token(bool value_expected, H5CL_token_t **token_ptr_ptr,
 
             next_byte = (uint8_t)strtoll(byte_str, NULL, 16);
 
-            (lex_vars_ptr->token.str_ptr)[lex_vars_ptr->token.str_len++] = (char)next_byte;
+            (lex_vars_ptr->token.bb_ptr)[lex_vars_ptr->token.bb_len++] = next_byte;
         }
 
         (lex_vars_ptr->token.str_ptr)[lex_vars_ptr->token.str_len] = '\0';
@@ -671,6 +1120,62 @@ H5CL__lex_read_token(bool value_expected, H5CL_token_t **token_ptr_ptr,
 
     } else if ( ( '+' == next_char ) || ( '-' == next_char ) || 
                 ( '.' == next_char ) || ( isdigit(next_char) ) ) {  /* integer or float */
+
+        char next_char_plus_1 = *(lex_vars_ptr->next_char_ptr + 1);
+        char next_char_plus_2;
+        bool ill_formed = false;
+        int chars_to_skip = 1;
+
+        if ( '\0' != next_char_plus_1 ) {
+
+            next_char_plus_2 = *(lex_vars_ptr->next_char_ptr + 2);
+        }
+
+        /* check for mal-formed numeric constants */
+        if ( ( ( '+' == next_char ) || ( '-' == next_char ) ) && 
+             ( ( ! isdigit(next_char_plus_1) ) && ( '.' != next_char_plus_1 ) ) ) {
+
+            ill_formed = true;
+            chars_to_skip = 2;
+ 
+        } else if ( ( ( '+' == next_char ) || ( '-' == next_char ) ) && 
+                    ( '.' == next_char_plus_1 ) && ( ! isdigit(next_char_plus_2) ) ) {
+
+            ill_formed = true;
+            chars_to_skip = 3;
+
+        } else if ( ( '.' == next_char ) && ( ! isdigit(next_char_plus_1) ) ) {
+
+            ill_formed = true;
+            chars_to_skip = 2;
+        }
+
+        if ( ill_formed ) {
+
+            /* we have an ill formed numerical constant -- flag an error */
+
+            char err_str[H5CL_MAX_ERR_MSG_LEN + 1];
+
+            if ( H5CL__construct_err_ctx(lex_vars_ptr) < 0 ) {
+
+                snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                         "Ill-formed numerical constant.  Error constructing context.");
+
+            } else {
+
+                snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                         "Ill-formed numerical constant.  Context: %s",
+                         lex_vars_ptr->err_ctx);
+            }
+
+            /* while it isn't necessary functionally, increment lex_vars_ptr->next_char_ptr
+             * past the ill formed numerical constant.  Do this to facilitate testing.
+             */
+            lex_vars_ptr->next_char_ptr += chars_to_skip;
+
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, err_str);
+
+        } /* il_formed */
 
         /* read integer or float token */
 
@@ -703,24 +1208,47 @@ H5CL__lex_read_token(bool value_expected, H5CL_token_t **token_ptr_ptr,
         if ( is_float ) {
 
             lex_vars_ptr->token.code = H5CL_FLOAT_TOK;
+            errno = 0;
             lex_vars_ptr->token.f_val = strtod(lex_vars_ptr->token.str_ptr, NULL);
+            assert(0 == errno);
 
         } else {
 
             lex_vars_ptr->token.code = H5CL_INT_TOK;
+            errno = 0;
             lex_vars_ptr->token.int_val = strtoll(lex_vars_ptr->token.str_ptr, NULL, 10);
+            assert(0 == errno);
         }
-
-        assert(0 == errno);
 
     } else if ( '\0' == next_char ) { /* end of input */
 
         /* end of input string */
+        if ( eoi_expected ) {
 
-        lex_vars_ptr->token.code = H5CL_EOS_TOK;
-        lex_vars_ptr->token.str_ptr[0] = '\0';
-        lex_vars_ptr->token.str_len = 0;
+            lex_vars_ptr->token.code = H5CL_EOS_TOK;
+            lex_vars_ptr->token.str_ptr[0] = '\0';
+            lex_vars_ptr->token.str_len = 0;
 
+        } else {
+
+            char err_str[H5CL_MAX_ERR_MSG_LEN + 1];
+
+            /* EOI not expected -- flag an un-expected end of input error. */
+
+            if ( H5CL__construct_err_ctx(lex_vars_ptr) < 0 ) {
+
+                snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                         "Un-expected end of input string.  Error constructing context.");
+
+            } else {
+
+                snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                         "Un-expected end of input string.  Context: %s",
+                         lex_vars_ptr->err_ctx);
+            }
+
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, err_str);
+        }
     } else {
 
         /* should be un-reachable */
@@ -739,7 +1267,7 @@ done:
 
 /*******************************************************************************
  *
- * Function:    H5CL__init_nv_pair()
+ * Function:    H5CL_init_nv_pair()
  *
  * Purpose:     Initialize the supplied instance of struct H5CL_nv_pair_t. 
  *              The struct_tag is presumed to be set, but all other fields 
@@ -763,7 +1291,7 @@ done:
  *******************************************************************************/
 
 herr_t
-H5CL__init_nv_pair(H5CL_nv_pair_t * nv_pair_ptr)
+H5CL_init_nv_pair(H5CL_nv_pair_t * nv_pair_ptr)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
@@ -785,12 +1313,12 @@ done:
 
     FUNC_LEAVE_NOAPI(ret_value)
 
-} /* H5CL__init_nv_pair() */
+} /* H5CL_init_nv_pair() */
 
 
 /*******************************************************************************
  *
- * Function:    H5CL__take_down_nv_pair()
+ * Function:    H5CL_take_down_nv_pair()
  *
  * Purpose:     Take down the supplied instance of struct H5CL_nv_pair_t. 
  *
@@ -814,7 +1342,7 @@ done:
  *******************************************************************************/
 
 herr_t
-H5CL__take_down_nv_pair(H5CL_nv_pair_t * nv_pair_ptr)
+H5CL_take_down_nv_pair(H5CL_nv_pair_t * nv_pair_ptr)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
@@ -849,7 +1377,7 @@ done:
 
     FUNC_LEAVE_NOAPI(ret_value)
 
-} /* H5CL__take_down_nv_pair() */
+} /* H5CL_take_down_nv_pair() */
 
 
 /*******************************************************************************
@@ -909,28 +1437,60 @@ H5CL__parse_name_value_pair(H5CL_nv_pair_t *nv_pair_ptr, H5CL_lex_vars_t * lex_v
 
 
     /* parse the left parentheses */
-    if ( H5CL__lex_read_token(false, &token_ptr, lex_vars_ptr) < 0 )
+    if ( H5CL__lex_read_token(false, false, &token_ptr, lex_vars_ptr) < 0 )
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "H5CL__lex_read_token() failed -- '(' expected.");
 
     assert(H5CL_TOKEN_STRUCT_TAG == token_ptr->struct_tag);
 
     if ( H5CL_L_PAREN_TOK != token_ptr->code ) {
 
-        assert( H5CL_L_PAREN_TOK == token_ptr->code );
+        char err_str[H5CL_MAX_ERR_MSG_LEN + 1];
+
+        /* We have encountered an syntax error -- first token in a NV pair must be a left paren */
+
+        if ( H5CL__construct_err_ctx(lex_vars_ptr) < 0 ) {
+
+            snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                "Syntax error -- Initial \'(\' of name value pair expected..  Error constructing context.");
+
+        } else {
+
+            snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                     "Syntax error -- Initial \'(\' of name value pair expected.  Context: %s",
+                     lex_vars_ptr->err_ctx);
+        }
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, err_str);
     }
 
 
     /* parse the name in the name value pair, duplicate the string 
      * containing the name and store its address in name_ptr.
      */
-    if ( H5CL__lex_read_token(false, &token_ptr, lex_vars_ptr) < 0 )
+    if ( H5CL__lex_read_token(false, false, &token_ptr, lex_vars_ptr) < 0 )
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "H5CL__lex_read_token() failed -- <name> expected.");
 
     assert(H5CL_TOKEN_STRUCT_TAG == token_ptr->struct_tag);
 
     if ( H5CL_SYMBOL_TOK != token_ptr->code ) {
 
-        assert(false);
+        char err_str[H5CL_MAX_ERR_MSG_LEN + 1];
+
+        /* syntax error -- name of name value pair expected */
+
+        if ( H5CL__construct_err_ctx(lex_vars_ptr) < 0 ) {
+
+            snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                     "Syntax error -- name of name value pair expected.  Error constructing context.");
+
+        } else {
+
+            snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                     "Syntax error -- name of name value pair expected.  Context: %s",
+                     lex_vars_ptr->err_ctx);
+        }
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, err_str);
     }
 
     assert( NULL != token_ptr->str_ptr );
@@ -949,7 +1509,7 @@ H5CL__parse_name_value_pair(H5CL_nv_pair_t *nv_pair_ptr, H5CL_lex_vars_t * lex_v
     /* parse the value associated with the name, and store it as appropriate 
      * in local variables.
      */
-    if ( H5CL__lex_read_token(true, &token_ptr, lex_vars_ptr) < 0 )
+    if ( H5CL__lex_read_token(true, false, &token_ptr, lex_vars_ptr) < 0 )
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "H5CL__lex_read_token() failed -- <value> expected.");
 
     assert( H5CL_TOKEN_STRUCT_TAG == token_ptr->struct_tag );
@@ -1017,21 +1577,54 @@ H5CL__parse_name_value_pair(H5CL_nv_pair_t *nv_pair_ptr, H5CL_lex_vars_t * lex_v
             break;
 
         default: 
-            /* replace with unexpected token error message */ 
-            assert(false);
+            {
+                char err_str[H5CL_MAX_ERR_MSG_LEN + 1];
+
+                /* syntax error -- value of name value pair expected */
+
+                if ( H5CL__construct_err_ctx(lex_vars_ptr) < 0 ) {
+
+                    snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                         "Syntax error -- value of name value pair expected.  Error constructing context.");
+
+                } else {
+
+                    snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                             "Syntax error -- value of name value pair expected.  Context: %s",
+                             lex_vars_ptr->err_ctx);
+                }
+
+                HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, err_str);
+            }
             break;
     }
 
 
     /* parse the right parentheses */
-    if ( H5CL__lex_read_token(false, &token_ptr, lex_vars_ptr) < 0 )
+    if ( H5CL__lex_read_token(false, false, &token_ptr, lex_vars_ptr) < 0 )
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "H5CL__lex_read_token() failed -- ')' expected.");
 
     assert(H5CL_TOKEN_STRUCT_TAG == token_ptr->struct_tag);
 
     if ( H5CL_R_PAREN_TOK != token_ptr->code ) {
 
-        assert(false);
+        char err_str[H5CL_MAX_ERR_MSG_LEN + 1];
+
+        /* We have encountered an syntax error -- MV pair terminal r paren expected */
+
+        if ( H5CL__construct_err_ctx(lex_vars_ptr) < 0 ) {
+
+            snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                "Syntax error -- Terminal \')\' of name value pair expected..  Error constructing context.");
+
+        } else {
+
+            snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                     "Syntax error -- Terminal \')\' of name value pair expected.  Context: %s",
+                     lex_vars_ptr->err_ctx);
+        }
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, err_str);
     }
 
 
@@ -1167,14 +1760,30 @@ H5CL__parse_name_value_pair_list(H5CL_nv_pair_t * nv_pairs, int max_nv_pairs,
 
 
     /* parse the left parentheses */
-    if ( H5CL__lex_read_token(false, &token_ptr, lex_vars_ptr) < 0 )
+    if ( H5CL__lex_read_token(false, false, &token_ptr, lex_vars_ptr) < 0 )
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "H5CL__lex_read_token() failed -- '(' expected.");
 
     assert(H5CL_TOKEN_STRUCT_TAG == token_ptr->struct_tag);
 
     if ( H5CL_L_PAREN_TOK != token_ptr->code ) {
 
-        assert( H5CL_L_PAREN_TOK == token_ptr->code );
+        char err_str[H5CL_MAX_ERR_MSG_LEN + 1];
+
+        /* We have encountered an syntax error -- initial left paren of name value pair list expected */
+
+        if ( H5CL__construct_err_ctx(lex_vars_ptr) < 0 ) {
+
+            snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+             "Syntax error -- Initial \'(\' of name value pair listexpected..  Error constructing context.");
+
+        } else {
+
+            snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                     "Syntax error -- Initial \'(\' of name value pair list expected.  Context: %s",
+                     lex_vars_ptr->err_ctx);
+        }
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, err_str);
     }
 
     
@@ -1202,14 +1811,32 @@ H5CL__parse_name_value_pair_list(H5CL_nv_pair_t * nv_pairs, int max_nv_pairs,
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "max number of name value pairs exceeded.");
 
     /* parse the right parentheses */
-    if ( H5CL__lex_read_token(false, &token_ptr, lex_vars_ptr) < 0 )
+    if ( H5CL__lex_read_token(false, false, &token_ptr, lex_vars_ptr) < 0 )
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "H5CL__lex_read_token() failed -- ')' expected.");
 
     assert(H5CL_TOKEN_STRUCT_TAG == token_ptr->struct_tag);
 
     if ( H5CL_R_PAREN_TOK != token_ptr->code ) {
 
-        assert(false);
+        char err_str[H5CL_MAX_ERR_MSG_LEN + 1];
+
+        /* We have encountered an syntax error -- MV pair list terminal r paren expected */
+
+        if ( H5CL__construct_err_ctx(lex_vars_ptr) < 0 ) {
+
+            snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                     "Syntax error -- Terminal \')\' of name value pair list or leading \'(\' of "
+                     "name value pair expected.  Error constructing context.");
+
+        } else {
+
+            snprintf(err_str, H5CL_MAX_ERR_MSG_LEN, 
+                     "Syntax error -- Terminal \')\' of name value pair list or leading \'(\' of "
+                     "name value pair expected.  Context: %s",
+                     lex_vars_ptr->err_ctx);
+        }
+
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, err_str);
     }
 
 done:

--- a/hdf5/hdf5-1.14.6/src/H5CLdevelop.h
+++ b/hdf5/hdf5-1.14.6/src/H5CLdevelop.h
@@ -47,7 +47,7 @@
  *
  * struct H5CL_nv_pair_t
  *
- * The structure used to store the name and value from a successfully parse
+ * The structure used to store the name and value from a successfully parsed
  * name value pair.
  *
  * The fields in the structure are discussed individually below.
@@ -86,18 +86,18 @@
  *                      The length of this vector is stored in the len field.
  *
  *              H5CL_VAL_LIST: The value associated with the name value
- *                      pair is a configuration languation sub expression
+ *                      pair is a configuration language sub expression
  *                      most likely containing configuration data for
  *                      underlying VFD(s).  It is stored as a string in
  *                      a dynamically allocated vector of char.  The
  *                      length of the sub expression (less the terminating
  *                      null char) is stored in the len field.
  *
- * int_val:     uint64_t containing the integer value assocated with the
+ * int_val:     int64_t containing the integer value associated with the
  *              name value pair if val_type == H5CL_VAL_INT.  In all other
  *              cases, int_val should be set to 0.
  *
- * f_val:       double containing the floating point value assocated with
+ * f_val:       double containing the floating point value associated with
  *              the name value pair if val_type == H5CL_VAL_FLOAT.  In all
  *              other cases, f_val should be set to 0.0.
  *

--- a/hdf5/hdf5-1.14.6/src/H5CLpkg.h
+++ b/hdf5/hdf5-1.14.6/src/H5CLpkg.h
@@ -204,12 +204,10 @@ typedef struct H5CL_token_t
  * end_of_input: Boolean that is initialized to false, and set to true when 
  *              the end of the input string is reached.
  *
- * line_num:    Integer value initialized to zero, and incremented each time 
- *              next_char_ptr is incremented past a new line character.
- *
- * char_num:    Integer value initialized to zero, and incremented each time
- *              next_char_ptr is incremented.  It is reset to zero each time
- *              line_num is incremented.
+ * err_ctx:     Array of char of length H5CL_ERR_CTX_LEN + 1 used to stage
+ *              a string containing a substring of the input string 
+ *              centered at the point at which a syntax error was detected.
+ *              This string is used to provide context for error messages.
  *
  * token:       Instance of struct H5CL_token_t.  A pointer to this instance 
  *              is returned by the lexer, and reused for each new token 
@@ -219,22 +217,22 @@ typedef struct H5CL_token_t
 
 #define H5CL_LEX_VARS_STRUCT_TAG 		0x006A
 #define H5CL_INVALID_LEX_VARS_STRUCT_TAG 	0x06A0
+#define H5CL_ERR_CTX_LEN                        30
+#define H5CL_MAX_ERR_MSG_LEN                    (128 + H5CL_ERR_CTX_LEN + 6)
 
 typedef struct H5CL_lex_vars_t
 {
-	uint32_t struct_tag;
+    uint32_t struct_tag;
 
-        char * input_str_ptr;
+    char * input_str_ptr;
 
-        char * next_char_ptr;
+    char * next_char_ptr;
 
-        bool end_of_input;
+    bool end_of_input;
 
-        int32_t line_num;
+    char err_ctx[H5CL_ERR_CTX_LEN + 7];
 
-        int32_t char_num;
-
-        struct H5CL_token_t token;
+    struct H5CL_token_t token;
 	
 } H5CL_lex_vars_t;
 
@@ -249,12 +247,11 @@ typedef struct H5CL_lex_vars_t
 
 H5_DLL herr_t H5CL__init_lex_vars(const char * input_str_ptr, H5CL_lex_vars_t * lex_vars_ptr);
 H5_DLL herr_t H5CL__take_down_lex_vars(H5CL_lex_vars_t * lex_vars_ptr);
+H5_DLL herr_t H5CL__construct_err_ctx(H5CL_lex_vars_t * lex_vars_ptr);
 H5_DLL herr_t H5CL__lex_get_non_blank(H5CL_lex_vars_t * lex_vars_ptr);
 H5_DLL herr_t H5CL__lex_peek_next_char(char * next_char_ptr, H5CL_lex_vars_t * lex_vars_ptr);
-H5_DLL herr_t H5CL__lex_read_token(bool value_expected, H5CL_token_t **token_ptr_ptr,
-                                     H5CL_lex_vars_t * lex_vars_ptr);
-H5_DLL herr_t H5CL__init_nv_pair(H5CL_nv_pair_t * nv_pair_ptr);
-H5_DLL herr_t H5CL__take_down_nv_pair(H5CL_nv_pair_t * nv_pair_ptr);
+H5_DLL herr_t H5CL__lex_read_token(bool value_expected, bool eoi_expected, H5CL_token_t **token_ptr_ptr,
+                                   H5CL_lex_vars_t * lex_vars_ptr);
 H5_DLL herr_t H5CL__parse_name_value_pair(H5CL_nv_pair_t *nv_pair_ptr, H5CL_lex_vars_t * lex_vars_ptr);
 H5_DLL herr_t H5CL__parse_name_value_pair_list(H5CL_nv_pair_t * nv_pairs, int max_nv_pairs,
                                                 H5CL_lex_vars_t * lex_vars_ptr);

--- a/hdf5/hdf5-1.14.6/src/H5CLpkg.h
+++ b/hdf5/hdf5-1.14.6/src/H5CLpkg.h
@@ -117,31 +117,36 @@
  *                                                                            
  * struct_tag:  unsigned integer which must always contain the the value               
  *		H5CL_TOKEN_STRUCT_TAG.  The struct_tag field allows us to 
- *              verify that a pointer to struct H5FD_cl_token_t does in fact 
+ *              verify that a pointer to struct H5CL_token_t does in fact 
  *              point to an instance of same.                                           
  *                                                                         
  * code:        Integer code indicating the type of the token.  The set of 
- *              alowable values for this field is equal to the set of 
- *              H5FD_CL_TOKEN #defines earlier in this file.                                
+ *              allowable values for this field is equal to the set of 
+ *              H5CL_*_TOK #defines earlier in this file.                                
  *                                                                          
  * str_ptr:     Pointer to char.  str_ptr points to a dynamically allocated
  *		string which contains a text representation of the token. 
  *              Note that in the case of numerical values, *str_ptr need not 
  *              agree with val, as *str_ptr may contain a text representation 
  *              of an out of range value. 
+ *
+ *              The buffer pointed to by str_ptr is recycled, and at present,
+ *              will always be of the same length as the input string in the
+ *              containing instance of H5CL_lex_vars_t.
  *                                                                         
  * str_len:     size_t containing the length of the null terminated string 
  *		pointed to by str_ptr.                                     
  *                                                                           
  * max_str_len: size_t containing the number of bytes in the buffer pointed
  *		to by str_ptr.  Note that should always be larger than     
- *              str_len.  Since we recycle *str_ptr, it is possible for   
- *              max_str_len to be much larger than str_len.              
+ *              str_len.  At present, max_str_len will always be the same as
+ *              the length of the input string in the containing instance of
+ *              of H5CL_lex_vars_t
  *                                                                      
  * int_val:     int64_t containing any integer value associated with the 
  *              instance of H5FD_cl_token_t.                                 
  *                                                                     
- * f_val:       Double containg any floating point value associated with the 
+ * f_val:       Double containing any floating point value associated with the 
  *              instance of H5FD_cl_token_t.                                    
  *
  * bb_ptr:      Pointer to a dynamically vector of uint8_t of length equal 
@@ -150,7 +155,7 @@
  *              bb_ptr is always max_str_len.
  *
  * bb_len       size_t field containing the number of bytes in the binary 
- *              blob. As per str_len, this value must always be lets than
+ *              blob. As per str_len, this value must always be less than
  *              max_str_len.
  *                                                                          
  *******************************************************************************/
@@ -189,7 +194,7 @@ typedef struct H5CL_token_t
  * variables employed by the configuration language lexer code. The fields of
  * this structure are discussed individually below.
  *                               
- * struct_tag:  Unsigend integer which must always contain the the value
+ * struct_tag:  Unsigned integer which must always contain the the value
  *		H5CL_LEX_VARS_SRUCT_TAG.  The struct_tag field allows us to 
  *              easily verify that a pointer to struct H5CL_lex_vars_t does in 
  *              fact point to an instance of same.

--- a/hdf5/hdf5-1.14.6/src/H5CLprivate.h
+++ b/hdf5/hdf5-1.14.6/src/H5CLprivate.h
@@ -22,7 +22,7 @@
 #include "H5CLdevelop.h"
 
 /* Private headers needed by this file */
-#include "H5CLpkg.h"
+
 
 /**************************/
 /* Library Private Macros */
@@ -43,5 +43,10 @@
 /* Library Private Prototypes */
 /******************************/
 
+H5_DLL herr_t H5CL_parse_config(const char * input_str_ptr, char * expected_name_ptr, 
+         H5CL_nv_pair_t nv_pairs[], int num_pairs);
+H5_DLL herr_t H5CL_load_vfd_config_str_into_fapl(hid_t fapl_id, char * vfd_config_str_ptr);
+H5_DLL herr_t H5CL_init_nv_pair(H5CL_nv_pair_t * nv_pair_ptr);
+H5_DLL herr_t H5CL_take_down_nv_pair(H5CL_nv_pair_t * nv_pair_ptr);
 
 #endif /* H5CL_private_H */

--- a/hdf5/hdf5-1.14.6/src/H5FD.c
+++ b/hdf5/hdf5-1.14.6/src/H5FD.c
@@ -741,8 +741,9 @@ H5FD_open(bool try, H5FD_t **_file, const char *name, unsigned flags, hid_t fapl
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "zero format address range");
 
     /* Get file access property list */
-    if (NULL == (plist = (H5P_genplist_t *)H5I_object(fapl_id)))
+    if (NULL == (plist = (H5P_genplist_t *)H5I_object(fapl_id))) {
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access property list");
+    }
 
     /* Get the VFD to open the file with */
     if (H5P_peek(plist, H5F_ACS_FILE_DRV_NAME, &driver_prop) < 0)

--- a/hdf5/hdf5-1.14.6/src/H5FDcrypt.c
+++ b/hdf5/hdf5-1.14.6/src/H5FDcrypt.c
@@ -1,0 +1,3238 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by Lifeboat, LLC                                                *
+ * All rights reserved.                                                      *
+ *                                                                           * 
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/*
+ * Purpose:     The page buffer VFD converts random I/O requests to page 
+ *		aligned I/O requests, which it then passes down to the 
+ *		underlying VFD.
+ */
+
+/* This source code file is part of the H5FD driver module */
+#include "H5FDdrvr_module.h"
+
+#include "H5private.h"    /* Generic Functions        */
+#include "H5Eprivate.h"   /* Error handling           */
+#include "H5Fprivate.h"   /* File access              */
+#include "H5FDprivate.h"  /* File drivers             */
+#include "H5FDcrypt.h"    /* Encryption file driver   */
+#include "H5FLprivate.h"  /* Free Lists               */
+#include "H5Iprivate.h"   /* IDs                      */
+#include "H5MMprivate.h"  /* Memory management        */
+#include "H5Pprivate.h"   /* Property lists           */
+#include "H5CLprivate.h"
+
+#include <gcrypt.h>
+
+
+
+/* The driver identification number, initialized at runtime */
+static hid_t H5FD_CRYPT_g = 0;
+
+/******************************************************************************
+ *
+ * Structure:   H5FD_crypt_t
+ *
+ * Structure used to store all information required to manage the encryption
+ * VFD.
+ *
+ * An instance of this structure is created when the file is "opened" and 
+ * discarded when the file is closed.
+ *
+ * The fields of this structure are discussed individually below.
+ *
+ * pub:	An instance of H5FD_t which contains fields common to all VFDs.
+ *      It must be the first item in this structure, since at higher levels,
+ *      this structure will be treated as an instance of H5FD_t.
+ *
+ * fa:  An instance of H5FD_crypt_vfd_config_t containing all configuration 
+ *      data needed to setup and run the encryption.  This data is contained in 
+ *      an instance of H5FD_encryption_vfd_config_t for convenience in the get 
+ *      and set FAPL calls.
+ *
+ * config_str: If the encryption vfd is configured via a configuratin
+ *      language string, config_str is set to point to a copy of this
+ *      string.  In all other cases, this field is set to NULL.
+ *
+ *      Note that this string is parsed, and its data is loaded into
+ *      fa above on open.
+ *
+ * file: Pointer to the instance of H5FD_t used to manage the underlying 
+ *	VFD.  Note that this VFD may or may not be terminal (i.e. perform 
+ *	actual I/O on a file).
+ *
+ * ciphertext_buf:  
+ *      Pointer to the dynamically allocated buffer used to store encrypted 
+ *      data either loaded from file to be decrypted on a read, or 
+ *      encrypted and then written to file on a write.
+ *
+ *      This buffer is allocated at file open time, and is of size 
+ *      fa->encryption_buffer_size.  Note that this size must be some positive 
+ *      multiple of fa->ciphertext_page_size.
+ *      
+ *      The field should be NULL if the buffer is not allocated.
+ *
+ * num_ct_buf_pages: 
+ *      convenience field containing the size of the ciphertext_buf in 
+ *      ciphertext pages.  This field should be zero if the ciphertext_buf is 
+ *      undefined, and is computed at file open time.
+ *
+ * ciphertext_offset: 
+ *      The encrypted file has two header pages, the first of which contains 
+ *      configuration data. The second header page contains a known encrypted 
+ *      phrase and is used to verify that the supplied key is correct.
+ *
+ *      As a result, the encrypted HDF5 file proper starts two ciphertext
+ *      pages after the beginning of the file.  Since the ciphertext_page_size
+ *      is variable, the ciphertext_offset is set to 2 * 
+ *      fa.ciphertext_page_size at file open time as a convenience in 
+ *      computing the base address of I/O requests to the encrypted HDf5 file.
+ *
+ *      ciphertext_offset is computed at file open time.
+ *
+ *
+ * EOA / EOF management:
+ *
+ * The encryption VFD introduces several problems with respect to EOA / EOF 
+ * management.
+ *
+ * 1) The most obvious of these is the difference between plain text and 
+ *    cipher text page size.  Since the VFD stack above the encrypting 
+ *    VFD is un-aware of the fact that the HDF5 file is encrypted, it is 
+ *    necessary to interpret between the two views of the EOA and EOF above
+ *    and below the encrypting VFD..
+ *
+ * 2) At least at present, the first two ciphertext pages of the encrypted
+ *    file are used to store configuration data on the encrypted file so 
+ *    as to verify that this matches that passed in through the FAPL, and 
+ *    to store a known phrase to verify that the provided key is correct.
+ *    
+ * 3) The encryption VFD accepts only paged I/O -- plain taxt pages above,
+ *    and cipher text pages below.  From a plain text page perspective, 
+ *    this should be handled at higher levels in the VFD stack -- if not,
+ *    the encryption VFD should flag an error as appropriate.
+ *
+ * All these adjustments can be done on the fly, with no need for additional
+ * fields in H5FD_crypt_t.  However, the following fields are added and 
+ * maintained for debugging purposes.  We may choose to remove them in 
+ * the future.
+ *
+ * eoa_up: The current EOA as seen by the VFD directly above the encryption 
+ *      VFD in the VFD stack.  This value is set to zero at file open time,
+ *      and retains that value until the first set eoa call.
+ *
+ * eoa_down: The current EOA as seen by the VFD directly below the encryption
+ *      VFD in the VFD stack. This field is set to 2 * fa.ciphertext_page_size
+ *      (which is also the value of the ciphertext_offset field) at file 
+ *      open time to allow the encryption VFD to read the configuration pages.  
+ *
+ * eof_up: The current EOF as seen by the VFD directly above the encryption
+ *      VFD in the VFD stack.  Note that this value is undefined until the 
+ *      first get_eof call is received -- in this case the field is set to
+ *      HADDR_UNDEF.
+ *
+ * eof_down: The current EOF as seen by the VFD directly below the encryption
+ *      VFD in the VFD stack.  Note that this value is undefined until the
+ *      first get_eof call is received -- in this case the field is set to
+ *      HADDR_UNDEF.
+ *
+ ******************************************************************************/
+
+typedef struct H5FD_crypt_t {
+    H5FD_t                   pub;
+    H5FD_crypt_vfd_config_t  fa;
+    char                   * config_str;
+    H5FD_t                 * file;
+
+    /* encryption management fields */
+    unsigned char          * ciphertext_buf;   
+    uint64_t                 num_ct_buf_pages;
+    haddr_t                  ciphertext_offset;
+
+    haddr_t                  eoa_up;
+    haddr_t                  eoa_down;
+    haddr_t                  eof_up;
+    haddr_t                  eof_down;
+
+    /* encryption statistics fields */
+
+    /* Must define stats and associated functions if we get 
+     * the Phase II.
+     *                          JRM -- 9/23/24
+     */
+} H5FD_crypt_t;
+
+
+H5FD_crypt_vfd_config_t test_vfd_config = {
+    /* magic                  = */ H5FD_CRYPT_CONFIG_MAGIC,
+    /* version                = */ H5FD_CURR_CRYPT_VFD_CONFIG_VERSION,
+    /* plaintext_page_size    = */ H5FD_CRYPT_DEFAULT_PLAINTEXT_PAGE_SIZE,
+    /* ciphertext_page_size   = */ H5FD_CRYPT_DEFAULT_CIPHERTEXT_PAGE_SIZE,
+    /* encryption_buffer_size = */ H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE,
+    /* cipher                 = */ H5FD_CRYPT_DEFAULT_CIPHER,
+    /* cipher_block_size      = */ H5FD_CRYPT_DEFAULT_CIPHER_BLOCK_SIZE,
+    /* key_size               = */ H5FD_CRYPT_DEFAULT_KEY_SIZE,
+    /* key                    = */ H5FD_CRYPT_TEST_KEY,
+    /* iv_size                = */ H5FD_CRYPT_DEFAULT_IV_SIZE,
+    /* mode                   = */ H5FD_CRYPT_DEFAULT_MODE,
+    /* fapl_id                = */ H5P_DEFAULT,
+};
+
+
+/*
+ * These macros check for overflow of various quantities.  These macros
+ * assume that HDoff_t is signed and haddr_t and size_t are unsigned.
+ *
+ * ADDR_OVERFLOW:   Checks whether a file address of type `haddr_t'
+ *                  is too large to be represented by the second argument
+ *                  of the file seek function.
+ *
+ * SIZE_OVERFLOW:   Checks whether a buffer size of type `hsize_t' is too
+ *                  large to be represented by the `size_t' type.
+ *
+ * REGION_OVERFLOW: Checks whether an address and size pair describe data
+ *                  which can be addressed entirely by the second
+ *                  argument of the file seek function.
+ */
+#define MAXADDR          (((haddr_t)1 << (8 * sizeof(HDoff_t) - 1)) - 1)
+#define ADDR_OVERFLOW(A) (HADDR_UNDEF == (A) || ((A) & ~(haddr_t)MAXADDR))
+#define SIZE_OVERFLOW(Z) ((Z) & ~(hsize_t)MAXADDR)
+#define REGION_OVERFLOW(A, Z)                                                                                \
+    (ADDR_OVERFLOW(A) || SIZE_OVERFLOW(Z) || HADDR_UNDEF == (A) + (Z) || (HDoff_t)((A) + (Z)) < (HDoff_t)(A))
+#define H5FD_CRYPT__MAX_PARAMS 10
+
+
+#define H5FD_CRYPT_DEBUG_OP_CALLS 0 /* debugging print toggle; 0 disables */
+
+#if H5FD_CRYPT_DEBUG_OP_CALLS
+#define H5FD_CRYPT_LOG_CALL(name)                                                                         \
+    do {                                                                                                     \
+        printf("called %s()\n", (name));                                                                     \
+        fflush(stdout);                                                                                      \
+    } while (0)
+#else
+#define H5FD_CRYPT_LOG_CALL(name) /* no-op */       
+#endif                               /* H5FD_CRYPT_DEBUG_OP_CALLS */
+    
+
+/* Private functions */
+
+/* Prototypes */
+static herr_t  H5FD__crypt_term(void);
+static herr_t  H5FD__crypt_populate_config(H5FD_crypt_vfd_config_t *vfd_config,
+                                           H5FD_crypt_vfd_config_t       *fapl_out);
+static hsize_t H5FD__crypt_sb_size(H5FD_t *_file);
+static herr_t  H5FD__crypt_sb_encode(H5FD_t *_file, char *name /*out*/, unsigned char *buf /*out*/);
+static herr_t  H5FD__crypt_sb_decode(H5FD_t *_file, const char *name, const unsigned char *buf);
+static void   *H5FD__crypt_fapl_get(H5FD_t *_file);
+static void   *H5FD__crypt_fapl_copy(const void *_old_fa);
+static herr_t  H5FD__crypt_fapl_free(void *_fapl);
+static H5FD_t *H5FD__crypt_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr);
+static herr_t  H5FD__crypt_load_config(H5FD_crypt_t * file_ptr, hid_t crypt_fapl_id);
+static herr_t  H5FD__crypt_parse_config(const char * config_str, H5FD_crypt_vfd_config_t * config_ptr);
+static herr_t  H5FD__crypt_close(H5FD_t *_file);
+static int     H5FD__crypt_cmp(const H5FD_t *_f1, const H5FD_t *_f2);
+static herr_t  H5FD__crypt_query(const H5FD_t *_file, unsigned long *flags /* out */);
+static herr_t  H5FD__crypt_get_type_map(const H5FD_t *_file, H5FD_mem_t *type_map);
+#if 0 
+/* The current implementations of the alloc and free callbacks
+ * cause space allocation failures in the upper library.  This    
+ * has to be dealt with if we want the page buffer and encryption
+ * to run with VFDs that require it (split, multi).
+ * However, since targeting just the sec2 VFD is sufficient    
+ * for the Phase I prototype, we will bypass the issue
+ * for now.
+ *                                JRM -- 9/6/24
+ */
+static haddr_t H5FD__crypt_alloc(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, hsize_t size);
+static herr_t  H5FD__crypt_free(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, hsize_t size);
+#endif
+static haddr_t H5FD__crypt_get_eoa(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type);
+static herr_t  H5FD__crypt_set_eoa(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, haddr_t addr);
+static haddr_t H5FD__crypt_get_eof(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type);
+static herr_t  H5FD__crypt_get_handle(H5FD_t *_file, hid_t H5_ATTR_UNUSED fapl, void **file_handle);
+static herr_t  H5FD__crypt_read(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, size_t size,
+                                   void *buf);
+static herr_t  H5FD__crypt_write(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, size_t size,
+                                    const void *buf);
+static herr_t  H5FD__crypt_flush(H5FD_t *_file, hid_t dxpl_id, bool closing);
+static herr_t  H5FD__crypt_truncate(H5FD_t *_file, hid_t dxpl_id, bool closing);
+static herr_t  H5FD__crypt_lock(H5FD_t *_file, bool rw);
+static herr_t  H5FD__crypt_unlock(H5FD_t *_file);
+static herr_t  H5FD__crypt_delete(const char *filename, hid_t fapl_id);
+static herr_t  H5FD__crypt_ctl(H5FD_t *_file, uint64_t op_code, uint64_t flags, const void *input,
+                                  void **output);
+static herr_t  H5FD__crypt_read_first_page(H5FD_crypt_t *file_ptr);
+static herr_t  H5FD__crypt_decrypt_test_phrase(H5FD_crypt_t *file_ptr);
+static herr_t  H5FD__crypt_encrypt_page(H5FD_crypt_t *file_ptr, unsigned char *ciphertext, 
+                                    const unsigned char *plaintext);
+static herr_t  H5FD__crypt_decrypt_page(H5FD_crypt_t *file_ptr, unsigned char *ciphertext, 
+                                    unsigned char *plaintext);
+static herr_t  H5FD__crypt_write_first_page(H5FD_crypt_t *file_ptr);
+static herr_t  H5FD__crypt_write_second_page(H5FD_crypt_t *file_ptr);
+static void    H5FD__crypt_init_gcrypt_library(void);
+
+static const H5FD_class_t H5FD_crypt_g = {
+    H5FD_CLASS_VERSION,              /* struct version       */
+    H5FD_CRYPT_VALUE,                /* value                */
+    "encryption",                    /* name                 */
+    MAXADDR,                         /* maxaddr              */
+    H5F_CLOSE_WEAK,                  /* fc_degree            */
+    H5FD__crypt_term,                /* terminate            */
+    H5FD__crypt_sb_size,             /* sb_size              */
+    H5FD__crypt_sb_encode,           /* sb_encode            */
+    H5FD__crypt_sb_decode,           /* sb_decode            */
+    sizeof(H5FD_crypt_vfd_config_t), /* fapl_size            */
+    H5FD__crypt_fapl_get,            /* fapl_get             */
+    H5FD__crypt_fapl_copy,           /* fapl_copy            */
+    H5FD__crypt_fapl_free,           /* fapl_free            */
+    0,                               /* dxpl_size            */
+    NULL,                            /* dxpl_copy            */
+    NULL,                            /* dxpl_free            */
+    H5FD__crypt_open,                /* open                 */
+    H5FD__crypt_close,               /* close                */
+    H5FD__crypt_cmp,                 /* cmp                  */
+    H5FD__crypt_query,               /* query                */
+    H5FD__crypt_get_type_map,        /* get_type_map         */
+#if 0 
+/* The current implementations of the alloc and free callbacks
+ * cause space allocation failures in the upper library.  This    
+ * has to be dealt with if we want the page buffer and encryption
+ * to run with VFDs that require it (split, multi).
+ * However, since targeting just the sec2 VFD is sufficient    
+ * for the Phase I prototype, we will bypass the issue
+ * for now.
+ *                                JRM -- 9/6/24
+ */
+    H5FD__crypt_alloc,               /* alloc                */
+    H5FD__crypt_free,                /* free                 */
+#else
+    NULL,                            /* alloc                */
+    NULL,                            /* free                 */
+#endif
+    H5FD__crypt_get_eoa,             /* get_eoa              */
+    H5FD__crypt_set_eoa,             /* set_eoa              */
+    H5FD__crypt_get_eof,             /* get_eof              */
+    H5FD__crypt_get_handle,          /* get_handle           */
+    H5FD__crypt_read,                /* read                 */
+    H5FD__crypt_write,               /* write                */
+    NULL,                            /* read_vector          */
+    NULL,                            /* write_vector         */
+    NULL,                            /* read_selection       */
+    NULL,                            /* write_selection      */
+    H5FD__crypt_flush,               /* flush                */
+    H5FD__crypt_truncate,            /* truncate             */
+    H5FD__crypt_lock,                /* lock                 */
+    H5FD__crypt_unlock,              /* unlock               */
+    H5FD__crypt_delete,              /* del                  */
+    H5FD__crypt_ctl,                 /* ctl                  */
+    H5FD_FLMAP_DICHOTOMY             /* fl_map               */
+};
+
+/* Declare a free list to manage the H5FD_crypt_t struct */
+H5FL_DEFINE_STATIC(H5FD_crypt_t);
+
+/* Declare a free list to manage the H5FD_crypt_vfd_config_t struct */
+H5FL_DEFINE_STATIC(H5FD_crypt_vfd_config_t);
+
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_init_gcrypt_library
+ *
+ * Purpose:     This function calls functions from the libgcrypt library to 
+ *              allocate a pool of memory that is protected from swapping to 
+ *              disk and can be wiped in a secure manner. Useful for storing 
+ *              sensitive data like keys.
+ * 
+ *              NOTE: This iteration doesn't use the secure memory pool. More 
+ *              investigation on how to handle key management is needed before
+ *              this can be implemented.
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+static void
+H5FD__crypt_init_gcrypt_library(void)
+{
+    if (!gcry_check_version(GCRYPT_VERSION)) {
+        perror("libgcrypt version mismatch\n");
+        exit(2);
+    }
+
+    /**
+     * Suspend warnings about secure memory not being initialized 
+     * This is necessary because we haven't initialized secure memory yet
+     */ 
+    gcry_control(GCRYCTL_SUSPEND_SECMEM_WARN);
+
+    /* Initialize secure memory */
+    gcry_control(GCRYCTL_INIT_SECMEM, 4096, 0);
+
+    /**
+     * Resume warnings about secure memory not being initialized
+     * So if the secure memory pool was not initialized successfully, we will
+     * get a warning
+     */ 
+    gcry_control(GCRYCTL_RESUME_SECMEM_WARN);
+
+    /* Let libgcrypt know that initialization is finished */
+    gcry_control(GCRYCTL_INITIALIZATION_FINISHED, 0);
+}
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD_crypt_init
+ *
+ * Purpose:     Initialize the page buffer driver by registering it with the 
+ *              library.
+ *
+ * Return:      Success:    The driver ID for the page buffer driver.
+ *              Failure:    Negative
+ *-----------------------------------------------------------------------------
+ */
+hid_t
+H5FD_crypt_init(void)
+{
+    hid_t ret_value = H5I_INVALID_HID;
+
+    FUNC_ENTER_NOAPI_NOERR
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    if (H5I_VFL != H5I_get_type(H5FD_CRYPT_g)) {
+        H5FD_CRYPT_g = H5FDregister(&H5FD_crypt_g);
+        H5FD__crypt_init_gcrypt_library();
+    }
+
+    ret_value = H5FD_CRYPT_g;
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD_crypt_init() */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_term
+ *
+ * Purpose:     Shut down the page buffer VFD.
+ *
+ * Returns:     SUCCEED (Can't fail)
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_term(void)
+{
+    FUNC_ENTER_PACKAGE_NOERR
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    /* Reset VFL ID */
+    H5FD_CRYPT_g = 0;
+
+    FUNC_LEAVE_NOAPI(SUCCEED)
+
+} /* end H5FD__crypt_term() */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__copy_plist
+ *
+ * Purpose:     Sanity-wrapped H5P_copy_plist() for underlying VFD Utility 
+ *              function for operation in multiple locations.
+ *
+ * Return:      0 on success, -1 on error.
+ *-----------------------------------------------------------------------------
+ */
+static int
+H5FD__copy_plist(hid_t fapl_id, hid_t *id_out_ptr)
+{
+    int             ret_value = 0;
+    H5P_genplist_t *plist_ptr = NULL;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    assert(id_out_ptr != NULL);
+
+    if (false == H5P_isa_class(fapl_id, H5P_FILE_ACCESS))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, -1, 
+                    "not a file access property list");
+
+    plist_ptr = (H5P_genplist_t *)H5I_object(fapl_id);
+
+    if (NULL == plist_ptr)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, -1, 
+                    "unable to get property list");
+
+    *id_out_ptr = H5P_copy_plist(plist_ptr, false);
+
+    if (H5I_INVALID_HID == *id_out_ptr)
+        HGOTO_ERROR(H5E_VFL, H5E_BADTYPE, -1, 
+                    "unable to copy file access property list");
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__copy_plist() */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5Pset_fapl_crypt
+ *
+ * Purpose:     Sets the file access property list to use the encryption driver
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+herr_t
+H5Pset_fapl_crypt(hid_t fapl_id, H5FD_crypt_vfd_config_t *vfd_config)
+{
+    H5FD_crypt_vfd_config_t *info      = NULL;
+    H5P_genplist_t       *plist_ptr = NULL;
+    herr_t                ret_value = SUCCEED;
+
+    FUNC_ENTER_API(FAIL)
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    if (H5FD_CRYPT_CONFIG_MAGIC != vfd_config->magic)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, 
+                    "invalid configuration (magic number mismatch)");
+
+    if (H5FD_CURR_CRYPT_VFD_CONFIG_VERSION != vfd_config->version)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, 
+                    "invalid config (version number mismatch)");
+
+    if (NULL == (plist_ptr = (H5P_genplist_t *)H5I_object(fapl_id)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a valid property list");
+
+    info = H5FL_CALLOC(H5FD_crypt_vfd_config_t);
+
+    if (NULL == info)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, 
+                    "unable to allocate file access property list struct");
+
+    if (H5FD__crypt_populate_config(vfd_config, info) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, 
+                    "can't setup driver configuration");
+
+    ret_value = H5P_set_driver(plist_ptr, H5FD_CRYPT, info, NULL);
+
+done:
+    if (info)
+        info = H5FL_FREE(H5FD_crypt_vfd_config_t, info);
+
+    FUNC_LEAVE_API(ret_value)
+
+} /* end H5Pset_fapl_crypt() */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5Pget_fapl_crypt
+ *
+ * Purpose:     Returns information about the encryption VFD file access 
+ *              property list through the instance of H5FD_crypt_vfd_config_t
+ *              pointed to by config.
+ *
+ *              Will fail if *config is received without pre-set valid magic 
+ *              and version information.
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+herr_t
+H5Pget_fapl_crypt(hid_t fapl_id, H5FD_crypt_vfd_config_t *config /*out*/)
+{
+    const H5FD_crypt_vfd_config_t *fapl_ptr     = NULL;
+    H5FD_crypt_vfd_config_t       *default_fapl = NULL;
+    H5P_genplist_t                *plist_ptr    = NULL;
+    herr_t                         ret_value    = SUCCEED;
+
+    FUNC_ENTER_API(FAIL)
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    /* Check arguments */
+    if (true != H5P_isa_class(fapl_id, H5P_FILE_ACCESS))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, 
+                    "not a file access property list");
+
+    if (config == NULL)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "config pointer is null");
+
+    if (H5FD_CRYPT_CONFIG_MAGIC != config->magic)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, 
+                    "info-out pointer invalid (magic number mismatch)");
+
+    if (H5FD_CURR_CRYPT_VFD_CONFIG_VERSION != config->version)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, 
+                    "info-out pointer invalid (version unsafe)");
+
+    /* Pre-set out FAPL ID with intent to replace these values */
+    config->fapl_id = H5I_INVALID_HID;
+
+    /* Check and get the encryption VFD fapl */
+    if (NULL == (plist_ptr = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, 
+                    "not a file access property list");
+
+    if (H5FD_CRYPT != H5P_peek_driver(plist_ptr))
+        HGOTO_ERROR(H5E_PLIST, H5E_BADVALUE, FAIL, "incorrect VFL driver");
+
+    fapl_ptr = (const H5FD_crypt_vfd_config_t *)H5P_peek_driver_info(plist_ptr);
+
+    if (NULL == fapl_ptr) {
+
+        if (NULL == (default_fapl = H5FL_CALLOC(H5FD_crypt_vfd_config_t)))
+            HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, 
+                        "unable to allocate file access property list struct");
+
+        if (H5FD__crypt_populate_config(NULL, default_fapl) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, 
+                        "can't initialize driver configuration info");
+
+        fapl_ptr = default_fapl;
+    }
+
+    /* Copy scalar data */
+    config->plaintext_page_size      = fapl_ptr->plaintext_page_size;
+    config->ciphertext_page_size     = fapl_ptr->ciphertext_page_size;
+    config->encryption_buffer_size   = fapl_ptr->encryption_buffer_size;
+    config->cipher                   = fapl_ptr->cipher;
+    config->cipher_block_size        = fapl_ptr->cipher_block_size;
+    config->key_size                 = fapl_ptr->key_size;
+    config->iv_size                  = fapl_ptr->iv_size;
+    config->mode                     = fapl_ptr->mode;
+
+
+    /* copy Key */
+    if ( fapl_ptr->key_size > 0 ) {
+
+        memcpy((void *)config->key, (const void *)fapl_ptr->key, 
+                (size_t)fapl_ptr->key_size);
+    }
+
+    /* Copy FAPL */
+    if (H5FD__copy_plist(fapl_ptr->fapl_id, &(config->fapl_id)) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "can't copy underlying FAPL");
+
+done:
+    if (default_fapl)
+        H5FL_FREE(H5FD_crypt_vfd_config_t, default_fapl);
+
+    FUNC_LEAVE_API(ret_value)
+
+} /* end H5Pget_fapl_crypt() */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_populate_config
+ *
+ * Purpose:    Populates a H5FD_crypt_vfd_config_t structure with the provided
+ *             values, supplying defaults where values are not provided.
+ *
+ * Return:    Non-negative on success/Negative on failure
+ *
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_populate_config(H5FD_crypt_vfd_config_t *vfd_config, 
+                            H5FD_crypt_vfd_config_t *fapl_out)
+{
+    H5P_genplist_t *def_plist;
+    H5P_genplist_t *plist;
+    bool            free_config = false;
+    herr_t          ret_value   = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    assert(fapl_out);
+
+    /* Checks magic number */
+    if ( ( vfd_config ) && ( H5FD_CRYPT_CONFIG_MAGIC != vfd_config->magic ) )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, 
+                            "Incorrect H5FD_crypt_vfd_config_t magic field");
+
+    /* Checks version*/
+    if ( ( vfd_config ) && 
+                ( H5FD_CURR_CRYPT_VFD_CONFIG_VERSION != vfd_config->version ) )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, 
+                            "Unknown H5FD_crypt_vfd_config_t version");
+
+    /* Checks key is an appropriate size */
+    if ( ( vfd_config ) && ( H5FD_CRYPT_MAX_KEY_SIZE < vfd_config->key_size ) )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, FAIL, "key_size too big");
+
+    /** 
+     * Checks the ciphertext page size is at least the size of plaintext page
+     * size + IV size to store both the ciphertext and the IV.
+     */
+    if ( ( vfd_config ) && ( vfd_config->iv_size > 0 ) )
+        if ( ( vfd_config->ciphertext_page_size < 
+                    vfd_config->plaintext_page_size + vfd_config->iv_size))
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, 
+                            "ciphertext_page_size too small");
+
+    /* Checks encryption buffer size is a multiple of ciphertext page size */
+    if ( ( vfd_config ) && ( vfd_config->encryption_buffer_size % 
+                                vfd_config->ciphertext_page_size != 0 ) )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, 
+            "encryption_buffer_size not a multiple of ciphertext_page_size");
+    
+    /* add more checks as needed */
+
+    memset(fapl_out, 0, sizeof(H5FD_crypt_vfd_config_t));
+
+    if ( NULL == vfd_config ) {
+
+        vfd_config = H5MM_calloc(sizeof(H5FD_crypt_vfd_config_t));
+
+        if (NULL == vfd_config)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, 
+                        "unable to allocate file access property list struct");
+
+        vfd_config->magic                  = H5FD_CRYPT_CONFIG_MAGIC;
+        vfd_config->version                = H5FD_CURR_CRYPT_VFD_CONFIG_VERSION;
+        vfd_config->plaintext_page_size    = H5FD_CRYPT_DEFAULT_PLAINTEXT_PAGE_SIZE;
+        vfd_config->ciphertext_page_size   = H5FD_CRYPT_DEFAULT_CIPHERTEXT_PAGE_SIZE;
+        vfd_config->encryption_buffer_size = H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE;
+        vfd_config->cipher                 = H5FD_CRYPT_DEFAULT_CIPHER;
+        vfd_config->cipher_block_size      = H5FD_CRYPT_DEFAULT_CIPHER_BLOCK_SIZE;
+
+        vfd_config->key_size               = 0;
+
+        vfd_config->iv_size                = H5FD_CRYPT_DEFAULT_IV_SIZE;
+        vfd_config->mode                   = H5FD_CRYPT_DEFAULT_MODE;
+
+        vfd_config->fapl_id                = H5P_DEFAULT;
+
+        free_config = true;
+    }
+
+    fapl_out->magic                  = vfd_config->magic;
+    fapl_out->version                = vfd_config->version;
+    fapl_out->plaintext_page_size    = vfd_config->plaintext_page_size;
+    fapl_out->ciphertext_page_size   = vfd_config->ciphertext_page_size;
+    fapl_out->encryption_buffer_size = vfd_config->encryption_buffer_size;
+    fapl_out->cipher                 = vfd_config->cipher;
+    fapl_out->cipher_block_size      = vfd_config->cipher_block_size;
+    fapl_out->key_size               = vfd_config->key_size;
+    fapl_out->iv_size                = vfd_config->iv_size;
+    fapl_out->mode                   = vfd_config->mode;
+
+    /* copy Key */
+    if ( vfd_config->key_size > 0 ) {
+
+        memcpy((void *)fapl_out->key, (const void *)vfd_config->key, 
+                                            (size_t)vfd_config->key_size);
+    }
+
+    /* pre-set value */
+    fapl_out->fapl_id               = H5P_FILE_ACCESS_DEFAULT; 
+
+    if (NULL == (def_plist = 
+                    (H5P_genplist_t *)H5I_object(H5P_FILE_ACCESS_DEFAULT)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, 
+                                "not a file access property list");
+
+    /* Set non-default underlying FAPL ID in page buffer configuration info */
+    if (H5P_DEFAULT != vfd_config->fapl_id) {
+
+        if (false == H5P_isa_class(vfd_config->fapl_id, H5P_FILE_ACCESS))
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access list");
+
+        fapl_out->fapl_id = vfd_config->fapl_id;
+
+    } else {
+
+        /* Use copy of default file access property list for underlying FAPL ID
+         * The Sec2 driver is explicitly set on the FAPL ID, as the default
+         * driver might have been replaced with the page buffer VFD, which
+         * would cause recursion.
+         */
+        if ((fapl_out->fapl_id = H5P_copy_plist(def_plist, false)) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTCOPY, FAIL, 
+                                            "can't copy property list");
+
+        if (NULL == (plist = (H5P_genplist_t *)H5I_object(fapl_out->fapl_id)))
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, 
+                                            "not a file access property list");
+
+        if (H5P_set_driver_by_value(plist, H5_VFD_SEC2, NULL, true) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, 
+                                "can't set default driver on underlying FAPL");
+    }
+
+done:
+    if ( free_config && vfd_config ) {
+
+        H5MM_free(vfd_config);
+    }
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_populate_config() */
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_flush
+ *
+ * Purpose:     Flush underlying VFD.
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_flush(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, bool closing)
+{
+    H5FD_crypt_t *file      = (H5FD_crypt_t *)_file;
+    herr_t        ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    /* Public API for dxpl "context" */
+    if (H5FDflush(file->file, dxpl_id, closing) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTFLUSH, FAIL, 
+                                        "unable to flush underlying file");
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_flush() */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_read
+ *
+ * Purpose:     Reads the specified pages from the underlying file, decrypt 
+ *              them, and returns the associated plaintext.
+ *
+ *              Size must be a multiple of the plaintext page size, and addr 
+ *              must lie on a plaintext page boundary. Because of the first 
+ *              two pages being used to store the encryption configuration data
+ *              and the test encryption phrase, file_ptr->ciphertext_offset is
+ *              used to adjust the addr to skip over those first two pages. 
+ * 
+ * Return:      Success:    SUCCEED
+ *                          The read result is written into the BUF buffer
+ *                          which should be allocated by the caller.
+ *
+ *              Failure:    FAIL
+ *                          The contents of BUF are undefined.
+ *
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, 
+                    hid_t H5_ATTR_UNUSED dxpl_id, haddr_t addr, 
+                    size_t size, void *buf)
+{
+    H5FD_crypt_t *   file_ptr      = (H5FD_crypt_t *)_file;
+    H5P_genplist_t * plist_ptr = NULL;
+    haddr_t          ciphertext_addr;  /* addr converted for ciphertext size */
+    haddr_t          ct_addr;          /* current addr of the read */
+    size_t           ct_size;          /* size currently in ciphertext buf */
+    uint64_t         pages_remaining;  /* number of pages remaining */
+    /* number of pages remaining in ciphertext buf */
+    uint64_t         ct_buf_pages_remaining; 
+    unsigned char *  pt_ptr = NULL;    /* ptr to plaintext buffer */
+    unsigned char *  ct_ptr = NULL;    /* ptr to ciphertext buffer */
+    herr_t           ret_value = SUCCEED; /* Return value */
+
+#ifdef DEBUG
+    size_t           ciphertext_size;  /* size converted for ciphertext size */
+#endif
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    assert(file_ptr && file_ptr->pub.cls);
+    assert(buf);
+
+    /* verify the DXPL -- we don't use the dxpl_id, so do we need this? */
+    if (NULL == (plist_ptr = (H5P_genplist_t *)H5I_object(dxpl_id)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a property list");
+
+    /* Check for overflow conditions -- do we need these tests? */
+    if (!H5_addr_defined(addr))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, 
+                    "addr undefined, addr = %llu", (unsigned long long)addr);
+
+    if (REGION_OVERFLOW(addr, size))
+        HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, addr = %llu", 
+                        (unsigned long long)addr);
+
+    /* Checks that size is a multiple of the plaintext page size */
+    if ( (size % file_ptr->fa.plaintext_page_size) != 0)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, 
+                    "size must be a multiple of the plaintext page size");
+
+    /* Checks that addr is on a plaintext page boudnary */
+    if ( (addr % file_ptr->fa.plaintext_page_size) != 0 )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, 
+                        "addr must lie on a plaintext page boundary");
+
+    pages_remaining = size / file_ptr->fa.plaintext_page_size;
+    assert( 0 < pages_remaining );
+
+    /* Compute the cipher text addr from the plain text addr.  Note that
+     * we must add two cipher text pages to account for the two header pages.
+     */
+    ciphertext_addr = (addr / (haddr_t)(file_ptr->fa.plaintext_page_size)) *
+                      ((haddr_t)(file_ptr->fa.ciphertext_page_size)) +
+                      file_ptr->ciphertext_offset;
+
+#ifdef DEBUG
+    /* compute the cipher text size from the plain text sizc. */
+    ciphertext_size = (size / file_ptr->fa.plaintext_page_size) * 
+                                        file_ptr->fa.ciphertext_page_size;
+#endif
+
+    /* Read the cipher text, decrypt it, and copy the plaintext into the 
+     * provided buffer. Since the ciphertext may be larger than the ciphertext 
+     * buffer, must allow for multiple reads if the ciphertext buffer must be 
+     * loaded repeatedly
+     */
+
+    ct_buf_pages_remaining = 0;
+    pt_ptr = (unsigned char *)buf;
+    ct_ptr = NULL;
+    ct_addr = ciphertext_addr;
+    ct_size = 0;
+
+    /* While loop for multiple iterations if pages are > encryption buf size */
+    while ( pages_remaining > 0 ) {
+
+         
+        /* If the ciphertext pages remaining is 0 loads ciphertext pages into 
+         * the buffer, either all of the pages needed or the maximum number the 
+         * buffer can hold if there are too many.
+         */
+        if ( 0 == ct_buf_pages_remaining ) {
+
+            /* If the number of pages remaining is larger than what the 
+             * ciphertext buffer can hold
+             */
+            if ( pages_remaining >= file_ptr->num_ct_buf_pages ) {
+
+                /* Load the ciphertext buf with it's maximum page size */
+                ct_size = file_ptr->fa.encryption_buffer_size;
+                ct_buf_pages_remaining = file_ptr->num_ct_buf_pages;
+
+            /* If the pages remaining < ciphertext buffer size*/
+            } else {
+
+                /* Load all remaining pages into the ciphertext buffer */
+                ct_size = pages_remaining * file_ptr->fa.ciphertext_page_size;
+                ct_buf_pages_remaining = pages_remaining;
+            }
+
+            assert( ct_size <= file_ptr->fa.encryption_buffer_size );
+            assert( ct_buf_pages_remaining <= pages_remaining );
+
+            ct_ptr = file_ptr->ciphertext_buf;
+
+            if ( H5FDread(file_ptr->file, type, dxpl_id, ct_addr, ct_size, 
+                            (void *)(ct_ptr)) < 0 )
+                HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, 
+                                        "Read of encryption buffer failed");
+
+            /* update ct_addr for the next read */
+            ct_addr += (haddr_t)ct_size;
+        }
+
+        /* Decrypt and write the ciphertext into plaintext buffer per page */
+        if ( H5FD__crypt_decrypt_page(file_ptr, ct_ptr, pt_ptr) != SUCCEED )
+            HGOTO_ERROR(H5E_VFL, H5E_WRITEERROR, FAIL, "Can't decrypt page.");
+
+        /* decrements the plaintext pages remaining and adjusts pointers */
+        pages_remaining--;
+        pt_ptr += file_ptr->fa.plaintext_page_size;
+
+        /* decrements the ciphertext pages remaining and adjusts pointers */
+        ct_buf_pages_remaining--;
+        ct_ptr += file_ptr->fa.ciphertext_page_size;
+
+    } /* while */
+
+#ifdef DEBUG
+    /* verify that we read the correct amount of ciphertext */
+    assert( (size_t)(ct_addr - ciphertext_addr) == ciphertext_size );
+#endif
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_read() */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_write
+ *
+ * Purpose:     Encrypt the supplied plaintext pages and write the 
+ *              corresponding ciphertext pages to the equivalent location in 
+ *              the encrypted file.
+ *
+ *              Size must be a multiple of the plaintext page size, and addr 
+ *              must lie on a plaintext page boundary. Because of the first 
+ *              two pages being used to store the encryption configuration data
+ *              and the test encryption phrase, file_ptr->ciphertext_offset is
+ *              used to adjust the addr to skip over those first two pages. 
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_write(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, 
+                    size_t size, const void *buf)
+{
+    H5FD_crypt_t *   file_ptr      = (H5FD_crypt_t *)_file;
+    H5P_genplist_t * plist_ptr = NULL;
+    haddr_t          ciphertext_addr;  /* addr converted for ciphertext size */
+    haddr_t          ct_addr;          /* current addr of the read */
+    size_t           ct_size;          /* size currently in ciphertext buf */
+    uint64_t         pages_remaining;  /* number of pages remaining */
+    /* number of pages remaining in ciphertext buf */
+    uint64_t         ct_buf_pages_remaining; 
+    const unsigned char *  pt_ptr = NULL;    /* ptr to plaintext buffer */
+    unsigned char *  ct_ptr = NULL;    /* ptr to ciphertext buffer */
+    herr_t           ret_value = SUCCEED; /* Return value */
+
+#ifdef DEBUG
+    size_t           ciphertext_size;  /* size converted for ciphertext size */
+#endif
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    assert(file_ptr && file_ptr->pub.cls);
+    assert(buf);
+
+    /* verify the DXPL -- we don't use the dxpl_id, do we really need this? */
+    if (NULL == (plist_ptr = (H5P_genplist_t *)H5I_object(dxpl_id)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a property list");
+
+    /* Checks that size is a multiple of the plaintext page size */
+    if ( (size % file_ptr->fa.plaintext_page_size) != 0)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, 
+                    "size must be a multiple of the plaintext page size");
+
+    /* Checks that addr is on a plaintext page boudnary */
+    if ( (addr % file_ptr->fa.plaintext_page_size) != 0 )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, 
+                    "addr must lie on a plaintext page boundary");
+
+    pages_remaining = size / file_ptr->fa.plaintext_page_size;
+    assert( 0 < pages_remaining );
+
+    /* Compute the cipher text addr from the plain text addr.  Note that
+     * we must add two cipher text pages to account for the two header pages.
+     */
+    ciphertext_addr = (addr / (haddr_t)(file_ptr->fa.plaintext_page_size)) * 
+                      ((haddr_t)(file_ptr->fa.ciphertext_page_size)) + 
+                      file_ptr->ciphertext_offset;
+
+#ifdef DEBUG
+    /* Compute the cipher text size from the plain text size. */
+    ciphertext_size = (size / file_ptr->fa.plaintext_page_size) * 
+                        file_ptr->fa.ciphertext_page_size;
+#endif
+
+    /* encrypt the plaintext and write it to the underlying file.  Since the 
+     * plaintext may be larger than the ciphertext buffer, must allow for 
+     * multiple writes as the ciphertext buffer fills and must be flushed.
+     */
+
+    ct_buf_pages_remaining = file_ptr->num_ct_buf_pages;
+    pt_ptr = (const unsigned char *)buf;
+    ct_ptr = file_ptr->ciphertext_buf;
+    ct_addr = ciphertext_addr;
+    ct_size = 0;
+
+    /* While loop for multiple iterations if pages are > encryption buf size */
+    while ( pages_remaining > 0 ) {
+
+        assert(ct_buf_pages_remaining > 0);
+
+        /* Encrypt and write the plaintext into ciphertext buffer per page */
+        if ( H5FD__crypt_encrypt_page(file_ptr, ct_ptr, pt_ptr) != SUCCEED )
+            HGOTO_ERROR(H5E_VFL, H5E_WRITEERROR, FAIL, "Can't encrypt page.");
+
+        /* increment ct_size and ct_ptr by the ciphertext page size */
+        ct_size += file_ptr->fa.ciphertext_page_size;
+        ct_ptr += file_ptr->fa.ciphertext_page_size;
+
+        /* decrements the plaintext pages remaining and adjusts pointers */
+        pages_remaining--;
+        pt_ptr += file_ptr->fa.plaintext_page_size;
+
+        /* decrements the ciphertext pages remaining */
+        ct_buf_pages_remaining--;
+
+        if ( ( 0 == pages_remaining ) || ( 0 == ct_buf_pages_remaining ) ) {
+
+            /* Either we have filled the ciphertext buffer, or we have run out 
+             * of plaintext. In either case, flush the ciphertext buffer, and 
+             * update the ct variables for another pass through the ciphertext 
+             * buffer.
+             */
+           if ( H5FDwrite(file_ptr->file, type, dxpl_id, ct_addr, ct_size, 
+                          (void *)(file_ptr->ciphertext_buf)) < 0 ) 
+               HGOTO_ERROR(H5E_VFL, H5E_WRITEERROR, FAIL, 
+                                "Write of encryption buffer failed.");
+
+           /* adjust ct_addr for the next encryption buffer write. Similarly, 
+            * update ct_ptr, ct_size, and ct_buf_pages_remaining for the next 
+            * pass through the the encryption buffer.
+            */
+
+           ct_addr += (haddr_t)ct_size;
+           ct_ptr = file_ptr->ciphertext_buf;
+           ct_size = 0;
+           ct_buf_pages_remaining = file_ptr->num_ct_buf_pages;
+        } 
+    } /* while */
+
+#ifdef DEBUG
+    assert( (size_t)(ct_addr - ciphertext_addr) == ciphertext_size );
+#endif
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_write() */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_fapl_get
+ *
+ * Purpose:     Returns a file access property list which indicates how the
+ *              specified file is being accessed. The return list could be used
+ *              to access another file the same way.
+ *
+ * Return:      Success:    Ptr to new file access property list with all
+ *                          members copied from the file struct.
+ *              Failure:    NULL
+ *-----------------------------------------------------------------------------
+ */
+static void *
+H5FD__crypt_fapl_get(H5FD_t *_file)
+{
+    H5FD_crypt_t *file      = (H5FD_crypt_t *)_file;
+    void      *ret_value = NULL;
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    ret_value = H5FD__crypt_fapl_copy(&(file->fa));
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_fapl_get() */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_fapl_copy
+ *
+ * Purpose:     Copies the file access properties.
+ *
+ * Return:      Success:    Pointer to a new property list info structure.
+ *              Failure:    NULL
+ *-----------------------------------------------------------------------------
+ */
+static void *
+H5FD__crypt_fapl_copy(const void *_old_fa)
+{
+    const H5FD_crypt_vfd_config_t *old_fa_ptr = 
+                                (const H5FD_crypt_vfd_config_t *)_old_fa;
+    H5FD_crypt_vfd_config_t       *new_fa_ptr = NULL;
+    void                          *ret_value  = NULL;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    assert(old_fa_ptr);
+
+    new_fa_ptr = H5FL_CALLOC(H5FD_crypt_vfd_config_t);
+
+    if (NULL == new_fa_ptr)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, 
+                        "unable to allocate encryption VFD FAPL");
+
+    H5MM_memcpy(new_fa_ptr, old_fa_ptr, sizeof(H5FD_crypt_vfd_config_t));
+
+    /* Copy the FAPL */
+    if (H5FD__copy_plist(old_fa_ptr->fapl_id, &(new_fa_ptr->fapl_id)) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, NULL, "can't copy underlying FAPL");
+
+    ret_value = (void *)new_fa_ptr;
+
+done:
+
+    if (NULL == ret_value) {
+
+        if (new_fa_ptr) {
+
+            new_fa_ptr = H5FL_FREE(H5FD_crypt_vfd_config_t, new_fa_ptr);
+        }
+    }
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_fapl_copy() */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_fapl_free
+ *
+ * Purpose:     Releases the file access lists
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_fapl_free(void *_fapl)
+{
+    H5FD_crypt_vfd_config_t *fapl      = (H5FD_crypt_vfd_config_t *)_fapl;
+    herr_t                ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    /* Check arguments */
+    assert(fapl);
+
+    if (H5I_dec_ref(fapl->fapl_id) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTDEC, FAIL, 
+                            "can't close underlying FAPL ID");
+
+    /* Free the property list */
+    fapl = H5FL_FREE(H5FD_crypt_vfd_config_t, fapl);
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_fapl_free() */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_open
+ *
+ * Purpose:     Create and/or opens a file as an HDF5 file.
+ * 
+ *              NOTE: On file creation the two configuration pages are 
+ *              constructed form the information contained in the FAPL and 
+ *              written to the new file. The first page contains the 
+ *              configuration details, and the second page encrypts the test
+ *              phrase using the cipher configuration provided.
+ *
+ * Return:      Success:    A pointer to a new file data structure. The public 
+ *                          fields will be initialized by the caller, which is 
+ *                          always H5FD_open().
+ *              Failure:    NULL
+ *-----------------------------------------------------------------------------
+ */
+static H5FD_t *
+H5FD__crypt_open(const char *name, unsigned flags, hid_t crypt_fapl_id, 
+                        haddr_t maxaddr)
+{
+    /* encryption VFD info */
+    H5FD_crypt_t                  *file_ptr     = NULL; 
+    H5FD_t                        *ret_value    = NULL;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    /* Check arguments */
+    if (!name || !*name)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "invalid file name");
+
+    if (0 == maxaddr || HADDR_UNDEF == maxaddr)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, NULL, "bogus maxaddr");
+
+    if (ADDR_OVERFLOW(maxaddr))
+        HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, NULL, "bogus maxaddr");
+
+    /* H5FD_CRYPT initializes the encryption VFD if it is not already 
+     * initialized.  
+     */
+    if (H5FD_CRYPT != H5Pget_driver(crypt_fapl_id))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, 
+                        "driver is not encryption VFD");
+
+    file_ptr = (H5FD_crypt_t *)H5FL_CALLOC(H5FD_crypt_t);
+
+    if (NULL == file_ptr)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, 
+                        "unable to allocate file struct");
+    file_ptr->fa.magic = H5FD_CRYPT_CONFIG_MAGIC;
+    file_ptr->fa.version = H5FD_CURR_CRYPT_VFD_CONFIG_VERSION;
+
+    if ( H5FD__crypt_load_config(file_ptr, crypt_fapl_id) < 0 ) 
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "can't load encryption VFD configuration");
+
+    /* Allocate encryption buffer */
+    file_ptr->ciphertext_buf = 
+                (unsigned char *)malloc(file_ptr->fa.encryption_buffer_size);
+
+    if ( NULL == file_ptr->ciphertext_buf )
+        HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, NULL, 
+                        "unable to allocate encryption buffer");
+
+    /* for convenience, size of encryption buf in number of ciphertext pages */
+    file_ptr->num_ct_buf_pages = file_ptr->fa.encryption_buffer_size / 
+                                            file_ptr->fa.ciphertext_page_size;
+
+    /* compute file_ptr->ciphertext_offset */
+    file_ptr->ciphertext_offset = (haddr_t)(2 * 
+                                        file_ptr->fa.ciphertext_page_size);
+
+    /* open the underlying VFD / file */
+    if (H5FD_open(false, &file_ptr->file, name, flags, file_ptr->fa.fapl_id, HADDR_UNDEF) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTOPENFILE, NULL, "unable to open underlying file");
+
+    /* Initialize the eoa/eof up/down fields */
+    file_ptr->eoa_up = 0;
+    file_ptr->eoa_down = (haddr_t)file_ptr->ciphertext_offset;
+    file_ptr->eof_up = HADDR_UNDEF;
+    file_ptr->eof_down = HADDR_UNDEF;
+
+    /* Set the eoa before trying to write to a file to avoid addr overflow*/
+    if (H5FD__crypt_set_eoa((H5FD_t *)file_ptr, H5FD_MEM_DRAW, file_ptr->eoa_up) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTSET, NULL, 
+                                    "H5FDset_eoa failed for underlying file");
+
+    /* If we are either truncating or creating the underlying file, we must 
+     * setup the header ciphertext pages.
+     */
+    if ( ( H5F_ACC_TRUNC & flags ) || ( H5F_ACC_CREAT & flags ) ) {
+
+        /* Write cipher information to the first page */
+        if ( H5FD__crypt_write_first_page(file_ptr) < 0 )
+            HGOTO_ERROR(H5E_VFL, H5E_WRITEERROR, NULL, 
+                    "cannot write first header page to the underlying file");
+
+        /* Write IV and test phrase to second page */
+        if ( H5FD__crypt_write_second_page(file_ptr) < 0 )
+            HGOTO_ERROR(H5E_VFL, H5E_WRITEERROR, NULL, 
+                    "cannot write second header page to the underlying file");
+    }
+
+    /* Read the first page of the file and verify that the configuration 
+     * information in the first page matches that provided in the FAPL.
+     */
+    if ( SUCCEED != H5FD__crypt_read_first_page(file_ptr) ) 
+        HGOTO_ERROR(H5E_VFL, H5E_CANTOPENFILE, NULL, 
+                    "first header page validation failed.");
+
+    /* Decrypt second page test phrase and compare it with expected value */
+    if ( SUCCEED != H5FD__crypt_decrypt_test_phrase(file_ptr) )
+        HGOTO_ERROR(H5E_VFL, H5E_CANTOPENFILE, NULL, 
+                                "second header page validation failed.");
+
+    ret_value = (H5FD_t *)file_ptr;
+
+done:
+
+    if (NULL == ret_value) {  /* do error cleanup */
+
+        if (file_ptr) {
+
+            if (H5I_INVALID_HID != file_ptr->fa.fapl_id) {
+
+                H5I_dec_ref(file_ptr->fa.fapl_id);
+            }
+
+            if (file_ptr->file) {
+
+                H5FD_close(file_ptr->file);
+            }
+
+            H5FL_FREE(H5FD_crypt_t, file_ptr);
+        }
+    } /* end if error */
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_open() */
+
+
+/*-------------------------------------------------------------------------
+ *
+ * Function:    H5FD__crypt_load_config
+ *
+ * Purpose:     Given the file pointer and the fapl ID, populate 
+ *              file_ptr->fa from the fapl file driver property.  Note 
+ *              that this property may contain crypt VFD configuration 
+ *              data in string format, binary format, or it may be 
+ *              omitted entirely.  In this later case, load file_ptr-fa 
+ *              with the default configuration.
+ *
+ * Return:      Success:    SUCCEED
+ *              Failure:    FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+
+herr_t
+H5FD__crypt_load_config(H5FD_crypt_t * file_ptr, hid_t crypt_fapl_id)
+{
+    const char * config_str = NULL;
+    H5P_genplist_t  * plist_ptr  = NULL;
+    const H5FD_crypt_vfd_config_t * config_ptr = NULL;
+    herr_t ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    assert(file_ptr);
+    assert(H5FD_CRYPT_CONFIG_MAGIC == file_ptr->fa.magic);
+    assert(NULL == file_ptr->config_str);
+    assert(H5FD_CURR_CRYPT_VFD_CONFIG_VERSION == file_ptr->fa.version);
+    assert(H5FD_CRYPT == H5Pget_driver(crypt_fapl_id));
+
+    file_ptr->config_str = NULL;
+
+    /* verify that the fapl driver info message at least specifies the encryption VFD */
+    if (H5FD_CRYPT != H5Pget_driver(crypt_fapl_id))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "driver messages doesn't specify the encryption VFD");
+
+    /* Get the driver-specific file access properties */
+    plist_ptr = (H5P_genplist_t *)H5I_object(crypt_fapl_id);
+
+    if ( NULL == plist_ptr )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "supplied fapl doesn't exist?");
+
+    config_ptr = (const H5FD_crypt_vfd_config_t *)H5P_peek_driver_info(plist_ptr);
+
+    config_str = H5P_peek_driver_config_str(plist_ptr);
+
+    assert( ! ( config_ptr && config_str ) );
+
+    if ( config_ptr ) {
+
+        if ( H5FD_CRYPT_CONFIG_MAGIC != config_ptr->magic )
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid configuration (magic number mismatch)");
+
+        /* Copy *fapl_ptr into file_ptr->fa.  Start with a memcpy() */
+        H5MM_memcpy(&(file_ptr->fa), config_ptr, sizeof(H5FD_crypt_vfd_config_t));
+
+        /* copy the FAPL for the underlying VFD stack, and store the id of the copy in file_ptr->fa.fapl_id. */
+        if (H5FD__copy_plist(config_ptr->fapl_id, &(file_ptr->fa.fapl_id)) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "can't copy underlying FAPL");
+
+    } else if ( config_str ) {
+
+        /* first, load the configuration with default values. 
+         * must do this, as the configuration string may not define all values -- which 
+         * means that the initial values must be reasonable where possible.
+         */
+        file_ptr->fa.magic                  = H5FD_CRYPT_CONFIG_MAGIC;
+        file_ptr->fa.version                = H5FD_CURR_CRYPT_VFD_CONFIG_VERSION;
+        file_ptr->fa.plaintext_page_size    = H5FD_CRYPT_DEFAULT_PLAINTEXT_PAGE_SIZE;
+        file_ptr->fa.ciphertext_page_size   = H5FD_CRYPT_DEFAULT_CIPHERTEXT_PAGE_SIZE;
+        file_ptr->fa.encryption_buffer_size = H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE;
+        file_ptr->fa.cipher                 = H5FD_CRYPT_DEFAULT_CIPHER;
+        file_ptr->fa.cipher_block_size      = H5FD_CRYPT_DEFAULT_CIPHER_BLOCK_SIZE;
+        file_ptr->fa.key_size               = H5FD_CRYPT_DEFAULT_KEY_SIZE;
+        file_ptr->fa.iv_size                = H5FD_CRYPT_DEFAULT_IV_SIZE;
+        file_ptr->fa.mode                   = H5FD_CRYPT_DEFAULT_MODE;
+        file_ptr->fa.fapl_id                = H5P_DEFAULT;
+
+        /* zero out file_ptr->fa.key */
+        memset(&(file_ptr->fa.key[0]), 0, H5FD_CRYPT_MAX_KEY_SIZE);
+
+        /* now call H5FD__crypt_parse_config() to parse the configuration string
+         * and overwrite any field in file_ptr->fa with values that appear in 
+         * the configuration string.
+         */
+        if ( H5FD__crypt_parse_config(config_str, &(file_ptr->fa)) < 0 )
+            HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "can't parse configuration string");
+
+        /* save a copy of the configuration string */
+        file_ptr->config_str = H5MM_strdup(config_str);
+
+    } else { /* just load the default configuration */
+
+        HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, "no encryption VFD configuration data provided.");
+
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5FD__crypt_load_config() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__crypt_parse_config
+ *
+ * Purpose:     Taking a string in the VFD configuration language as input,
+ *              parse the string and load its contents into an instance of 
+ *              H5FD_pb_vfd_config_t.  Note that default values are used 
+ *              for any values not specified in the configuration string.
+ *
+ *              Note also that some fields are required.  Their absence 
+ *              will cause the function to throw an error.
+ *
+ * Return:      Success:    SUCCEED
+ *              Failure:    FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+
+herr_t
+H5FD__crypt_parse_config(const char * config_str, H5FD_crypt_vfd_config_t * config_ptr)
+{
+    /* booleans used to track whether required fields have appeared */
+    bool have_key_size = false;
+    bool have_key = false;
+    int i;
+    size_t reported_key_size = 0;
+    char vfd_name[] = "encryption_VFD";
+    hid_t fapl_id = H5I_INVALID_HID;
+    H5CL_nv_pair_t nv_pairs[H5FD_CRYPT__MAX_PARAMS];
+    herr_t ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    assert(config_str);
+    assert(H5FD_CRYPT_CONFIG_MAGIC == config_ptr->magic);
+
+    for ( i = 0; i < H5FD_CRYPT__MAX_PARAMS; i++ ) {
+
+        nv_pairs[i].struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
+
+        if ( H5CL_init_nv_pair(&(nv_pairs[i])) < 0 )
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't initialize nv_pairs.");
+
+    }
+
+    if ( H5CL_parse_config(config_str, vfd_name, &(nv_pairs[0]), H5FD_CRYPT__MAX_PARAMS) < 0 )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't parse config_str.");
+
+    for ( i = 0; i < H5FD_CRYPT__MAX_PARAMS; i++ ) {
+
+        if ( H5CL_VAL_NONE != nv_pairs[i].val_type ) {
+
+            if ( 0 == strcmp("plaintext_page_size", nv_pairs[i].name_ptr) ) {
+
+                if ( H5CL_VAL_INT == nv_pairs[i].val_type ) {
+
+                    /* need range check */
+
+                    config_ptr->plaintext_page_size = (size_t)(nv_pairs[i].int_val);
+
+                } else {
+
+                    HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parameter name / type mismatch.");
+                }
+
+            } else if ( 0 == strcmp("ciphertext_page_size", nv_pairs[i].name_ptr) ) {
+
+                if ( H5CL_VAL_INT == nv_pairs[i].val_type ) {
+
+                    /* need range check */
+
+                    config_ptr->ciphertext_page_size = (size_t)(nv_pairs[i].int_val);
+
+                } else {
+
+                    HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parameter name / type mismatch.");
+                }
+
+            } else if ( 0 == strcmp("encryption_buffer_size", nv_pairs[i].name_ptr) ) {
+
+                if ( H5CL_VAL_INT == nv_pairs[i].val_type ) {
+
+                    /* need range check */
+
+                    config_ptr->encryption_buffer_size = (size_t)(nv_pairs[i].int_val);
+
+                } else {
+
+                    HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parameter name / type mismatch.");
+                }
+
+            } else if ( 0 == strcmp("cipher", nv_pairs[i].name_ptr) ) {
+
+                if ( H5CL_VAL_INT == nv_pairs[i].val_type ) {
+
+                    /* need range check */
+
+                    config_ptr->cipher = (int)(nv_pairs[i].int_val);
+
+                } else {
+
+                    HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parameter name / type mismatch.");
+                }
+
+            } else if ( 0 == strcmp("cipher_block_size", nv_pairs[i].name_ptr) ) {
+
+                if ( H5CL_VAL_INT == nv_pairs[i].val_type ) {
+
+                    /* need range check */
+
+                    config_ptr->cipher_block_size = (size_t)(nv_pairs[i].int_val);
+
+                } else {
+
+                    HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parameter name / type mismatch.");
+                }
+
+            } else if ( 0 == strcmp("key_size", nv_pairs[i].name_ptr) ) {
+
+                if ( H5CL_VAL_INT == nv_pairs[i].val_type ) {
+
+                    /* need range check */
+
+                    config_ptr->key_size = (size_t)(nv_pairs[i].int_val);
+
+                    if ( H5FD_CRYPT_MAX_KEY_SIZE < config_ptr->key_size ) 
+                        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "Key size > H5FD_CRYPT_MAX_KEY_SIZE.");
+
+                    if ( ( have_key ) && ( reported_key_size != config_ptr->key_size ) )
+                        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "key size / actual key size mismatch - 1.");
+
+                    have_key_size = TRUE;
+
+                } else {
+
+                    HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parameter name / type mismatch.");
+                }
+
+            } else if ( 0 == strcmp("key", nv_pairs[i].name_ptr) ) {
+
+                if ( H5CL_VAL_BB == nv_pairs[i].val_type ) {
+
+                    /* need range check */
+
+                    reported_key_size = nv_pairs[i].len;
+
+                    if ( H5FD_CRYPT_MAX_KEY_SIZE < reported_key_size ) 
+                        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "Actual key size > H5FD_CRYPT_MAX_KEY_SIZE.");
+
+                    if ( ( have_key_size ) && ( reported_key_size != config_ptr->key_size ) )
+                        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "key size / actual key size mismatch - 2.");
+
+                    memcpy(&(config_ptr->key[0]), (nv_pairs[i].vlen_val_ptr), reported_key_size);
+
+                    have_key = TRUE;
+
+                } else {
+
+                    HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parameter name / type mismatch.");
+                }
+
+            } else if ( 0 == strcmp("iv_size", nv_pairs[i].name_ptr) ) {
+
+                if ( H5CL_VAL_INT == nv_pairs[i].val_type ) {
+
+                    /* need range check */
+
+                    config_ptr->iv_size = (size_t)(nv_pairs[i].int_val);
+
+                } else {
+
+                    HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parameter name / type mismatch.");
+                }
+
+            } else if ( 0 == strcmp("mode", nv_pairs[i].name_ptr) ) {
+
+                if ( H5CL_VAL_INT == nv_pairs[i].val_type ) {
+
+                    /* need range check */
+
+                    config_ptr->mode = (int)(nv_pairs[i].int_val);
+
+                } else {
+
+                    HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parameter name / type mismatch.");
+                }
+
+            } else if ( 0 == strcmp("underlying_VFD", nv_pairs[i].name_ptr) ) {
+
+                if ( H5CL_VAL_INT == nv_pairs[i].val_type ) {
+
+                    fapl_id = (hid_t)(nv_pairs[i].int_val);
+
+                    if ( ( H5P_DEFAULT != fapl_id ) && ( false == H5P_isa_class(fapl_id, H5P_FILE_ACCESS) ) )
+
+                        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "Supplied FAPL ID isn't a FAPL ID.");
+
+                    config_ptr->fapl_id = fapl_id;
+
+                } else if ( H5CL_VAL_LIST == nv_pairs[i].val_type ) {
+
+                    /* construct a new FAPL and insert the configuration for the underlying 
+                     * VFD into it. 
+                     */
+                    H5P_genclass_t *pclass;
+
+                    if (NULL == (pclass = (H5P_genclass_t *)H5I_object_verify(H5P_FILE_ACCESS, H5I_GENPROP_CLS)))
+                        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "Can't get ptr to fapl class");
+
+                    if ( H5I_INVALID_HID == (fapl_id = H5P_create_id(pclass, false)) )
+                        HGOTO_ERROR(H5E_PLIST, H5E_CANTCREATE, FAIL, "can't create fapl for underlying VFD");
+
+                    if ( H5CL_load_vfd_config_str_into_fapl(fapl_id, (char *)(nv_pairs[i].vlen_val_ptr)) < 0 )
+                        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't set driver on fapl .");
+
+                    config_ptr->fapl_id = fapl_id;
+
+                } else {
+
+                    HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parameter name / type mismatch.");
+                }
+
+            } else {
+
+                HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "unknown parameter name.");
+            }
+        }
+    }
+
+    /* check for missing required values */
+    if ( ! have_key_size ) 
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "config string lacks key_size name value pair.");
+
+    if ( ! have_key ) 
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "config string lacks key name value pair.");
+
+    if ( H5P_DEFAULT ==  config_ptr->fapl_id ) {
+
+        hid_t copy_fapl_id;
+        H5P_genplist_t *default_fapl_ptr = NULL;
+        H5P_genplist_t *copy_fapl_ptr = NULL;
+
+        /* Use a copy of default file access property list for underlying FAPL ID.
+         * The Sec2 driver is explicitly set on the FAPL ID, as the default
+         * driver might have been replaced with the page buffer VFD, which
+         * would cause recursion.
+         */
+
+        /* get a pointer to the default fapl */
+        if ( NULL == ( default_fapl_ptr = (H5P_genplist_t *)H5I_object(H5P_FILE_ACCESS_DEFAULT) ) )
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access property list");
+
+        /* make a copy of the default fapl */
+        if ( ( copy_fapl_id = H5P_copy_plist(default_fapl_ptr, false)) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTCOPY, FAIL, "can't copy property list");
+
+        /* get a pointer to the copy of the default fapl */
+        if (NULL == (copy_fapl_ptr = (H5P_genplist_t *)H5I_object(copy_fapl_id)))
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access property list");
+
+        /* force the copy of the default fapl to specify the sec2 VFD */
+        if (H5P_set_driver_by_value(copy_fapl_ptr, H5_VFD_SEC2, NULL, true) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, "can't set default driver on underlying FAPL");
+
+        /* overwrite config_ptr->fapl_id with the id of the copy of the default fapl */
+        config_ptr->fapl_id = copy_fapl_id;
+
+    } else {
+
+        /* config_ptr->fapl_id is not H5P_DEFAULT.  Just verify that it is a fapl */
+
+        if (false == H5P_isa_class(config_ptr->fapl_id, H5P_FILE_ACCESS))
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access list");
+    }
+
+    for ( i = 0; i < H5FD_CRYPT__MAX_PARAMS; i++ ) {
+
+        if ( ( H5CL_NV_PAIR_STRUCT_TAG == nv_pairs[i].struct_tag ) &&
+             ( H5CL_take_down_nv_pair(&(nv_pairs[i])) < 0 ) )
+
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't take down nv_pair.");
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5FD__crypt_parse_config() */
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_close
+ *
+ * Purpose:     Closes the underlying file and take down the page buffer.
+ *
+ * Return:      Success:    SUCCEED
+ *              Failure:    FAIL, file not closed.
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_close(H5FD_t *_file)
+{
+    H5FD_crypt_t * file_ptr      = (H5FD_crypt_t *)_file;
+    herr_t         ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    /* Sanity check */
+    assert(file_ptr);
+
+    if (H5I_dec_ref(file_ptr->fa.fapl_id) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_ARGS, FAIL, 
+                                    "can't close underlying VFD FAPL");
+
+    if (file_ptr->file) {
+
+        if (H5FD_close(file_ptr->file) == FAIL)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTCLOSEFILE, FAIL, 
+                                    "unable to close underlying file");
+    }
+
+    /* discard encryption related data structures. */
+    if (file_ptr->ciphertext_buf)
+    {
+        free(file_ptr->ciphertext_buf);
+        file_ptr->ciphertext_buf = NULL;
+    }
+
+    /* Discard the configuration string if present */
+    if ( file_ptr->config_str ) {
+
+        file_ptr->config_str = H5MM_xfree(file_ptr->config_str);
+    }
+
+    /* Release the file info */
+    file_ptr = H5FL_FREE(H5FD_crypt_t, file_ptr);
+    file_ptr = NULL;
+
+    /* Freeing the secure memory */
+    gcry_control(GCRYCTL_TERM_SECMEM);
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_close() */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_get_eoa
+ *
+ * Purpose:     Returns the end-of-address marker for the file. The EOA marker 
+ *              is the first address past the last byte allocated in the format
+ *              address space.
+ *
+ *              Due to the fact that ciphertext pages are typically larger 
+ *              plain text pages, and the current use of the first two cipher
+ *              text pages to store configuration and test data, the EOA 
+ *              above the encryption VFD is different from that below.
+ *
+ *              Since we currently maintain the file_ptr->eoa_up and 
+ *              file_ptr->eoa_down fields, in principle, it is sufficient to 
+ *              simply return eoa_up.
+ *
+ *              However, as a sanity check, we request the eoa from the 
+ *              underlying VFD, and fail if it doesn't match file_ptr->eoa_down.
+ *
+ *              If this test passes, we return file_ptr->eoa_up.
+ *
+ *              Note that we don't have to concern outselves with the 
+ *              case in which the first get_eoa call arrives before the 
+ *              first set_eoa call since the eoa is set as part of the 
+ *              H5FD__crypt_open() call.
+ *
+ * Return:      Success:    The end-of-address-marker
+ *
+ *              Failure:    HADDR_UNDEF
+ *-----------------------------------------------------------------------------
+ */
+static haddr_t
+H5FD__crypt_get_eoa(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
+{
+    haddr_t             eoa_down;
+    const H5FD_crypt_t *file_ptr  = (const H5FD_crypt_t *)_file;
+    haddr_t             ret_value = HADDR_UNDEF;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    /* Sanity check */
+    assert(file_ptr);
+    assert(file_ptr->file);
+
+    if ((eoa_down = H5FD_get_eoa(file_ptr->file, type)) == HADDR_UNDEF)
+        HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, HADDR_UNDEF, "unable to get eoa");
+
+    if ( H5_addr_ne(eoa_down, file_ptr->eoa_down) ) 
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, HADDR_UNDEF, "eoa_down mismatch");
+
+    ret_value = file_ptr->eoa_up;
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_get_eoa */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_set_eoa
+ *
+ * Purpose:     Set the end-of-address marker for the file. This function is
+ *              called shortly after an existing HDF5 file is opened in order 
+ *              to tell the driver where the end of the HDF5 data is located.
+ *
+ *              In the encryption VFD case, we must extend the supplied EOA
+ *              to the next clear text boundary, then divide by the clear text
+ *              page size, add 2, multiply by the ciphertext page size, and 
+ *              pass the result to the underlying VFD.  If the call is 
+ *              successful, set eoa_up and eoa_down to the supplied and 
+ *              computed values respectively, and then return.
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_set_eoa(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, 
+                        haddr_t addr)
+{
+    haddr_t eoa_up;
+    haddr_t eoa_down;
+    int64_t page_num;
+    H5FD_crypt_t *file_ptr  = (H5FD_crypt_t *)_file;
+    herr_t        ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__)
+
+    /* Sanity check */
+    assert(file_ptr);
+    assert(file_ptr->file);
+
+    eoa_up = addr;
+
+    page_num = (int64_t)(addr / (haddr_t)((file_ptr->fa.plaintext_page_size)));
+
+    assert(page_num >= 0);
+
+    if ( 0 < (addr % (haddr_t)(file_ptr->fa.plaintext_page_size)) ) {
+
+        page_num++;
+    }
+
+    page_num += 2; /* to adjust for header pages */
+
+    eoa_down = ((haddr_t)(page_num)) * ((haddr_t)(file_ptr->fa.ciphertext_page_size));
+
+    if (H5FD_set_eoa(file_ptr->file, type, eoa_down) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, 
+                        "H5FDset_eoa failed for underlying file");
+
+    file_ptr->eoa_up = eoa_up;
+    file_ptr->eoa_down = eoa_down;
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_set_eoa() */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_get_eof
+ *
+ * Purpose:     Returns the end-of-address marker for the file. The EOA marker 
+ *              is the first address past the last byte allocated in the format
+ *              address space.
+ *
+ *              As with the EOA, the encryption VFD must translate the EOF 
+ *              from below the VFD to that which is expected above the 
+ *              VFD.  However, there is a major problem that doesn't appear
+ *              in the EOA case.
+ *
+ *              Specifically, the reported EOF need not be accurate -- indeed, 
+ *              the underlying VFD may report HADDR_UNDEF or the maximum file 
+ *              size.
+ *
+ *              The major uses of the get_eof call are:
+ *
+ *              1) Determine whether the file is empty.  This is used to 
+ *                 trigger creation of a new superblock.
+ *
+ *              2) Deterine whether the file has been truncated, and thus
+ *                 can't be opened.  This is done by comparing the reported
+ *                 EOF with that stored in the superblock, and refusing to 
+ *                 open if the reported EOF is smaller.
+ *
+ *              3) When extending the EOA, the library gets the reported 
+ *                 EOA and EOF, and adds the desired increment to the 
+ *                 maximum of the EOA and EOF to obtain the new EOA.
+ *                 
+ *              If the EOF is reported correctly, the above issues are 
+ *              moot.  The EOF will be a multiple of the ciphertext 
+ *              page size, which is easily converted to the same multiple
+ *              of cleartext pages less two, and reported.
+ *
+ *              The more interesting question is how to handle errors in 
+ *              the EOF.  The obvious solution is to flag an error on obvious
+ *              errors (i.e. EOF less than 2 * ciphertext page size or not 
+ *              a multiple of ciphertext page size) and apply the usual
+ *              conversion to any EOF that passes these simple checks.
+ *              The only exception to this is the error value HADDR_UNDEF, 
+ *              which is simply relayed up the VFD stack if it is received 
+ *              from below.
+ *
+ *              This is the approach I am using for now.  It may cause
+ *              problems with some underlying VFD stacks, but it should 
+ *              be fine with sec2.
+ *                                                 JRM -- 08/20/24
+ *
+ * Return:      Success:    The end-of-address-marker
+ *
+ *              Failure:    HADDR_UNDEF
+ *
+ *-----------------------------------------------------------------------------
+ */
+static haddr_t
+H5FD__crypt_get_eof(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
+{
+    haddr_t             eof_up;
+    haddr_t             eof_down;
+    uint64_t            num_pages;
+    H5_GCC_CLANG_DIAG_OFF("cast-qual")
+    H5FD_crypt_t        *file_ptr  = (H5FD_crypt_t *)_file;
+    H5_GCC_CLANG_DIAG_ON("cast-qual")
+    haddr_t             ret_value = HADDR_UNDEF; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    /* Sanity check */
+    assert(file_ptr);
+    assert(file_ptr->file);
+
+    if (HADDR_UNDEF == (eof_down = H5FD_get_eof(file_ptr->file, type)))
+        HGOTO_ERROR(H5E_VFL, H5E_CANTGET, HADDR_UNDEF, "unable to get eof");
+
+    num_pages = (uint64_t)(eof_down / file_ptr->fa.ciphertext_page_size);
+
+    if ( num_pages < 2 ) 
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, HADDR_UNDEF, "underlying EOF incompatible with an encrypted file");
+
+    num_pages -= 2;
+
+    if ( 0 != (eof_down % file_ptr->fa.ciphertext_page_size) ) {
+
+        /* An encrypted file must have length some multiple of the ciphertext 
+         * page size. Flag an error for now, but note that we will probably 
+         * have to make some adjustments to allow for user blocks.
+         */
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, HADDR_UNDEF, "underlying EOF not a multiple of ciphertext page size");
+    }
+
+    eof_up = ((haddr_t)(num_pages)) * ((haddr_t)(file_ptr->fa.plaintext_page_size));
+
+    file_ptr->eof_up = eof_up;
+    file_ptr->eof_down = eof_down;
+
+    ret_value = eof_up;
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_get_eof */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_truncate
+ *
+ * Purpose:     Notify driver to truncate the file back to the allocated size.
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_truncate(H5FD_t *_file, hid_t dxpl_id, bool closing)
+{
+    H5FD_crypt_t *file      = (H5FD_crypt_t *)_file;
+    herr_t        ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    assert(file);
+    assert(file->file);
+
+    if (H5FDtruncate(file->file, dxpl_id, closing) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTUPDATE, FAIL, "unable to truncate file");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_truncate */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_sb_size
+ *
+ * Purpose:     Obtains the number of bytes required to store the driver file
+ *              access data in the HDF5 superblock.
+ *
+ * Return:      Success:    Number of bytes required.
+ *
+ *              Failure:    0 if an error occurs or if the driver has no data 
+ *                          to store in the superblock.
+ *
+ * NOTE: no public API for H5FD_sb_size, it needs to be added
+ *-----------------------------------------------------------------------------
+ */
+static hsize_t
+H5FD__crypt_sb_size(H5FD_t *_file)
+{
+    H5FD_crypt_t *file      = (H5FD_crypt_t *)_file;
+    hsize_t    ret_value = 0;
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    /* Sanity check */
+    assert(file);
+    assert(file->file);
+
+    if (file->file) {
+
+        ret_value = H5FD_sb_size(file->file);
+    }
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_sb_size */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_sb_encode
+ *
+ * Purpose:     Encode driver-specific data into the output arguments.
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_sb_encode(H5FD_t *_file, char *name /*out*/, 
+                        unsigned char *buf /*out*/)
+{
+    H5FD_crypt_t *file      = (H5FD_crypt_t *)_file;
+    herr_t     ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    /* Sanity check */
+    assert(file);
+    assert(file->file);
+
+    if (file->file && H5FD_sb_encode(file->file, name, buf) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTENCODE, FAIL, 
+                            "unable to encode the superblock in file");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_sb_encode */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_sb_decode
+ *
+ * Purpose:     Decodes the driver information block.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ * NOTE: no public API for H5FD_sb_size, need to add
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_sb_decode(H5FD_t *_file, const char *name, 
+                        const unsigned char *buf)
+{
+    H5FD_crypt_t *file      = (H5FD_crypt_t *)_file;
+    herr_t     ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    /* Sanity check */
+    assert(file);
+    assert(file->file);
+
+    if (H5FD_sb_load(file->file, name, buf) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTDECODE, FAIL, 
+                        "unable to decode the superblock in file");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_sb_decode */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_cmp
+ *
+ * Purpose:     Compare the keys of two files.
+ *
+ * Return:      Success:    A value like strcmp()
+ *              Failure:    Must never fail
+ *-----------------------------------------------------------------------------
+ */
+static int
+H5FD__crypt_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
+{
+    const H5FD_crypt_t *f1 = (const H5FD_crypt_t *)_f1;
+    const H5FD_crypt_t *f2 = (const H5FD_crypt_t *)_f2;
+    herr_t ret_value    = 0; /* Return value */
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    assert(f1);
+    assert(f2);
+
+    ret_value = H5FD_cmp(f1->file, f2->file);
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_cmp */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_get_handle
+ *
+ * Purpose:     Returns a pointer to the file handle of low-level virtual
+ *              file driver.
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_get_handle(H5FD_t *_file, hid_t H5_ATTR_UNUSED fapl, 
+                        void **file_handle)
+{
+    H5FD_crypt_t *file      = (H5FD_crypt_t *)_file;
+    herr_t     ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    /* Check arguments */
+    assert(file);
+    assert(file->file);
+    assert(file_handle);
+
+    if (H5FD_get_vfd_handle(file->file, file->fa.fapl_id, file_handle) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL, 
+                                        "unable to get handle of file");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_get_handle */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_lock
+ *
+ * Purpose:     Sets a file lock.
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_lock(H5FD_t *_file, bool rw)
+{
+    H5FD_crypt_t *file      = (H5FD_crypt_t *)_file; /* VFD file struct */
+    herr_t        ret_value = SUCCEED;            /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    assert(file);
+    assert(file->file);
+
+    /* Place the lock on each file */
+    if (H5FD_lock(file->file, rw) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTLOCKFILE, FAIL, "unable to lock file");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_lock */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_unlock
+ *
+ * Purpose:     Removes a file lock.
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_unlock(H5FD_t *_file)
+{
+    H5FD_crypt_t *file      = (H5FD_crypt_t *)_file; /* VFD file struct */
+    herr_t        ret_value = SUCCEED;            /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    /* Check arguments */
+    assert(file);
+    assert(file->file);
+
+    if (H5FD_unlock(file->file) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTUNLOCKFILE, FAIL, 
+                                            "unable to unlock R/W file");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_unlock */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_ctl
+ *
+ * Purpose:     Encryption VFD version of the ctl callback.
+ *
+ *              The desired operation is specified by the op_code parameter.
+ *
+ *              The flags parameter controls management of op_codes that are 
+ *              unknown to the callback
+ *
+ *              The input and output parameters allow op_code specific input 
+ *              and output
+ *
+ *              At present, this VFD supports no op codes of its own and 
+ *              simply passes ctl calls on to the underlying VFD
+ *
+ * Return:      Non-negative on success/Negative on failure
+ *
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_ctl(H5FD_t *_file, uint64_t op_code, uint64_t flags, 
+                        const void *input, void **output)
+{
+    H5FD_crypt_t *file      = (H5FD_crypt_t *)_file;
+    herr_t     ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    /* Sanity checks */
+    assert(file);
+
+    switch (op_code) {
+
+        /* probably want to add options for displaying and reseting stats */
+
+        /* Unknown op code */
+        default:
+            if (flags & H5FD_CTL_ROUTE_TO_TERMINAL_VFD_FLAG) {
+
+                /* Pass ctl call down to underlying VFD */
+
+                if (H5FDctl(file->file, op_code, flags, input, output) < 0)
+                    HGOTO_ERROR(H5E_VFL, H5E_FCNTL, FAIL, 
+                                                "VFD ctl request failed");
+            }
+            else {
+                /* If no valid VFD routing flag is specified, fail for unknown 
+                 * op code if H5FD_CTL_FAIL_IF_UNKNOWN_FLAG flag is set.
+                 */
+                if (flags & H5FD_CTL_FAIL_IF_UNKNOWN_FLAG)
+                    HGOTO_ERROR(H5E_VFL, H5E_FCNTL, FAIL,
+                        "VFD ctl request failed (unknown op code and fail if unknown flag is set)");
+            }
+
+            break;
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_ctl() */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_query
+ *
+ * Purpose:     Set the flags that this VFL driver is capable of supporting.
+ *              (listed in H5FDpublic.h)
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_query(const H5FD_t *_file, unsigned long *flags /* out */)
+{
+    const H5FD_crypt_t *file      = (const H5FD_crypt_t *)_file;
+    herr_t           ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    if (file) {
+        assert(file);
+        assert(file->file);
+
+        if (H5FDquery(file->file, flags) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTLOCK, FAIL, 
+                                    "unable to query R/W file");
+
+#if 0 /* zero out the data sieve flag */
+        *flags = *flags & (unsigned long)(~H5FD_FEAT_DATA_SIEVE);
+        *flags = *flags & (unsigned long)(~H5FD_FEAT_AGGREGATE_SMALLDATA);
+#endif
+    }
+    else {
+        /* There is no file. Because this is a pure passthrough VFD,
+         * it has no features of its own.
+         */
+        if (flags)
+            *flags = 0;
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_query() */
+
+#if 0 
+/* The current implementations of the alloc and free callbacks
+ * cause space allocation failures in the upper library.  This    
+ * has to be dealt with if we want the page buffer and encryption
+ * to run with VFDs that require it (split, multi).
+ * However, since targeting just the sec2 VFD is sufficient    
+ * for the Phase I prototype, we will bypass the issue
+ * for now.
+ *                                JRM -- 9/6/24
+ */
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_alloc
+ *
+ * Purpose:     Allocate file memory.
+ *
+ *              Handling this call as a pass through while maintaining the
+ *              eoa_up and eoa_down is made more complicated by the fact
+ *              that some VFDs treat this call as a set eoa call, and
+ *              others (multi / split file driver only?) implement it as
+ *              an addition to the current EOA (for the specified type).
+ *
+ *              This is a bit awkward for the page buffer.  For now,
+ *              solve this by:
+ *
+ *              
+ *
+ *              1) pass through the alloc call.
+ *
+ *              2) make a get eoa call on the underlying VFD to obtain
+ *                 the current eoa from below.  Call this value eoa_up
+ *
+ *              3) if eoa_up is not on a page boundary, increment it to
+ *                 the next page boundary, set the eoa of the underlying
+ *                 VFD to the is value, and save it in eoa_down.
+ *
+ *              4) store the new values of eoa_up and eoa_down in *file_ptr.
+ *
+
+ *
+ * Return:      Address of allocated space (HADDR_UNDEF if error).
+ *-----------------------------------------------------------------------------
+ */
+static haddr_t
+H5FD__crypt_alloc(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, hsize_t size)
+{
+    haddr_t       eoa_up;
+    haddr_t       eoa_down;
+    haddr_t       size_down;
+    int64_t       num_pages;
+    H5FD_crypt_t *file_ptr  = (H5FD_crypt_t *)_file; /* VFD file struct */
+    haddr_t       ret_value = HADDR_UNDEF;        /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    /* Check arguments */
+    assert(file_ptr);
+    assert(file_ptr->file);
+
+    /* convert the supplied size to the equivalent value in ciphertext pages,
+     * rounding up to the next cipher text page boundary.
+     */
+    num_pages = (int64_t)(size / (haddr_t)((file_ptr->fa.plaintext_page_size)));
+    
+    assert(num_pages >= 0);
+    
+    if ( 0 < (size % (haddr_t)(file_ptr->fa.plaintext_page_size)) ) {
+        
+        num_pages++;
+    }
+
+    size_down = (hsize_t)(((haddr_t)num_pages) * (haddr_t)((file_ptr->fa.ciphertext_page_size)));
+    
+
+    if ( H5FDalloc(file_ptr->file, type, dxpl_id, size_down) == HADDR_UNDEF)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, HADDR_UNDEF, 
+                                "unable to allocate for underlying file");
+
+    /* Depending on the underlying VFD, the H5FDalloc() call may simply set 
+     * the underlying EOA to size_down, or may add size_down to the current 
+     * eoa.  
+     * 
+     * In the former case, we must extend the underlying eoa by two times
+     * the ciphertext page size, set the eoa below to this value, and set 
+     * eoa_up accordingly.
+     *
+     * In the latter case, we must extend the eoa up by num_pages clear text
+     * pages, and set eoa up according.
+     *
+     * In either case, we must verify that eoa_up and eoa_down have the 
+     * the correct relationship to each other, and return eoa_up.
+     *
+     * In all other case, set the lower EOA equal to file_ptr->eao_down, 
+     * flag an error and return HADDR_UNDEF.
+     */
+
+    if ((eoa_down = H5FD_get_eoa(file_ptr->file, type)) == HADDR_UNDEF)
+        HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, HADDR_UNDEF, "unable to get eoa");
+
+    if ( eoa_down == size_down ) { /* alloc call is equivalent to a set eoa call */
+
+        eoa_down += 2 * file_ptr->fa.ciphertext_page_size;
+
+        if ( eoa_down != ((haddr_t)(num_pages + 2) * (haddr_t)(file_ptr->fa.ciphertext_page_size)) ) {
+
+            fprintf(stderr, "eoa_down     = 0x%llx\n", (unsigned long long)eoa_down);
+            fprintf(stderr, "num_pages    = %lld\n", (unsigned long long)num_pages);
+            fprintf(stderr, "ct_page_size = 0x%lld\n", 
+                    (unsigned long long)(file_ptr->fa.ciphertext_page_size));
+        }
+
+        assert( eoa_down == ((haddr_t)(num_pages + 2) * (haddr_t)(file_ptr->fa.ciphertext_page_size)) );
+
+        if (H5FD_set_eoa(file_ptr->file, type, eoa_down) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTSET, HADDR_UNDEF, "H5FDset_eoa failed for underlying file");
+
+        eoa_up = (haddr_t)num_pages * (haddr_t)(file_ptr->fa.plaintext_page_size);
+
+        file_ptr->eoa_down = eoa_down;
+#if 0
+        file_ptr->eoa_up   = eoa_up;
+
+        ret_value = eoa_up;
+#else 
+        file_ptr->eoa_up   = size;
+
+        ret_value = size;
+#endif
+
+    } else if ( eoa_down == (file_ptr->eoa_down + size_down) ) { /* alloc adds addr to current eoa */
+
+        if ( 0 != (eoa_down % file_ptr->fa.ciphertext_page_size) ) {
+
+            fprintf(stderr, "\neoa_down                    = 0x%llx\n", (unsigned long long)eoa_down);
+            fprintf(stderr, "ct_page_size                = 0x%llx\n", 
+                    (unsigned long long)(file_ptr->fa.ciphertext_page_size));
+            fprintf(stderr, "eoa_down mod ct_page_size   = 0x%llx\n", 
+                    (unsigned long long)(eoa_down % file_ptr->fa.ciphertext_page_size));
+        }
+
+        assert( 0 == (eoa_down % file_ptr->fa.ciphertext_page_size) );
+
+        num_pages = (int64_t)(eoa_down / file_ptr->fa.ciphertext_page_size);
+
+        assert( 2 <= num_pages );
+
+        eoa_up = ((haddr_t)(num_pages - 2)) * (haddr_t)(file_ptr->fa.plaintext_page_size);
+
+        file_ptr->eoa_down = eoa_down;
+        file_ptr->eoa_up   = eoa_up;
+
+        ret_value = eoa_up;
+
+    } else { /* un-expected eoa_down -- fail */
+
+        HGOTO_ERROR(H5E_VFL, H5E_CANTSET, HADDR_UNDEF, "un-expected eoa for underlying file");
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_alloc() */
+#endif
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_get_type_map
+ *
+ * Purpose:     Retrieve the memory type mapping for this file
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_get_type_map(const H5FD_t *_file, H5FD_mem_t *type_map)
+{
+    const H5FD_crypt_t *file      = (const H5FD_crypt_t *)_file;
+    herr_t           ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    /* Check arguments */
+    assert(file);
+    assert(file->file);
+
+    /* Retrieve memory type mapping for the underlying file */
+    if (H5FD_get_fs_type_map(file->file, type_map) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL, 
+                            "unable to get type map for the underlying file");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_get_type_map() */
+
+#if 0 
+/* The current implementations of the alloc and free callbacks
+ * cause space allocation failures in the upper library.  This    
+ * has to be dealt with if we want the page buffer and encryption
+ * to run with VFDs that require it (split, multi).
+ * However, since targeting just the sec2 VFD is sufficient    
+ * for the Phase I prototype, we will bypass the issue
+ * for now.
+ *                                JRM -- 9/6/24
+ */
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_free
+ *
+ * Purpose:     Pass the free call down to the underlying VFD.
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_free(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, 
+                    hsize_t size)
+{
+    H5FD_crypt_t *file_ptr = (H5FD_crypt_t *)_file; /* VFD file struct */
+    herr_t     ret_value   = SUCCEED;            /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_CRYPT_LOG_CALL(__func__);
+
+    /* Check arguments */
+    assert(file_ptr);
+    assert(file_ptr->file);
+
+    if (H5FDfree(file_ptr->file, type, dxpl_id, addr, size) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTFREE, FAIL, 
+                            "unable to free space in the underlying file");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__crypt_free() */
+#endif
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_delete
+ *
+ * Purpose:     Delete a file
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_delete(const char *filename, hid_t fapl_id)
+{
+    const H5FD_crypt_vfd_config_t *fapl_ptr     = NULL;
+    H5FD_crypt_vfd_config_t       *default_fapl = NULL;
+    H5P_genplist_t             *plist;
+    herr_t                      ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    assert(filename);
+
+    /* Get the driver info */
+    if (H5P_FILE_ACCESS_DEFAULT == fapl_id) {
+
+        if (NULL == (default_fapl = H5FL_CALLOC(H5FD_crypt_vfd_config_t)))
+            HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, 
+                        "unable to allocate file access property list struct");
+
+        if (H5FD__crypt_populate_config(NULL, default_fapl) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, 
+                        "can't initialize driver configuration info");
+
+        fapl_ptr = default_fapl;
+    }
+    else {
+
+        if (NULL == (plist = (H5P_genplist_t *)H5I_object(fapl_id)))
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, 
+                        "not a file access property list");
+
+        if (NULL == (fapl_ptr = 
+                (const H5FD_crypt_vfd_config_t *)H5P_peek_driver_info(plist))){
+
+            if (NULL == (default_fapl = H5FL_CALLOC(H5FD_crypt_vfd_config_t)))
+                HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL,
+                        "unable to allocate file access property list struct");
+
+            if (H5FD__crypt_populate_config(NULL, default_fapl) < 0)
+                HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, 
+                        "can't initialize driver configuration info");
+
+            fapl_ptr = default_fapl;
+        }
+    }
+
+    if (H5FDdelete(filename, fapl_ptr->fapl_id) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTDELETEFILE, FAIL, 
+                            "unable to delete file");
+
+done:
+
+    if (default_fapl)
+        H5FL_FREE(H5FD_crypt_vfd_config_t, default_fapl);
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5FD__crypt_delete() */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_read_first_page
+ *
+ * Purpose:     Reads the first page of the file to get the cipher 
+ *              configuration details (plaintext size, ciphertext size, 
+ *              encryption buffer size, cipher, cipher block size, key size, 
+ *              iv size, mode of operation, minimum ciphertext page size). Then 
+ *              validates the configuration details by comparing them with 
+ *              the FAPL information. 
+ * 
+ *              If the validation fails, return FAIL. Otherwise return SUCCEED.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_read_first_page(H5FD_crypt_t *file_ptr)
+{
+    /* temp location for parsed data */
+    H5FD_crypt_vfd_config_t parsed_config;       
+    herr_t                  ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    assert(file_ptr->fa.ciphertext_page_size <= 
+                            file_ptr->fa.encryption_buffer_size);
+    assert(file_ptr->ciphertext_buf); /* verify the buffer was allocated */
+
+    /* Read the first page of the file */
+    if (H5FD_read(file_ptr->file, H5FD_MEM_DRAW, (haddr_t)0, 
+                    file_ptr->fa.ciphertext_page_size, 
+                    (void *)(file_ptr->ciphertext_buf)) < 0 )
+        HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, 
+                            "can't read first header page");
+
+    /* Parse to get the encryption algorithm and mode */
+    if (sscanf((char *)file_ptr->ciphertext_buf,
+            "plaintext_page_size: %zu\n"
+            "ciphertext_page_size: %zu\n"
+            "encryption_buffer_size: %zu\n"
+            "cipher: %d\n"
+            "cipher_block_size: %zu\n"
+            "key_size: %zu\n"
+            "iv_size: %zu\n"
+            "mode: %d\n",
+            &parsed_config.plaintext_page_size,
+            &parsed_config.ciphertext_page_size,
+            &parsed_config.encryption_buffer_size,
+            &parsed_config.cipher,
+            &parsed_config.cipher_block_size,
+            &parsed_config.key_size,
+            &parsed_config.iv_size,
+            &parsed_config.mode) != 8) {
+
+        HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, 
+                                "can't parse first header page");
+    }
+
+    /* Validate the parsed details */
+    if (parsed_config.plaintext_page_size       != file_ptr->fa.plaintext_page_size ||
+        parsed_config.ciphertext_page_size      != file_ptr->fa.ciphertext_page_size ||
+        parsed_config.encryption_buffer_size    != file_ptr->fa.encryption_buffer_size ||
+        parsed_config.cipher                    != file_ptr->fa.cipher ||
+        parsed_config.cipher_block_size         != file_ptr->fa.cipher_block_size ||
+        parsed_config.key_size                  != file_ptr->fa.key_size ||
+        parsed_config.iv_size                   != file_ptr->fa.iv_size ||
+        parsed_config.mode                      != file_ptr->fa.mode) {
+
+        HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, 
+                            "First header page / FAPL config mismatch");
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5FD__crypt_read_first_page() */
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_decrypt_test_phrase
+ *
+ * Purpose:     Reads the second page of the file and decrypts it to compare 
+ *              the expected test phrase with the decrypted phrase to validate 
+ *              the decryption process.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_decrypt_test_phrase(H5FD_crypt_t *file_ptr)
+{
+    unsigned char * decrypted_page = NULL; /* buffer for decrypted page */
+    const char *    expected_phrase = "Decryption works";  
+    herr_t          ret_value = SUCCEED;
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    if ( NULL == (decrypted_page = 
+        (unsigned char *)malloc((size_t)(file_ptr->fa.plaintext_page_size))) ) 
+
+        HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, 
+                            "can't allocate buffer for plaintext page");
+
+
+    /* Read the encrypted second page of the file into the ciphertext buffer */
+    if (H5FD_read(file_ptr->file, H5FD_MEM_DRAW, 
+                    (haddr_t)(file_ptr->fa.ciphertext_page_size),
+                    file_ptr->fa.ciphertext_page_size, 
+                    (void *)(file_ptr->ciphertext_buf)) < 0 )
+
+        HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, 
+                                "can't read second header page");
+
+
+    /* Decrypt and write the second page into decrypted_page buffer */
+    if ( H5FD__crypt_decrypt_page(file_ptr, file_ptr->ciphertext_buf, 
+                                    decrypted_page) != SUCCEED ) 
+
+        HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, 
+                                "can't decrypt second header page");
+
+    /* Compare the decrypted phrase with the expected phrase */
+    if ( memcmp(decrypted_page, expected_phrase, strlen(expected_phrase)) != 0)
+
+        HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, 
+                        "Unexpected test phrase in second header page.");
+
+done:
+
+    if ( decrypted_page ) {
+
+        free(decrypted_page);
+    }
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5FD__crypt_decrypt_test_phrase() */
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_decrypt_page
+ *
+ * Purpose:     Decrypts a page of data using the cipher configuration details 
+ *              read from the first page of the file. The function initializes 
+ *              a handle variable of type gcry_cipher_hd_t which is used to 
+ *              store the context for the cryptographic operations.
+ *
+ *              The key is loaded from the fapl and is set to the handle for 
+ *              encryption.
+ *
+ *              If used, an Initialization Vector (IV) is generated and stored 
+ *              in the first block of the ciphertext buffer, then set to the 
+ *              handle to be used in the  decryption.
+ *
+ *              The input data (the ciphertext page data starting after the IV 
+ *              block in the ciphertext_buf) is decrypted and stored in the 
+ *              output buffer (plaintext_buf).
+ *
+ *              NOTE: each cipher function is followed by a call to 
+ *              handle_gcrypt_error(err) which checks for errors and converts 
+ *              them to a string message.
+ *
+ * Cipher Integer List:
+ *              Cipher = 0 means AES256
+ *              Cipher = 1 means TWOFISH 
+ * 
+ * Mode Integer List:
+ *              Mode = 0 means CBC
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_decrypt_page(H5FD_crypt_t *file_ptr, unsigned char *ciphertext_buf,
+                            unsigned char *plaintext_buf)
+{   
+    char error_string[256];
+    int cipher;
+    int mode;
+    gcry_cipher_hd_t handle; 
+    gcry_error_t err;
+    herr_t   ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+    
+    /* Checking what cipher the file needs for decryption */
+    if (file_ptr->fa.cipher == 0) 
+        cipher = GCRY_CIPHER_AES256;
+
+    else if (file_ptr->fa.cipher == 1)
+        cipher = GCRY_CIPHER_TWOFISH;
+
+    else
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, FAIL, "Unknown cipher");
+
+    /* Checking what mode the file needs for decryption */
+    if (file_ptr->fa.mode == 0)
+        mode = GCRY_CIPHER_MODE_CBC;
+    
+    else
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, FAIL, "Unknown mode");
+
+
+    /* Initializes the handle with the cipher and mode (AES256, CBC) */
+    if ( 0 != (err = gcry_cipher_open(&handle, cipher, mode, 0)) ) {
+
+        snprintf(error_string, (size_t)256, "gcrypt error: %s", 
+                        gcry_strerror(err));
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, FAIL, "%s", error_string);
+    }
+
+    /* Sets the key to the handle for the decryption */
+    if ( 0 != (err = gcry_cipher_setkey(handle, test_vfd_config.key, 32)) )
+    {
+        snprintf(error_string, (size_t)256, "gcrypt error: %s", 
+                            gcry_strerror(err));
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, FAIL, "%s", error_string);
+    }
+
+    /*  Sets the IV to the handle for decryption using the IV read above */
+    if ( 0 != (err = gcry_cipher_setiv(handle, ciphertext_buf, 16)) ) {
+
+        snprintf(error_string, (size_t)256, "gcrypt error: %s", 
+                        gcry_strerror(err));
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, FAIL, "%s", error_string);
+    }
+
+    /* Decrypts the ciphertext page using the handle */
+    if ( 0 != (err = gcry_cipher_decrypt(
+            handle,                                /* cipher config */
+            plaintext_buf,                         /* plaintext */
+            file_ptr->fa.plaintext_page_size,      /* plaintext size */
+            ciphertext_buf + file_ptr->fa.iv_size, /* ciphertext */
+            file_ptr->fa.plaintext_page_size       /* ciphertext size */
+            )) ) {
+
+        snprintf(error_string, (size_t)256, "gcrypt error: %s", 
+                        gcry_strerror(err));
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, FAIL, "%s", error_string);
+    }
+
+    gcry_cipher_close(handle);
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5FD__crypt_decrypt_page() */
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_encrypt_page
+ *
+ * Purpose:     Encrypts a page of data using the cipher configurationdetails 
+ *              read from the first page of the file. The function initializes 
+ *              a handle variable of type gcry_cipher_hd_t which is used to 
+ *              store the context for the cryptographic operations.
+ *
+ *              The key is loaded from the fapl (test_vfd_config struct) and is
+ *              set to the handle for encryption.
+ *
+ *              If used an Initialization Vector (IV) is generated and stored 
+ *              in the first block of the ciphertext buffer, then set to the 
+ *              handle to be used in the encryption.
+ *
+ *              The input data (plaintext page in the plaintext_buf) is 
+ *              encrypted and stored in the output buffer (ciphertext_buf) 
+ *              after the IV block.
+ *
+ *              NOTE: each cipher function is followed by a call to 
+ *              handle_gcrypt_error(err) which checks for errors and converts 
+ *              them to a string message.
+ *
+ * Cipher Integer List:
+ *              Cipher = 0 means AES256
+ *              Cipher = 1 means TWOFISH 
+ * 
+ * Mode Integer List:
+ *              Mode = 0 means CBC
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_encrypt_page(H5FD_crypt_t *file_ptr, unsigned char *ciphertext_buf, 
+                         const unsigned char *plaintext_buf)
+{
+    char error_string[256];
+    int cipher;
+    int mode;
+    gcry_cipher_hd_t handle;
+    gcry_error_t     err;
+    herr_t   ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    /* Checking what cipher the file needs for decryption */
+    if (file_ptr->fa.cipher == 0) 
+        cipher = GCRY_CIPHER_AES256;
+
+    else if (file_ptr->fa.cipher == 1)
+        cipher = GCRY_CIPHER_TWOFISH;
+
+    else
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, FAIL, "Unknown cipher");
+
+    /* Checking what mode the file needs for decryption */
+    if (file_ptr->fa.mode == 0)
+        mode = GCRY_CIPHER_MODE_CBC;
+    
+    else
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, FAIL, "Unknown mode");
+
+
+
+    /* Initializes the handle with the cipher and mode (AES256, CBC) */
+    if ( 0 != (err = gcry_cipher_open(&handle, cipher, mode, 0)) ) {
+
+        snprintf(error_string, (size_t)256, "gcrypt error: %s", 
+                        gcry_strerror(err));
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, FAIL, "%s", error_string);
+    }
+
+    /* Sets the key to the handle for the encryption */
+    if ( 0 != (err = gcry_cipher_setkey(handle, test_vfd_config.key, 32)) ) 
+    {
+        snprintf(error_string, (size_t)256, "gcrypt error: %s", 
+                    gcry_strerror(err));
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, FAIL, "%s", error_string);
+    } 
+
+    /* Generates a random IV (nonce = number used once) for each page */
+    gcry_create_nonce(ciphertext_buf, 16);
+
+    /* Set the IV to the handle */
+    if ( 0 != (err = gcry_cipher_setiv(handle, ciphertext_buf, 16)) ) {
+
+        snprintf(error_string, (size_t)256, "gcrypt error: %s", 
+                    gcry_strerror(err));
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, FAIL, "%s", error_string);
+    }
+
+    /* Encrypts the plaintext page using the handle */
+    if ( 0 != (err = gcry_cipher_encrypt(
+            handle,                                /* cipher config */
+            ciphertext_buf + file_ptr->fa.iv_size, /* ciphertext */ 
+            file_ptr->fa.plaintext_page_size,      /* ciphertext size */
+            plaintext_buf,                         /* plaintext */
+            file_ptr->fa.plaintext_page_size       /* plaintext size */
+            )) ) {
+
+        snprintf(error_string, (size_t)256, "gcrypt error: %s", 
+                    gcry_strerror(err));
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, FAIL, "%s", error_string);
+    }
+
+    gcry_cipher_close(handle);
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5FD__crypt_encrypt_page() */
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_write_first_page
+ *
+ * Purpose:     Writes the cipher configuration details from the fapl to the 
+ *              first page of the file
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_write_first_page(H5FD_crypt_t *file_ptr)
+{
+    herr_t   ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    assert(file_ptr->fa.ciphertext_page_size <= 
+                file_ptr->fa.encryption_buffer_size);
+    assert(file_ptr->ciphertext_buf); /* verify the buffer was allocated */
+
+    /* initialize the first page of the cipher text buffer with NULLs */
+    memset((void *)(file_ptr->ciphertext_buf), '\0', 
+                    file_ptr->fa.ciphertext_page_size);
+
+
+    /* 512 bytes is larger than the data produced to write to the page 
+     * this double checks the ciphertext page is large enough 
+     */
+    assert(file_ptr->fa.ciphertext_page_size > 512);
+
+    /* Write configuration data to the ciphertext buffer.  We are using the 
+     * ciphertext buffer to assemble plaintext configuration data for write to 
+     * the first page of the file, which is an odd use of it.  However, it 
+     * exists and we know it is big enough, so why not. 
+     */
+    snprintf((char *)file_ptr->ciphertext_buf, 
+                    test_vfd_config.ciphertext_page_size,
+             "plaintext_page_size: %zu\n"
+             "ciphertext_page_size: %zu\n"
+             "encryption_buffer_size: %zu\n"
+             "cipher: %d\n"
+             "cipher_block_size: %zu\n"
+             "key_size: %zu\n"
+             "iv_size: %zu\n"
+             "mode: %d\n",
+             file_ptr->fa.plaintext_page_size,
+             file_ptr->fa.ciphertext_page_size,
+             file_ptr->fa.encryption_buffer_size,
+             file_ptr->fa.cipher,
+             file_ptr->fa.cipher_block_size,
+             file_ptr->fa.key_size,
+             file_ptr->fa.iv_size,
+             file_ptr->fa.mode);
+
+    /* Right now we are putting the header pages at offset 0.  Need to think 
+     * on how this will interact with user blocks.  No need to solve this now, 
+     * but must address it in phase 2, if we get it.
+     */
+    if (H5FD_write(file_ptr->file, H5FD_MEM_DRAW, (haddr_t)0, 
+                    file_ptr->fa.ciphertext_page_size, 
+                    (void *)(file_ptr->ciphertext_buf)) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_WRITEERROR, FAIL, 
+                        "Write of first header page failed.");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5FD__crypt_write_first_page */
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__crypt_write_second_page
+ *
+ * Purpose:     Encrypts the test phrase and writes it (and the associated IV,
+ *              if there is one, in the first block on the page) to the second 
+ *              page of the file.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-----------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_write_second_page(H5FD_crypt_t *file_ptr)
+{   
+    const char *test_phrase = "Decryption works";
+    unsigned char * test_phrase_buf = NULL;
+    herr_t   ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    assert(file_ptr->fa.ciphertext_page_size <= 
+                file_ptr->fa.encryption_buffer_size);
+    assert(file_ptr->ciphertext_buf); /* verify the buffer was allocated */
+    assert(file_ptr->fa.plaintext_page_size > strlen(test_phrase));
+
+    /* initialize the first page of the cipher text buffer with NULLs */
+    memset((void *)(file_ptr->ciphertext_buf), '\0', 
+                file_ptr->fa.ciphertext_page_size);
+
+    /* Allocate the test phrase buffer.  Don't do it on the stack since the 
+     * plaintext page size is unbounded, and may blow out the stack.
+     */
+    test_phrase_buf = (unsigned char *)calloc(file_ptr->fa.ciphertext_page_size, 
+                        sizeof(unsigned char));
+  
+    if ( NULL == test_phrase_buf )
+        HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, 
+                        "unable to allocate the test phrase buffer");
+    
+    /* Copy the test phrase to the buffer after the IV */
+    memcpy(test_phrase_buf, test_phrase, strlen(test_phrase) + 1);
+    
+    /* Encrypt the buffer */
+    if (H5FD__crypt_encrypt_page(file_ptr, file_ptr->ciphertext_buf, 
+                                    test_phrase_buf) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_WRITEERROR, FAIL, 
+                        "Can't encrypt the second header page.");
+
+    if (H5FDwrite(file_ptr->file, H5FD_MEM_DRAW, H5P_DEFAULT, 
+                    (haddr_t)(file_ptr->fa.ciphertext_page_size), 
+                    file_ptr->fa.ciphertext_page_size, 
+                    (void *)(file_ptr->ciphertext_buf)) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_WRITEERROR, FAIL, 
+                            "Write of second header page failed.");
+
+done:
+
+    if ( test_phrase_buf ) {
+
+        free(test_phrase_buf);
+        test_phrase_buf = NULL;
+    }
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5FD__crypt_write_second_page() */
+
+

--- a/hdf5/hdf5-1.14.6/src/H5FDcrypt.h
+++ b/hdf5/hdf5-1.14.6/src/H5FDcrypt.h
@@ -1,0 +1,200 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by Lifeboat, LLC                                                *
+ * All rights reserved.                                                      *
+ *                                                                           * 
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/*
+ * Purpose:	The public header file for the encryption file driver (VFD)
+ */
+
+#ifndef H5FDcrypt_H
+#define H5FDcrypt_H
+
+/** Initializer for the page buffer VFD */
+#define H5FD_CRYPT          (H5FDperform_init(H5FD_crypt_init))
+
+/** Identifier for the page buffer VFD */
+#define H5FD_CRYPT_VALUE H5_VFD_CRYPT
+
+/** Semi-unique constant used to help identify Encryption Config structure pointers */
+#define H5FD_CRYPT_CONFIG_MAGIC                         0x504200
+
+/** Semi-unique constant used to help identify Encryption structure pointers */
+#define H5FD_CRYPT_MAGIC                                0x504201 
+
+/** The version of the H5FD_crypt_vfd_config_t structure used */
+#define H5FD_CURR_CRYPT_VFD_CONFIG_VERSION 	            1
+
+/** The default clear text page size in bytes */
+#define H5FD_CRYPT_DEFAULT_PLAINTEXT_PAGE_SIZE		    4096
+
+/** The default cypher text page size in bytes */
+#define H5FD_CRYPT_DEFAULT_CIPHERTEXT_PAGE_SIZE	        4112
+
+/** The default offset for the ciphertext */
+#define H5FD_CRYPT_DEFAULT_CIPHERTEXT_OFFSET            8224
+
+/** The default encryption buffer size in bytes */
+#define H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE       65792
+
+/** The default encryption cipher */    /* 0 is code for GCRY_CIPHER_AES256 */
+#define H5FD_CRYPT_DEFAULT_CIPHER                     	0 
+
+/** The default block size used by the default encryption cipher */
+#define H5FD_CRYPT_DEFAULT_CIPHER_BLOCK_SIZE            16
+
+/** The default key size in bytes used by the default encryption cipher */
+#define H5FD_CRYPT_DEFAULT_KEY_SIZE                     32
+
+/** The maximum key size in bytes.  This value is used to set the size of the 
+    key buffer in H5FD_crypt_vfd_config_t. */
+#define H5FD_CRYPT_MAX_KEY_SIZE                         1024  
+
+#define H5FD_CRYPT_TEST_KEY             "^sÿâ,ªT]õaiÎ_}Õ¬#¾Ló;h#ÀýÁ!S²"
+
+/** The default initialization vector (IV) size in bytes */
+#define H5FD_CRYPT_DEFAULT_IV_SIZE                      16
+
+/** The default mode of operation */    /* 0 = GCRY_CIPHER_MODE_CBC */
+#define H5FD_CRYPT_DEFAULT_MODE                         0
+
+/** The default minimum ciphertext page size in bytes */
+#define H5FD_CRYPT_DEFAULT_MINIMUM_CIPHERTEXT_PAGE_SIZE 4096
+
+
+/******************************************************************************
+ * 
+ * Structure: H5FD_crypt_vfd_config_t
+ * 
+ * Description: 
+ * 
+ * Structure to hold configuration options for the page buffer VFD.
+ * 
+ * Fields: 
+ * 
+ * magic (int32_t):
+ *      Magic number to identify this struct. Must be H5FD_CRYPT_MAGIC.
+ * 
+ * version (unsigned int):
+ *      Version number of this struct. Currently must be 
+ *      H5FD_CURR_CRYPT_VFD_CONFIG_VERSION.
+ * 
+ * plaintext_page_size (size_t):
+ *      Size of the plaintext page size in bytes.
+ * 
+ * ciphertext_page_size (size_t):
+ *      Size of the ciphertext page size in bytes. Should be the size of 
+ *      the plaintext page size plus the size of the encryption overhead 
+ *      (this iteration the only thing adding to the size is the IV size).
+ * 
+ * encryption_buffer_size (size_t):
+ *      Size of the encryption buffer in bytes. Must be a multiple of the
+ *      ciphertext page size.
+ * 
+ * cipher (int):
+ *      Integer code specifying the desired cipher. 
+ *      int code: 0 = GCRY_CIPHER_AES256
+ *                1 = GCRY_CIPHER_TWOFISH
+ * 
+ * cipher_block_size (size_t):
+ *      Size of the cipher block in bytes.
+ * 
+ * key_size (size_t):
+ *      Size of the key in bytes.
+ * 
+ * unit8_t key[H5FD_CRYPT_MAX_KEY_SIZE]:
+ *      Buffer to hold the key. Next iteration the key will be in a secure
+ *      memory pool made by the libgcrypt library.
+ * 
+ * iv_size (size_t):
+ *      Size of the initialization vector in bytes. Normally same size as
+ *      block size.
+ * 
+ * mode (int):
+ *      Mode of operation for the encryption, which controls how multiple
+ *      cipher blocks are handled. This iteration the only mode of operation
+ *      is Cipher Block Chaining (CBC).
+ * 
+ * fapl_id (hid_t):
+ *      File-access property list for setting up the VFD stack      
+ * 
+ ******************************************************************************
+ */
+typedef struct H5FD_crypt_vfd_config_t {
+    int32_t      magic;            
+    unsigned int version;          
+    size_t plaintext_page_size;     
+    size_t ciphertext_page_size;    
+    size_t encryption_buffer_size;       
+    int cipher;                     
+
+    /* add fields for key, etc */
+    size_t cipher_block_size;        
+    size_t key_size;                
+
+    uint8_t key[H5FD_CRYPT_MAX_KEY_SIZE];
+
+    size_t iv_size;                 
+    int mode;          
+
+    hid_t fapl_id;                 
+} H5FD_crypt_vfd_config_t;
+//! <!-- [H5FD_crypt_vfd_config_t_snip] -->
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @private
+ *
+ * \brief Private initializer for the page buffer VFD
+ */
+H5_DLL hid_t H5FD_crypt_init(void);
+
+/**
+ * \ingroup FAPL
+ *
+ * \brief Sets the file access property list to use the page buffer driver
+ *
+ * \fapl_id
+ * \param[in] config_ptr Configuration options for the VFD
+ * \returns \herr_t
+ *
+ * \details H5Pset_fapl_crypt() sets the file access property list identifier,
+ *          \p fapl_id, to use the page buffer driver.
+ *
+ *          The page buffer VFD converts randon I/O requests to paged I/O
+ *          requests as required, and then relays the paged I/O requests to 
+ *	    the underlying VFD stack.
+ *
+ * \since 1.10.7, 1.12.1
+ */
+H5_DLL herr_t H5Pset_fapl_crypt(hid_t fapl_id, 
+                                    H5FD_crypt_vfd_config_t *config_ptr);
+
+/**
+ * \ingroup FAPL
+ *
+ * \brief Gets bage buffer VFD configuration properties from the the file access property list
+ *
+ * \fapl_id
+ * \param[out] config_ptr Configuration options for the VFD
+ * \returns \herr_t
+ *
+ * \details H5Pget_fapl_crypt() retrieves a copy of the H5FD_crypt_vfd_config_t from the 
+ *          indicated FAPL.
+ *
+ *          The page buffer VFD converts randon I/O requests to paged I/O
+ *          requests as required, and then relays the paged I/O requests to 
+ *	    the underlying VFD stack.
+ *
+ * \since 1.10.7, 1.12.1
+ */
+H5_DLL herr_t H5Pget_fapl_crypt(hid_t fapl_id, H5FD_crypt_vfd_config_t *config_ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/hdf5/hdf5-1.14.6/src/H5FDpb.c
+++ b/hdf5/hdf5-1.14.6/src/H5FDpb.c
@@ -1,0 +1,4054 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by Lifeboat, LLC                                                *
+ * All rights reserved.                                                      *
+ *                                                                           * 
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/*
+ * Purpose:     The page buffer VFD converts random I/O requests to page 
+ *		aligned I/O requests, which it then passes down to the 
+ *		underlying VFD.
+ */
+
+/* This source code file is part of the H5FD driver module */
+#include "H5FDdrvr_module.h"
+
+#include "H5private.h"    /* Generic Functions        */
+#include "H5Eprivate.h"   /* Error handling           */
+#include "H5Fprivate.h"   /* File access              */
+#include "H5FDprivate.h"  /* File drivers             */
+#include "H5FDpb.h"       /* Page Buffer file driver  */
+#include "H5FLprivate.h"  /* Free Lists               */
+#include "H5Iprivate.h"   /* IDs                      */
+#include "H5MMprivate.h"  /* Memory management        */
+#include "H5Pprivate.h"   /* Property lists           */
+#include "H5CLprivate.h" 
+
+/** Semi-unique constant used to help identify Page Header structure pointers */
+#define H5FD_PB_PAGEHEADER_MAGIC                0x504202
+
+/** Semi-unique constant used to help identify Hash Table structure pointers */
+#define H5FD_PB_HASH_TABLE_MAGIC                0x504203
+
+/** Semi-unique constant used to help identify Replacement Policy structure pointers */
+#define H5FD_PB_RP_MAGIC                        0x504204
+
+/** Maximum number of name value pairs that may appear in configuration language 
+  * configuration string for the page buffer */
+#define H5FD_PB__MAX_PARAMS                     6
+
+/** The version of the H5FD_pb_vfd_config_t structure used */
+#define H5FD_CURR_PB_VFD_CONFIG_VERSION         1
+
+/** The default page buffer page size in bytes */
+#define H5FD_PB_DEFAULT_PAGE_SIZE               4096
+
+/** The default maximum number of pages resident in the page buffer at any one time */
+#define H5FD_PB_DEFAULT_MAX_NUM_PAGES           64
+
+/** The default replacement policy to be used by the page buffer */
+#define H5FD_PB_DEFAULT_REPLACEMENT_POLICY      0 /* 0 = Least Recently Used */
+
+/** The default number of buckets in the hash table */
+#define H5FD_PB_DEFAULT_NUM_HASH_BUCKETS        16
+
+/******************************************************************************
+ *Bitfield for the PageHeader flags
+ *
+ * A bitfield used to indicate the status of the H5FD_pb_pageheader_t structure
+ * (defined in the next structure) and the page it contains. 
+ *
+ * DIRTY_FLAG
+ *      Indicates the page inside the H5FD_pb_pageheader_t structure has been
+ *      modified and is more current than the version of the page in the file.
+ *
+ * BUSY_FLAG
+ *      Indicates the H5FD_pb_pageheader_t structure is currently being used, 
+ *      either being read from or written to, or is about to be read from or 
+ *      written to.
+ *
+ * READ_FLAG
+ *      Indicates the H5FD_pb_pageheader_t structure is currently being read 
+ *      from.
+ *
+ * WRITE_FLAG 
+ *      Indicates the H5FD_pb_pageheader_t structure is currently being written 
+ *      to.
+ *
+ * INVALID_FLAG
+ *      Indicates the page inside the H5FD_pb_pageheader_t structure has been 
+ *      flagged as invalid. An invalid page means that a middle write has been
+ *      done on that page directly to the file making the version in the page
+ *      buffer out of date. 
+ *      If flagged as invalid the H5FD_pb_pageheader_t structure is removed 
+ *      from the hash table to not show up in searches and is adjusted in the
+ *      replacement policy list to be the next H5FD_pb_pageheader_t to be 
+ *      evicted.
+ ******************************************************************************
+ */
+#define H5FD_PB_DIRTY_FLAG      0X0001    /* 0b00000001 */
+#define H5FD_PB_BUSY_FLAG       0x0002    /* 0b00000010 */
+#define H5FD_PB_READ_FLAG       0x0004    /* 0b00000100 */
+#define H5FD_PB_WRITE_FLAG      0x0008    /* 0b00001000 */
+#define H5FD_PB_INVALID_FLAG    0x0010    /* 0b00010000 */
+
+
+/* The driver identification number, initialized at runtime */
+static hid_t H5FD_PB_g = 0;
+
+
+/******************************************************************************
+ *
+ * Structure:   H5FD_pb_pageheader_t
+ *
+ * Description:
+ *
+ * The H5FD_pb_pageheader_t structure is used to store a page from the file in
+ * the page buffer, and details about the page.
+ * 
+ * The hash table and replacement policy (these two structures are in the 
+ * H5FD_pb_t structure) use this structure as nodes to track the pages in the 
+ * page buffer and the order of pages to be evicted.
+ *
+ * Fields:
+ *
+ * magic (int32_t):
+ *      Magic number to identify this struct. Must be H5FD_PB_PAGE_HEADER_MAGIC
+ *
+ * hash_code (uint32_t):
+ *      Key used to determine which bucket in the hash table this instance of
+ *      H5FD_pb_pageheader_t is stored in. The method of calculating the hash
+ *      code is described in the H5FD__pb_calc_hash_code() function's header
+ *      comment.
+ *
+ * ht_next_ptr (H5FD_pb_pageheader_t *):
+ *      Pointer to the next H5FD_pb_pageheader_t structure in the hash table 
+ *      bucket, or NULL if this instance of the strucure is the tail.
+ *
+ * ht_prev_ptr (H5FD_pb_pageheader_t *):
+ *      Pointer to the previous H5FD_pb_pageheader_t structure in the hash 
+ *      table bucket, or NULL if this instance of the strucutre is the head.
+ *
+ * rp_next_ptr (H5FD_pb_pageheader_t *):
+ *      Pointer to the next H5FD_pb_pageheader_t structure in the replacement 
+ *      policy list, or NULL if this instance of the structure is the tail 
+ *      (i.e. this instance is the next one to be evicted).
+ *
+ * rp_prev_ptr (H5FD_pb_pageheader_t *):
+ *      Pointer to the previous H5FD_pb_pageheader_t structure in the 
+ *      replacement policy list, or NULL if this instance is the head 
+ *      (i.e. this instance is the most recently added to the list).
+ *
+ * flags (int32_t):
+ *      Integer field used to store various flags that indicate the state of
+ *      the page header. The flags are stored as bits in the integer field.
+ *      The flags are as follows:
+ *          - 0b00000001: dirty     (modified since last write)
+ *          - 0b00000010: busy      (currently being read/written)
+ *          - 0b00000100: read      (queued up to be read)
+ *          - 0b00001000: write     (queued up to be written)
+ *          - 0b00010000: invalid   (contains old data, page must be discarded)
+ *
+ * page_addr (haddr_t):
+ *      Integer value indicating the addr of the page (also can be thought of 
+ *      as the offset from the beginning of the file in bytes). This is the 
+ *      location of the page in the file, and is used to identify the page and
+ *      calculate the hash key.
+ *
+ * type (H5FD_mem_t):
+ *      Type of memory in the page.  This is the type associated with the 
+ *      I/O request that occasioned the load of the page into the page 
+ *      buffer.
+ *
+ * page (unsigned char):
+ *      buffer containing the actual data of the page. This is the data that
+ *      is read from the file and stored in the page buffer.
+ *
+ ******************************************************************************
+ */
+typedef struct H5FD_pb_pageheader_t {
+    int32_t             magic;
+    uint32_t            hash_code;
+    struct H5FD_pb_pageheader_t * ht_next_ptr;
+    struct H5FD_pb_pageheader_t * ht_prev_ptr;
+    struct H5FD_pb_pageheader_t * rp_next_ptr;
+    struct H5FD_pb_pageheader_t * rp_prev_ptr;
+    int32_t             flags;
+    haddr_t             page_addr;
+    H5FD_mem_t          type;
+    unsigned char       page[];
+} H5FD_pb_pageheader_t;
+
+
+/******************************************************************************
+ *
+ * Structure:   H5FD_pb_t
+ *
+ * Description:
+ *
+ * Root structure used to store all information required to manage the page
+ * buffer. An instance of this strucutre is created when the file is "opened"
+ * and is discarded when the file is "closed".
+ *
+ * Fields:
+ *
+ * pub:	An instance of H5FD_t which contains fields common to all VFDs.
+ *      It must be the first item in this structure, since at higher levels,
+ *      this structure will be treated as an instance of H5FD_t.
+ *
+ * magic (int32_t):
+ *      Magic number to identify this struct. Must be H5FD_PB_MAGIC.
+ *
+ * fa:  An instance of H5FD_pb_vfd_config_t containing all configuration data 
+ *      needed to setup and run the page buffer.  This data is contained in 
+ *      an instance of H5FD_pb_vfd_config_t for convenience in the get and 
+ *      set FAPL calls.
+ *
+ * config_str: If the page buffer vfd is configured via a configuratin 
+ *      language string, config_str is set to point to a copy of this 
+ *      string.  In all other cases, this field is set to NULL.
+ *
+ *      Note that this string is parsed, and its data is loaded into 
+ *      fa above on open.
+ *
+ * file: Pointer to the instance of H5FD_t used to manage the underlying 
+ *	VFD.  Note that this VFD may or may not be terminal (i.e. perform 
+ *	actual I/O on a file).
+ *
+ * Hash Table Description:
+ *      The hash table indexes the valid pages that currently reside in the 
+ *      page buffer for quick retrieval. The hash table uses a simple hash 
+ *      function (described in the H5FD__pb_calc_hash_code() function's header
+ *      comment) to determine which bucket in the hash table a 
+ *      H5FD_pb_pageheader_t instance should be stored in.
+ * 
+ *      The number of buckets must be a power of 2.
+ *
+ *      NOTE: The number of buckets in the hash table is currently fixed, but
+ *      will be made configurable in future versions.
+ *
+ * Hast Table Fields:
+ *      index:
+ *          An integer value to signify which bucket in the hash table we are
+ *          currently looking at.
+ * 
+ *      num_pages_in_bucket:
+ *          An integer value to track of the number of pages that are stored in
+ *          the bucket. This is a statistic used for debugging andperformance 
+ *          analysis.
+ *
+ *      ht_head_ptr:
+ *          Pointer to the head of the doubly linked list of page headers in
+ *          the bucket. 
+ * 
+ *      NOTE: the tail pointers for the hash table buckets are not needed, so 
+ *            they are not included in the structure.
+ * 
+ *
+ * Replacement Policy Description:
+ *      A doubly linked list data structure used to track all 
+ *      H5FD_pb_pageheader_t instances and determine eviction order based on
+ *      the replacement policy used.
+ * 
+ *      NOTE: Currenlty LRU (least recently used) and FIFO (first-in first-out) 
+ *            are the replacement policies implemented.
+ *
+ * Replacement Policy Fields:
+ *      rp_policy:
+ *          An integer value used to determine which replacement policy will be
+ *          used. 
+ *          0 = LRU 
+ *          1 = FIFO 
+ *
+ *      rp_head_ptr:
+ *          Pointer to the replacement policy list's head of 
+ *          H5FD_pb_pageheader_t structures. The head is the location in the 
+ *          list where the structures are added to.
+ *
+ *      rp_tail_ptr:
+ *          Pointer to the replacement policy list's tail of 
+ *          H5FD_pb_pageheader_t structures. The tail is the location in the 
+ *          lsit where the structures are selected to be evicted.
+ * 
+ * 
+ * EOA management:
+ *
+ * The page buffer VFD introduces an issue with respect to EOA management.
+ *
+ * Specifically, the page buffer converts random I/O to paged I/O.  As 
+ * a result, when it receives a set EOA directive, it must extend the 
+ * supplied EOA to the next page boundary lest the write of data in the
+ * final page in the file fail.
+ *
+ * Similarly, when the current EOA is requested, the page buffer must 
+ * return the most recent EOA set from above, not the EOA returned by 
+ * the underlying VFD.
+ *
+ * Righly or wrongly, we make no attempt to adjust the reported EOF.
+ * This may result in waste space in files.  If this becomes excessive, 
+ * we will have to re-visit this issue.
+ *
+ * eoa_up: The current EOA as seen by the VFD directly above the encryption
+ *      VFD in the VFD stack.  This value is set to zero at file open time,
+ *      and retains that value until the first set eoa call.
+ *
+ * eoa_down: The current EOA as seen by the VFD directly below the encryption
+ *      VFD in the VFD stack. This field is set to eoa_up extended to the 
+ *      next page boundary.  As with eoa_up, this alue is set to zero at 
+ *      file open time, and retains that value until the first set eoa call.
+ *
+ * 
+ * Page Buffer Statistics Fields:
+ *
+ * num_pages (size_t):
+ *      The total number of pages that were stored in the page buffer over the
+ *      session. This is a statistic used for debugging and performance analysis.
+ *
+ * largest_num_in_bucket (size_t):
+ *      The largest number of pages that were stored in a single bucket in the
+ *      hash table over the session. This is a statistic used for debugging
+ *      and performance analysis.
+ *
+ * num_hits (size_t):
+ *      The number of times a page was found in the hash table and did not
+ *      require a read from the file. This is a statistic used for debugging
+ *      and performance analysis.
+ *
+ * num_misses (size_t):
+ *      The number of times a page was not found in the hash table and required
+ *      a read from the file. This is a statistic used for debugging and
+ *      performance analysis.
+ *
+ * max_search_depth (size_t):
+ *      The maximum depth that was searched in the hash table and return a hit.
+ *      This is a statistic used for debugging and performance analysis.
+ *
+ * total_success_depth (size_t):
+ *      A commulative sum of the depths that were searched in the hash table
+ *      and returned a hit. This is a statistic used for debugging and
+ *      performance analysis.
+ *
+ * total_fail_depth (size_t):
+ *      A commulative sum of the depths that were searched in the hash table
+ *      and returned a miss. This is a statistic used for debugging and
+ *      performance analysis.
+ *
+ * total_evictions (size_t):
+ *      The total number of times a page was evicted from the page buffer. 
+ *      This is a statistic used for debugging and performance analysis.
+ *
+ * total_dirty (size_t):
+ *      The total number of pages that were marked as dirty. This is a
+ *      statistic used for debugging and performance analysis.
+ *
+ * total_invalidated (size_t):
+ *      The total number of pages that were marked as invalid. This is a
+ *      statistic used for debugging and performance analysis.
+ *
+ * total_flushed (size_t):
+ *      The total number of pages that were flushed to the file. This is a
+ *      statistic used for debugging and performance analysis.
+ ******************************************************************************
+ */
+
+typedef struct H5FD_pb_t {
+
+    H5FD_t               pub;
+
+    int32_t              magic;
+    H5FD_pb_vfd_config_t fa;
+    char                *config_str;
+    H5FD_t              *file;
+
+    /* hash table fields */
+    struct {
+        int32_t               index;
+        int32_t               num_pages_in_bucket;
+        H5FD_pb_pageheader_t *ht_head_ptr;
+    } ht_bucket[H5FD_PB_DEFAULT_NUM_HASH_BUCKETS];
+
+    /* replacement policy fields */
+    int32_t                   rp_policy;
+    H5FD_pb_pageheader_t     *rp_head_ptr;
+    H5FD_pb_pageheader_t     *rp_tail_ptr;
+    int64_t                   rp_pageheader_count;
+    int64_t                   rp_dirty_count;
+
+
+    /* eoa management fields */
+    haddr_t                  eoa_up;
+    haddr_t                  eoa_down;
+
+    /* page buffer statistics fields */
+    /* Side comments are where these get updated */
+    size_t                    num_pages;            /* get_pageheader */
+    size_t                    num_heads;            /* ht_insert_pageheader */
+    size_t                    num_tails;            /* ht_insert_pageheader */
+    size_t                    largest_num_in_bucket; /* ht_insert_pageheader */
+    size_t                    num_hits;             /* ht_search_pageheader */
+    size_t                    num_misses;           /* ht_search_pageheader */
+    size_t                    total_middle_reads;   /* pb_read_pageheader */
+    size_t                    total_middle_writes;  /* pb_write_pageheader */
+    size_t                    max_search_depth;     /* ht_search_pageheader */
+    size_t                    total_success_depth;  /* ht_search_pageheader */
+    size_t                    total_fail_depth;     /* ht_search_pageheader */
+    size_t                    total_evictions;      /* rp_evict_pageheader */
+    size_t                    total_dirty;          /* pb_write */
+    size_t                    total_invalidated;    /* pb_invalidate_pageheader */
+    size_t                    total_flushed;        /* rp_evict_pageheader */
+
+} H5FD_pb_t;
+
+/*
+ * These macros check for overflow of various quantities.  These macros
+ * assume that HDoff_t is signed and haddr_t and size_t are unsigned.
+ *
+ * ADDR_OVERFLOW:   Checks whether a file address of type `haddr_t'
+ *                  is too large to be represented by the second argument
+ *                  of the file seek function.
+ *
+ * SIZE_OVERFLOW:   Checks whether a buffer size of type `hsize_t' is too
+ *                  large to be represented by the `size_t' type.
+ *
+ * REGION_OVERFLOW: Checks whether an address and size pair describe data
+ *                  which can be addressed entirely by the second
+ *                  argument of the file seek function.
+ */
+#define MAXADDR          (((haddr_t)1 << (8 * sizeof(HDoff_t) - 1)) - 1)
+#define ADDR_OVERFLOW(A) (HADDR_UNDEF == (A) || ((A) & ~(haddr_t)MAXADDR))
+#define SIZE_OVERFLOW(Z) ((Z) & ~(hsize_t)MAXADDR)
+#define REGION_OVERFLOW(A, Z)                                                                                \
+    (ADDR_OVERFLOW(A) || SIZE_OVERFLOW(Z) || HADDR_UNDEF == (A) + (Z) || (HDoff_t)((A) + (Z)) < (HDoff_t)(A))
+
+
+#define H5FD_PB_DEBUG_OP_CALLS 0 /* debugging print toggle; 0 disables */
+
+#if H5FD_PB_DEBUG_OP_CALLS
+#define H5FD_PB_LOG_CALL(name)                                                                         \
+    do {                                                                                                     \
+        printf("called %s()\n", (name));                                                                     \
+        fflush(stdout);                                                                                      \
+    } while (0)
+#else
+#define H5FD_PB_LOG_CALL(name) /* no-op */       
+#endif                               /* H5FD_PB_DEBUG_OP_CALLS */
+    
+
+/* Private functions */
+
+/* Prototypes */
+static herr_t  H5FD__pb_term(void);
+static herr_t  H5FD__pb_populate_config(H5FD_pb_vfd_config_t *vfd_config,
+                                              H5FD_pb_vfd_config_t       *fapl_out);
+static hsize_t H5FD__pb_sb_size(H5FD_t *_file);
+static herr_t  H5FD__pb_sb_encode(H5FD_t *_file, char *name /*out*/, unsigned char *buf /*out*/);
+static herr_t  H5FD__pb_sb_decode(H5FD_t *_file, const char *name, const unsigned char *buf);
+static void   *H5FD__pb_fapl_get(H5FD_t *_file);
+static void   *H5FD__pb_fapl_copy(const void *_old_fa);
+static herr_t  H5FD__pb_fapl_free(void *_fapl);
+static H5FD_t *H5FD__pb_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr);
+static herr_t  H5FD__pb_close(H5FD_t *_file);
+static int     H5FD__pb_cmp(const H5FD_t *_f1, const H5FD_t *_f2);
+static herr_t  H5FD__pb_query(const H5FD_t *_file, unsigned long *flags /* out */);
+static herr_t  H5FD__pb_get_type_map(const H5FD_t *_file, H5FD_mem_t *type_map);
+#if 0
+/* The current implementations of the alloc and free callbacks
+ * cause space allocation failures in the upper library.  This 
+ * has to be dealt with if we want the page buffer and encryption
+ * to run with VFDs that require it (split, multi).
+ * However, since targeting just the sec2 VFD is sufficient 
+ * for the Phase I prototype, we will bypass the issue
+ * for now.
+ *                                JRM -- 9/6/24
+ */
+static haddr_t H5FD__pb_alloc(H5FD_t *file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_id, hsize_t size);
+static herr_t  H5FD__pb_free(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, hsize_t size);
+#endif
+static haddr_t H5FD__pb_get_eoa(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type);
+static herr_t  H5FD__pb_set_eoa(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, haddr_t addr);
+static haddr_t H5FD__pb_get_eof(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type);
+static herr_t  H5FD__pb_get_handle(H5FD_t *_file, hid_t H5_ATTR_UNUSED fapl, void **file_handle);
+static herr_t  H5FD__pb_read(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, size_t size,
+                                   void *buf);
+static herr_t  H5FD__pb_write(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, size_t size,
+                                    const void *buf);
+static herr_t  H5FD__pb_flush(H5FD_t *_file, hid_t dxpl_id, bool closing);
+static herr_t  H5FD__pb_truncate(H5FD_t *_file, hid_t dxpl_id, bool closing);
+static herr_t  H5FD__pb_lock(H5FD_t *_file, bool rw);
+static herr_t  H5FD__pb_unlock(H5FD_t *_file);
+static herr_t  H5FD__pb_delete(const char *filename, hid_t fapl_id);
+static herr_t  H5FD__pb_ctl(H5FD_t *_file, uint64_t op_code, uint64_t flags, const void *input,
+                                  void **output);
+
+static const H5FD_class_t H5FD_pb_g = {
+    H5FD_CLASS_VERSION,           /* struct version       */
+    H5FD_PB_VALUE,                /* value                */
+    "page buffer",                /* name                 */
+    MAXADDR,                      /* maxaddr              */
+    H5F_CLOSE_WEAK,               /* fc_degree            */
+    H5FD__pb_term,                /* terminate            */
+    H5FD__pb_sb_size,             /* sb_size              */
+    H5FD__pb_sb_encode,           /* sb_encode            */
+    H5FD__pb_sb_decode,           /* sb_decode            */
+    sizeof(H5FD_pb_vfd_config_t), /* fapl_size            */
+    H5FD__pb_fapl_get,            /* fapl_get             */
+    H5FD__pb_fapl_copy,           /* fapl_copy            */
+    H5FD__pb_fapl_free,           /* fapl_free            */
+    0,                            /* dxpl_size            */
+    NULL,                         /* dxpl_copy            */
+    NULL,                         /* dxpl_free            */
+    H5FD__pb_open,                /* open                 */
+    H5FD__pb_close,               /* close                */
+    H5FD__pb_cmp,                 /* cmp                  */
+    H5FD__pb_query,               /* query                */
+    H5FD__pb_get_type_map,        /* get_type_map         */
+#if 0
+    /* The current implementations of the alloc and free callbacks
+     * cause space allocation failures in the upper library.  This 
+     * has to be dealt with if we want the page buffer and encryption
+     * to run with VFDs that require it (split, multi).
+     * However, since targeting just the sec2 VFD is sufficient 
+     * for the Phase I prototype, we will bypass the issue
+     * for now.
+     *                                JRM -- 9/6/24
+     */
+    H5FD__pb_alloc,               /* alloc                */
+    H5FD__pb_free,                /* free                 */
+#else
+    NULL,                         /* alloc                */
+    NULL,                         /* free                 */
+#endif
+    H5FD__pb_get_eoa,             /* get_eoa              */
+    H5FD__pb_set_eoa,             /* set_eoa              */
+    H5FD__pb_get_eof,             /* get_eof              */
+    H5FD__pb_get_handle,          /* get_handle           */
+    H5FD__pb_read,                /* read                 */
+    H5FD__pb_write,               /* write                */
+    NULL,                         /* read_vector          */
+    NULL,                         /* write_vector         */
+    NULL,                         /* read_selection       */
+    NULL,                         /* write_selection      */
+    H5FD__pb_flush,               /* flush                */
+    H5FD__pb_truncate,            /* truncate             */
+    H5FD__pb_lock,                /* lock                 */
+    H5FD__pb_unlock,              /* unlock               */
+    H5FD__pb_delete,              /* del                  */
+    H5FD__pb_ctl,                 /* ctl                  */
+    H5FD_FLMAP_DICHOTOMY          /* fl_map               */
+};
+
+
+
+herr_t   H5FD__pb_load_config(H5FD_pb_t * file_ptr, hid_t pb_fapl_id);
+herr_t   H5FD__pb_parse_config(const char * config_str, H5FD_pb_vfd_config_t * config_ptr);
+herr_t   H5FD__pb_flush_page(H5FD_pb_t * file_ptr, hid_t dxpl_id, H5FD_pb_pageheader_t *pageheader);
+herr_t   H5FD__pb_invalidate_pageheader(H5FD_pb_t *file_ptr, H5FD_pb_pageheader_t *pageheader);
+H5FD_pb_pageheader_t * H5FD__pb_alloc_and_init_pageheader(H5FD_pb_t * file_ptr, haddr_t addr, 
+                                                          uint32_t hash_code);
+H5FD_pb_pageheader_t* H5FD__pb_get_pageheader(H5FD_pb_t *file_ptr, H5FD_mem_t type, hid_t dxpl_id, 
+                                              haddr_t addr, uint32_t hash_code);
+uint32_t H5FD__pb_calc_hash_code(H5FD_pb_t *file_ptr, haddr_t addr);
+
+/* Hash Table Functions */
+herr_t   H5FD__pb_ht_insert_pageheader(H5FD_pb_t *file_ptr, H5FD_pb_pageheader_t *pageheader);
+herr_t   H5FD__pb_ht_remove_pageheader(H5FD_pb_t *file_ptr, H5FD_pb_pageheader_t *pageheader);
+H5FD_pb_pageheader_t *H5FD__pb_ht_search_pageheader(H5FD_pb_t *file_ptr, haddr_t addr, uint32_t hash_code);
+
+/* Replacement Policy Functions */
+herr_t   H5FD__pb_rp_insert_pageheader(H5FD_pb_t *file_ptr, H5FD_pb_pageheader_t *pageheader);
+herr_t   H5FD__pb_rp_prepend_pageheader(H5FD_pb_t *file_ptr, H5FD_pb_pageheader_t *pageheader);
+herr_t   H5FD__pb_rp_append_pageheader(H5FD_pb_t *file_ptr, H5FD_pb_pageheader_t *pageheader);
+herr_t   H5FD__pb_rp_remove_pageheader(H5FD_pb_t *file_ptr, H5FD_pb_pageheader_t *pageheader);
+herr_t   H5FD__pb_rp_touch_pageheader(H5FD_pb_t *file_ptr, H5FD_pb_pageheader_t *pageheader);
+H5FD_pb_pageheader_t *H5FD__pb_rp_evict_pageheader(H5FD_pb_t *file_ptr, haddr_t addr, uint32_t hash_code);
+
+/* Testing Functions */
+haddr_t  *H5FD__pb_rp_eviction_check(H5FD_t *_file, haddr_t *current_rp_addrs);
+
+
+/* Declare a free list to manage the H5FD_pb_t struct */
+H5FL_DEFINE_STATIC(H5FD_pb_t);
+
+/* Declare a free list to manage the H5FD_pb_vfd_config_t struct */
+H5FL_DEFINE_STATIC(H5FD_pb_vfd_config_t);
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD_pb_init
+ *
+ * Purpose:     Initialize the page buffer driver by registering it with 
+ *		        the library.
+ *
+ * Return:      Success:    The driver ID for the page buffer driver.
+ *              Failure:    Negative
+ *-------------------------------------------------------------------------
+ */
+hid_t
+H5FD_pb_init(void)
+{
+    hid_t ret_value = H5I_INVALID_HID;
+
+    FUNC_ENTER_NOAPI_NOERR
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    if (H5I_VFL != H5I_get_type(H5FD_PB_g))
+        H5FD_PB_g = H5FDregister(&H5FD_pb_g);
+
+    ret_value = H5FD_PB_g;
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD_pb_init() */
+
+/*---------------------------------------------------------------------------
+ * Function:    H5FD__pb_term
+ *
+ * Purpose:     Shut down the page buffer VFD.
+ *
+ * Returns:     SUCCEED (Can't fail)
+ *---------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_term(void)
+{
+    FUNC_ENTER_PACKAGE_NOERR
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    /* Reset VFL ID */
+    H5FD_PB_g = 0;
+
+    FUNC_LEAVE_NOAPI(SUCCEED)
+
+} /* end H5FD__pb_term() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__copy_plist
+ *
+ * Purpose:     Sanity-wrapped H5P_copy_plist() for each channel.
+ *              Utility function for operation in multiple locations.
+ *
+ * Return:      0 on success, -1 on error.
+ *-------------------------------------------------------------------------
+ */
+static int
+H5FD__copy_plist(hid_t fapl_id, hid_t *id_out_ptr)
+{
+    int             ret_value = 0;
+    H5P_genplist_t *plist_ptr = NULL;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    assert(id_out_ptr != NULL);
+
+    if (false == H5P_isa_class(fapl_id, H5P_FILE_ACCESS))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, -1, "not a file access property list");
+
+    plist_ptr = (H5P_genplist_t *)H5I_object(fapl_id);
+
+    if (NULL == plist_ptr)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, -1, "unable to get property list");
+
+    *id_out_ptr = H5P_copy_plist(plist_ptr, false);
+
+    if (H5I_INVALID_HID == *id_out_ptr)
+        HGOTO_ERROR(H5E_VFL, H5E_BADTYPE, -1, "unable to copy file access property list");
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__copy_plist() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5Pset_fapl_pb
+ *
+ * Purpose:     Sets the file access property list to use the
+ *              page buffer driver.
+ *
+ * Return:      SUCCEED/FAIL
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5Pset_fapl_pb(hid_t fapl_id, H5FD_pb_vfd_config_t *vfd_config)
+{
+    H5FD_pb_vfd_config_t *info      = NULL;
+    H5P_genplist_t       *plist_ptr = NULL;
+    herr_t                ret_value = SUCCEED;
+
+    FUNC_ENTER_API(FAIL)
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    if (H5FD_PB_CONFIG_MAGIC != vfd_config->magic)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid configuration (magic number mismatch)");
+
+    if (H5FD_CURR_PB_VFD_CONFIG_VERSION != vfd_config->version)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid config (version number mismatch)");
+
+    if (NULL == (plist_ptr = (H5P_genplist_t *)H5I_object(fapl_id)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a valid property list");
+
+    info = H5FL_CALLOC(H5FD_pb_vfd_config_t);
+
+    if (NULL == info)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, "unable to allocate file access property list struct");
+
+    if (H5FD__pb_populate_config(vfd_config, info) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, "can't setup driver configuration");
+
+    ret_value = H5P_set_driver(plist_ptr, H5FD_PB, info, NULL);
+
+done:
+    if (info)
+        info = H5FL_FREE(H5FD_pb_vfd_config_t, info);
+
+    FUNC_LEAVE_API(ret_value)
+
+} /* end H5Pset_fapl_pb() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5Pget_fapl_pb
+ *
+ * Purpose:     Returns information about the page buffer file access 
+ *              property list through the instance of H5FD_pb_vfd_config_t
+ *              pointed to by config.
+ *
+ *              Will fail if *config is received without pre-set valid
+ *              magic and version information.
+ *
+ * Return:      SUCCEED/FAIL
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5Pget_fapl_pb(hid_t fapl_id, H5FD_pb_vfd_config_t *config /*out*/)
+{
+    const H5FD_pb_vfd_config_t *fapl_ptr     = NULL;
+    H5FD_pb_vfd_config_t       *default_fapl = NULL;
+    H5P_genplist_t             *plist_ptr    = NULL;
+    herr_t                      ret_value    = SUCCEED;
+
+    FUNC_ENTER_API(FAIL)
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    /* Check arguments */
+    if (true != H5P_isa_class(fapl_id, H5P_FILE_ACCESS))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access property list");
+
+    if (config == NULL)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "config pointer is null");
+
+    if (H5FD_PB_CONFIG_MAGIC != config->magic)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "info-out pointer invalid (magic number mismatch)");
+
+    if (H5FD_CURR_PB_VFD_CONFIG_VERSION != config->version)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "info-out pointer invalid (version unsafe)");
+
+    /* Pre-set out FAPL ID with intent to replace this value */
+    config->fapl_id = H5I_INVALID_HID;
+
+    /* Check and get the page buffer fapl */
+    if (NULL == (plist_ptr = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access property list");
+
+    if (H5FD_PB != H5P_peek_driver(plist_ptr))
+        HGOTO_ERROR(H5E_PLIST, H5E_BADVALUE, FAIL, "incorrect VFL driver");
+
+    fapl_ptr = (const H5FD_pb_vfd_config_t *)H5P_peek_driver_info(plist_ptr);
+
+    if (NULL == fapl_ptr) {
+
+        if (NULL == (default_fapl = H5FL_CALLOC(H5FD_pb_vfd_config_t)))
+            HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, "unable to allocate file access property list struct");
+
+        if (H5FD__pb_populate_config(NULL, default_fapl) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, "can't initialize driver configuration info");
+
+        fapl_ptr = default_fapl;
+    }
+
+    /* Copy scalar data */
+    config->page_size     = fapl_ptr->page_size;
+    config->max_num_pages = fapl_ptr->max_num_pages;
+    config->rp            = fapl_ptr->rp;
+
+    /* Copy FAPL */
+    if (H5FD__copy_plist(fapl_ptr->fapl_id, &(config->fapl_id)) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "can't copy underlying FAPL");
+
+done:
+    if (default_fapl)
+        H5FL_FREE(H5FD_pb_vfd_config_t, default_fapl);
+
+    FUNC_LEAVE_API(ret_value)
+
+} /* end H5Pget_fapl_pb() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_populate_config
+ *
+ * Purpose:    Populates a H5FD_pb_vfd_config_t structure with the provided
+ *             values, supplying defaults where values are not provided.
+ *
+ * Return:     Non-negative on success/Negative on failure
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_populate_config(H5FD_pb_vfd_config_t *vfd_config, H5FD_pb_vfd_config_t *fapl_out)
+{
+    H5P_genplist_t *def_plist;
+    H5P_genplist_t *plist;
+    bool            free_config = false;
+    herr_t          ret_value   = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    assert(fapl_out);
+
+    assert( ( NULL == vfd_config ) || ( H5FD_PB_CONFIG_MAGIC == vfd_config->magic ) );
+    assert( ( NULL == vfd_config ) || ( H5FD_CURR_PB_VFD_CONFIG_VERSION == vfd_config->version ) );
+
+    memset(fapl_out, 0, sizeof(H5FD_pb_vfd_config_t));
+
+    if ( NULL == vfd_config ) {
+
+        vfd_config = H5MM_calloc(sizeof(H5FD_pb_vfd_config_t));
+
+        if (NULL == vfd_config)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, "unable to allocate file access property list struct");
+
+        vfd_config->magic         = H5FD_PB_CONFIG_MAGIC;
+        vfd_config->version       = H5FD_CURR_PB_VFD_CONFIG_VERSION;
+        vfd_config->page_size     = H5FD_PB_DEFAULT_PAGE_SIZE;
+        vfd_config->max_num_pages = H5FD_PB_DEFAULT_MAX_NUM_PAGES;
+        vfd_config->rp            = H5FD_PB_DEFAULT_REPLACEMENT_POLICY;
+        vfd_config->fapl_id       = H5P_DEFAULT;
+
+        free_config = true;
+    }
+
+    fapl_out->magic         = vfd_config->magic;
+    fapl_out->version       = vfd_config->version;
+    fapl_out->page_size     = vfd_config->page_size;
+    fapl_out->max_num_pages = vfd_config->max_num_pages;
+    fapl_out->rp            = vfd_config->rp;
+    fapl_out->fapl_id       = H5P_FILE_ACCESS_DEFAULT; /* pre-set value */
+
+    if (NULL == (def_plist = (H5P_genplist_t *)H5I_object(H5P_FILE_ACCESS_DEFAULT)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access property list");
+
+    /* Set non-default underlying FAPL ID in page buffer configuration info */
+    if (H5P_DEFAULT != vfd_config->fapl_id) {
+
+        if (false == H5P_isa_class(vfd_config->fapl_id, H5P_FILE_ACCESS))
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access list");
+
+        fapl_out->fapl_id = vfd_config->fapl_id;
+
+    } else {
+
+        /* Use copy of default file access property list for underlying FAPL ID.
+         * The Sec2 driver is explicitly set on the FAPL ID, as the default
+         * driver might have been replaced with the page buffer VFD, which
+         * would cause recursion.
+         */
+        if ((fapl_out->fapl_id = H5P_copy_plist(def_plist, false)) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTCOPY, FAIL, "can't copy property list");
+
+        if (NULL == (plist = (H5P_genplist_t *)H5I_object(fapl_out->fapl_id)))
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access property list");
+
+        if (H5P_set_driver_by_value(plist, H5_VFD_SEC2, NULL, true) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, "can't set default driver on underlying FAPL");
+    }
+
+done:
+    if ( free_config && vfd_config ) {
+
+        H5MM_free(vfd_config);
+    }
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_populate_config() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_flush
+ *
+ * Purpose:     Flushes all data from the page buffer, and then flush
+ *		        the underlying VFD.
+ *
+ * Return:      SUCCEED/FAIL
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_flush(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, bool closing)
+{
+    int64_t                pages_visited = 0;
+    H5FD_pb_pageheader_t * pageheader = NULL;
+    H5FD_pb_t            * file_ptr = (H5FD_pb_t *)_file;
+    herr_t                 ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    /* flush the page buffer */
+
+    pageheader = file_ptr->rp_tail_ptr;
+
+    while ( pageheader ) {
+
+        /* if the page is valid and dirty, flush it */
+        if ( ( 0 == (pageheader->flags & H5FD_PB_INVALID_FLAG) ) &&
+             ( pageheader->flags & H5FD_PB_DIRTY_FLAG ) ) {
+
+            if ( H5FD__pb_flush_page(file_ptr, dxpl_id, pageheader) )
+                HGOTO_ERROR(H5E_VFL, H5E_CANTFLUSH, FAIL, "unable to flush page");
+        } 
+
+        pages_visited++;
+
+        pageheader = pageheader->rp_prev_ptr;
+
+    } /* end while */
+
+    /* Verifies that all pages in the page buffer have been searched */
+    assert(pages_visited == file_ptr->rp_pageheader_count);
+
+    /* Verifies that all dirty pages have been flushed */
+    assert(0 == file_ptr->rp_dirty_count);
+
+    /* Public API for dxpl "context" */
+    if (H5FDflush(file_ptr->file, dxpl_id, closing) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTFLUSH, FAIL, "unable to flush underlying file");
+
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_flush() */
+
+
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_read
+ *
+ * Purpose:     Reads SIZE bytes of data from the page buffer and/or the 
+ *		        underlying VFD beginning at address ADDR, into buffer 
+ *              BUF according to data transfer properties in DXPL_ID.
+ * 
+ *              Turns random I/O read requests into paged I/O read requests.
+ *
+ * Return:      Success:    SUCCEED
+ *                          The read result is written into the BUF buffer
+ *                          which should be allocated by the caller.
+ *
+ *              Failure:    FAIL
+ *                          The contents of BUF are undefined.
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UNUSED dxpl_id, haddr_t addr,
+                    size_t size, void *buf)
+{
+    bool       head_exists        = FALSE;         
+    bool       middle_exists      = FALSE;
+    bool       tail_exists        = FALSE;
+    uint64_t   num_pages          = 0;           /* number of pages in the read request */
+    uint64_t   page_num;                         /* page number of the head page */
+    haddr_t    head_page_addr     = HADDR_UNDEF; /* addr for beginning of the head page */
+    haddr_t    head_start_addr    = HADDR_UNDEF; /* addr for where the write starts in the head page */
+    size_t     head_size          = 0;
+    haddr_t    middle_start_addr  = HADDR_UNDEF;    
+    size_t     middle_size        = 0;
+    uint64_t   middle_page_count  = 0;
+    uint64_t   middle_read_count = 0;            /* for calculating addrs in multi-paged middles */
+    uint64_t   middle_check_count = 0;           /* counts and checks if pages exist in the ht */
+    haddr_t    tail_start_addr    = HADDR_UNDEF;
+    size_t     tail_size          = 0;
+    haddr_t    addr_of_remainder;                /* Used to calculate if head, middle, and tails exist */
+    size_t     size_of_remainder;                /* Used to calculate if head, middle, and tails exist */
+    haddr_t    expected_addr;
+    uint32_t   hash_code;
+    size_t     read_count         = 0;           /* total count of all writes */
+    haddr_t    current_addr;                     /* tracks addr for multi-paged middles */
+    size_t     accumulated_size;                 /* size of straight through read middles */
+    haddr_t    accumulated_addr;                 /* addr for straight through read middles */
+
+    H5FD_pb_pageheader_t *head = NULL;
+    H5FD_pb_pageheader_t *tail = NULL;
+    H5FD_pb_pageheader_t *middle = NULL;
+    H5FD_pb_t *           file_ptr  = (H5FD_pb_t *)_file;
+    herr_t                ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    assert( file_ptr );
+    assert( file_ptr->pub.cls );
+    assert( H5FD_PB_MAGIC == file_ptr->magic );
+    assert( buf );
+
+    /* Check for overflow conditions */
+    if (!H5_addr_defined(addr))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "addr undefined, addr = %llu", (unsigned long long)addr);
+
+    if (REGION_OVERFLOW(addr, size))
+        HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, addr = %llu", (unsigned long long)addr);
+
+
+    addr_of_remainder = addr;
+    size_of_remainder = size;
+
+
+
+    /***** Checks if a head exists *****/
+
+    if ( addr_of_remainder % file_ptr->fa.page_size != 0 ) {
+
+        head_exists = TRUE;
+        page_num = addr / file_ptr->fa.page_size;
+        head_page_addr = page_num * file_ptr->fa.page_size;
+        head_start_addr = head_page_addr + ( addr % file_ptr->fa.page_size );
+        head_size = file_ptr->fa.page_size - ( addr % file_ptr->fa.page_size );
+
+        /* If head is larger then remainder then entire read is in the head */
+        if ( head_size >= size_of_remainder ) {
+
+            head_size = size_of_remainder;
+            size_of_remainder = 0;
+        }
+        else {
+
+            size_of_remainder -= head_size;
+            addr_of_remainder += head_size;
+
+            assert( size_of_remainder > 0 );
+            assert( 0 == ( addr_of_remainder % file_ptr->fa.page_size ) );
+        }
+
+        num_pages++; 
+    }
+    
+    assert( ( size_of_remainder == 0 ) || ( 0 == ( addr_of_remainder % file_ptr->fa.page_size )) );
+
+
+
+    /***** Checks if a middle exits *****/
+
+    if ( ( size_of_remainder > 0 ) && ( ( size_of_remainder / file_ptr->fa.page_size ) > 0 )) {
+
+        middle_exists = TRUE;
+        middle_start_addr = addr_of_remainder;
+        middle_page_count = size_of_remainder / file_ptr->fa.page_size;
+        middle_size = middle_page_count * file_ptr->fa.page_size;
+
+        assert( middle_size <= size_of_remainder );
+
+        size_of_remainder -= middle_size;
+        addr_of_remainder += middle_size;
+
+        assert( size_of_remainder < file_ptr->fa.page_size );
+        assert( 0 == ( addr_of_remainder % file_ptr->fa.page_size ) );
+
+        num_pages += middle_page_count;
+    }
+
+
+
+    /***** Checks if a tail exists *****/
+
+    if ( size_of_remainder > 0 ) {
+
+        assert( 0 == addr_of_remainder % file_ptr->fa.page_size );
+
+        tail_exists = TRUE;
+        tail_start_addr = addr_of_remainder;
+        tail_size = size_of_remainder;
+
+        num_pages++; 
+    }
+
+
+
+    /***** Check the head, middle, and tail sizes and starting addrs *****/
+
+    assert( head_size + middle_size + tail_size == size );
+
+    expected_addr = addr;
+
+    if ( head_exists ) {
+
+        assert( addr == head_start_addr );
+
+        if ( middle_exists || tail_exists ) {
+            
+            assert ( 0 == (( head_start_addr + head_size ) % file_ptr->fa.page_size ) );
+        }
+        else {
+
+            assert( (( head_start_addr + head_size ) - addr ) <= file_ptr->fa.page_size );
+        }
+
+        expected_addr += head_size;        
+    } 
+
+    if ( middle_exists ) {
+
+        assert( middle_start_addr == expected_addr ); 
+
+        expected_addr += middle_size;
+    }
+    
+    if ( tail_exists ) {
+
+        assert( tail_start_addr == expected_addr );
+    } 
+
+
+
+    /***** Performs read operation *****/
+
+
+    /***** Head operations *****/
+
+    if ( head_exists ) {
+
+        hash_code = H5FD__pb_calc_hash_code( file_ptr, head_page_addr );
+
+        head = H5FD__pb_ht_search_pageheader( file_ptr, head_page_addr, hash_code );
+
+        if ( head == NULL ) {
+
+            if ( NULL == ( head = H5FD__pb_get_pageheader( file_ptr, type, dxpl_id, head_page_addr, hash_code )) )
+                HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, "Head page could not be loaded");
+
+            /* Make sure the H5FD_pb_pageheader_t structure is not busy or invalid */
+            assert( 0 == ( head->flags & H5FD_PB_BUSY_FLAG ) );
+            assert( 0 == ( head->flags & H5FD_PB_INVALID_FLAG ) );
+
+            /* Sets the busy and read flag immediately */
+            head->flags |= ( H5FD_PB_BUSY_FLAG | H5FD_PB_READ_FLAG );
+            file_ptr->num_heads++;
+        }
+        else {
+
+            /* Make sure the H5FD_pb_pageheader_t structure is not busy or invalid */
+            assert( head );
+            assert( head->magic == H5FD_PB_PAGEHEADER_MAGIC );
+            assert( 0 == ( head->flags & H5FD_PB_BUSY_FLAG ) );
+            assert( 0 == ( head->flags & H5FD_PB_INVALID_FLAG ) );
+
+            /* Sets the busy and read flag immediately */
+            head->flags |= ( H5FD_PB_BUSY_FLAG | H5FD_PB_READ_FLAG );
+
+            if ( file_ptr->fa.rp == 0 ) {
+                H5FD__pb_rp_touch_pageheader( file_ptr, head );
+            }
+        }
+
+        assert( head );
+        assert( head->magic == H5FD_PB_PAGEHEADER_MAGIC );
+
+        assert( head->flags & H5FD_PB_BUSY_FLAG );
+        assert( head->flags & H5FD_PB_READ_FLAG );
+        assert( 0 == ( head->flags & H5FD_PB_WRITE_FLAG ) );
+        assert( 0 == ( head->flags & H5FD_PB_INVALID_FLAG ) );
+
+        H5MM_memcpy( buf, head->page + ( head_start_addr - head_page_addr ), head_size );
+
+        /* Resets flags now that the pageheader is done being read */
+        head->flags &= ~( H5FD_PB_BUSY_FLAG | H5FD_PB_READ_FLAG );
+
+        read_count++;
+    }
+
+
+    /***** Middle operations *****/
+
+    if ( middle_exists ) {
+
+        current_addr = middle_start_addr;
+        accumulated_size = 0;
+        accumulated_addr = HADDR_UNDEF;
+
+        /* Iterates through all pages in the middle */
+        for ( middle_check_count = 0; middle_check_count < middle_page_count; middle_check_count++ ) {
+
+            hash_code = H5FD__pb_calc_hash_code( file_ptr, current_addr );
+
+            middle = H5FD__pb_ht_search_pageheader( file_ptr, current_addr, hash_code );
+
+            /* If a middle page doesn't exist in ht then it gets added to accumulator*/
+            if ( middle == NULL ) {
+
+                if ( accumulated_size == 0 )
+                    accumulated_addr = current_addr;
+
+                accumulated_size += file_ptr->fa.page_size;
+
+            }
+
+            /**
+             * If a middle page does exist in the ht:
+             * 
+             * 1. Read any accumulated pages from the file or lower VFD to the buffer.
+             * 2. Touch the pageheader to update the replacement policy.
+             * 3. Read (copy) the page from the H5FD_pb_pageheader_t into the buffer.
+             */
+            else {
+
+                if ( accumulated_size > 0 ) {
+
+                    if ( H5FDread( file_ptr->file, type, dxpl_id, accumulated_addr, accumulated_size, 
+                                   (void *)(((char *)buf ) + head_size + 
+                                   ( middle_read_count * file_ptr->fa.page_size ))) < 0 ) {
+                        HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, \
+                                    "Middle page could not be read from file or lower VFD");
+                    }
+
+                    middle_read_count += accumulated_size / file_ptr->fa.page_size;
+                    accumulated_size = 0;
+                }
+
+                assert( middle );
+                assert( middle->magic == H5FD_PB_PAGEHEADER_MAGIC );
+
+                /* Make sure H5FD_pb_pageheader_t is not busy or invalid */
+                assert( 0 == ( middle->flags & H5FD_PB_BUSY_FLAG ) );
+                assert( 0 == ( middle->flags & H5FD_PB_INVALID_FLAG ) );
+
+                /* Sets the busy and read flags */
+                middle->flags |= ( H5FD_PB_BUSY_FLAG | H5FD_PB_READ_FLAG );
+
+                assert( middle->flags & H5FD_PB_BUSY_FLAG );
+                assert( middle->flags & H5FD_PB_READ_FLAG );
+                assert( 0 == ( middle->flags & H5FD_PB_INVALID_FLAG ) );
+
+                if ( file_ptr->fa.rp == 0 ) {
+                   H5FD__pb_rp_touch_pageheader( file_ptr, middle );
+                }
+
+                H5MM_memcpy( (void *)(((char *)buf ) + head_size + (middle_check_count * file_ptr->fa.page_size)),
+                             middle->page, file_ptr->fa.page_size );
+
+                middle_read_count++;
+
+                middle->flags &= ~( H5FD_PB_BUSY_FLAG | H5FD_PB_READ_FLAG );
+
+            }            
+
+            current_addr += file_ptr->fa.page_size;
+        }
+
+        /* If any accumulated pages haven't been read when the loop ends read them now. */
+        if ( accumulated_size > 0) {
+                
+                if ( H5FDread( file_ptr->file, type, dxpl_id, accumulated_addr, accumulated_size, 
+                            (void *)(((char *)buf) + head_size + ( middle_read_count * file_ptr->fa.page_size ))) < 0 )
+                    HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, \
+                                "Middle page could not be read from file or lower VFD");
+        }
+
+        file_ptr->total_middle_reads += middle_page_count;
+        read_count += middle_page_count;
+    }
+
+
+    /***** Tail operations *****/
+
+    if ( tail_exists ) {
+
+        hash_code = H5FD__pb_calc_hash_code( file_ptr, tail_start_addr );
+
+        tail = H5FD__pb_ht_search_pageheader( file_ptr, tail_start_addr, hash_code );
+
+        if ( tail == NULL ) {
+
+            if ( NULL == ( tail = H5FD__pb_get_pageheader( file_ptr, type, dxpl_id, tail_start_addr, hash_code )) )
+                HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, "Tail page could not be loaded");
+
+            /* Make sure H5FD_pb_pageheader_t is not busy or invalid */
+            assert( 0 == ( tail->flags & H5FD_PB_BUSY_FLAG ) );
+            assert( 0 == ( tail->flags & H5FD_PB_INVALID_FLAG ) );
+
+            /* Sets the busy and read flags */
+            tail->flags |= ( H5FD_PB_BUSY_FLAG | H5FD_PB_READ_FLAG );
+            file_ptr->num_tails++;
+        }
+        else {
+            /* Make sure H5FD_pb_pageheader_t is not busy or invalid */
+            assert( tail );
+            assert( tail->magic == H5FD_PB_PAGEHEADER_MAGIC );
+            assert( 0 == ( tail->flags & H5FD_PB_BUSY_FLAG ) );
+            assert( 0 == ( tail->flags & H5FD_PB_INVALID_FLAG ) );
+
+            /* Sets the pagehader as busy and read */
+            tail->flags |= ( H5FD_PB_BUSY_FLAG | H5FD_PB_READ_FLAG );
+
+            if ( file_ptr->fa.rp == 0 ) {
+                H5FD__pb_rp_touch_pageheader( file_ptr, tail );
+            }
+        }
+
+        assert( tail );
+        assert( tail->magic == H5FD_PB_PAGEHEADER_MAGIC );
+
+        assert( tail->flags & H5FD_PB_BUSY_FLAG );
+        assert( tail->flags & H5FD_PB_READ_FLAG );
+        assert( 0 == ( tail->flags & H5FD_PB_INVALID_FLAG ) );
+
+        H5MM_memcpy( (void *)(((char *)buf ) + head_size + ( middle_page_count * file_ptr->fa.page_size )), 
+                     tail->page, tail_size );
+
+        tail->flags &= ~( H5FD_PB_BUSY_FLAG | H5FD_PB_READ_FLAG );
+
+        read_count++;
+    }
+
+    assert( read_count == num_pages );
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_read() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_write
+ *
+ * Purpose:     Writes SIZE bytes of data to the page buffer and / or the 
+ *              underlying VFD beginning at address ADDR, from buffer BUF 
+ *		        according to data transfer properties in DXPL_ID.
+ *
+ *              Turns random I/O write requests into paged I/O write 
+ *              requests.
+ * 
+ * Return:      SUCCEED/FAIL
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_write(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, size_t size,
+                     const void *buf)
+{
+    bool       head_exists        = FALSE;         
+    bool       middle_exists      = FALSE;
+    bool       tail_exists        = FALSE;
+    uint64_t   num_pages          = 0;           /* number of pages in the request */
+    uint64_t   page_num;                         /* page number of the head page */
+    haddr_t    head_page_addr     = HADDR_UNDEF; /* addr for the beginning of the head page */
+    haddr_t    head_start_addr    = HADDR_UNDEF; /* addr for where the write starts in the head page */
+    size_t     head_size          = 0;
+    haddr_t    middle_start_addr  = HADDR_UNDEF;    
+    size_t     middle_size        = 0;
+    uint64_t   middle_page_count  = 0;           
+    uint64_t   middle_check_count = 0;           /* counts and checks if pages exist in the ht */
+    haddr_t    tail_start_addr    = HADDR_UNDEF;
+    size_t     tail_size          = 0;
+    haddr_t    addr_of_remainder;                /* Used to calculate if head, middle, and tails exist */
+    size_t     size_of_remainder;                /* Used to calculate if head, middle, and tails exist */
+    haddr_t    expected_addr;
+    uint32_t   hash_code;
+    size_t     write_count        = 0;           /* total count of all writes */
+    haddr_t    current_addr;                     /* used to track addr for multi-paged middles */
+
+    H5FD_pb_pageheader_t *head = NULL;
+    H5FD_pb_pageheader_t *tail = NULL;
+    H5FD_pb_pageheader_t *middle = NULL;
+    H5FD_pb_t *           file_ptr  = (H5FD_pb_t *)_file;
+    herr_t                ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    assert( file_ptr );
+    assert( file_ptr->pub.cls );
+    assert( H5FD_PB_MAGIC == file_ptr->magic );
+    assert( buf );
+
+    /* Check for overflow conditions */
+    if (!H5_addr_defined(addr))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "addr undefined, addr = %llu", (unsigned long long)addr);
+
+    if (REGION_OVERFLOW(addr, size))
+        HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, addr = %llu", (unsigned long long)addr);
+
+
+    addr_of_remainder = addr;
+    size_of_remainder = size;
+
+
+
+    /***** Checks if a head exists *****/
+
+    if ( addr_of_remainder % file_ptr->fa.page_size != 0 ) {
+
+        head_exists = TRUE;
+        page_num = addr / file_ptr->fa.page_size;
+        head_page_addr = page_num * file_ptr->fa.page_size;
+        head_start_addr = head_page_addr + ( addr % file_ptr->fa.page_size );
+        head_size = file_ptr->fa.page_size - ( addr % file_ptr->fa.page_size );
+
+        /* If head is smaller then remainder then entire write is in the head */
+        if ( head_size >= size_of_remainder ) {
+
+            head_size = size_of_remainder;
+            size_of_remainder = 0;
+
+        }
+        else {
+
+            size_of_remainder -= head_size;
+            addr_of_remainder += head_size;
+
+            assert( size_of_remainder > 0 );
+            assert( 0 == ( addr_of_remainder % file_ptr->fa.page_size ) );
+        }
+
+        num_pages++; 
+    }
+
+    assert( ( size_of_remainder == 0 ) || ( 0 == ( addr_of_remainder % file_ptr->fa.page_size )) );
+
+
+
+    /***** Checks if a middle exits *****/
+
+    if ( ( size_of_remainder > 0 ) && ( ( size_of_remainder / file_ptr->fa.page_size ) > 0 )) {
+
+        middle_exists = TRUE;
+        middle_start_addr = addr_of_remainder;
+        middle_page_count = size_of_remainder / file_ptr->fa.page_size;
+        middle_size = middle_page_count * file_ptr->fa.page_size;
+
+        assert( middle_size <= size_of_remainder );
+
+        size_of_remainder -= middle_size;
+        addr_of_remainder += middle_size;
+
+        assert( size_of_remainder < file_ptr->fa.page_size );
+        assert( 0 == ( addr_of_remainder % file_ptr->fa.page_size ) );
+
+        num_pages += middle_page_count;
+    }
+
+
+
+    /***** Checks if a tail exists *****/
+
+    if ( size_of_remainder > 0 ) {
+
+        assert( 0 == addr_of_remainder % file_ptr->fa.page_size );
+
+        tail_exists = TRUE;
+        tail_start_addr = addr_of_remainder;
+        tail_size = size_of_remainder;
+
+        num_pages++; 
+    }
+
+
+
+    /***** Check the head, middle, and tail sizes and starting addrs *****/
+
+    assert( head_size + middle_size + tail_size == size );
+
+    expected_addr = addr;
+
+    if ( head_exists ) {
+
+        assert( addr == head_start_addr );
+
+        if ( middle_exists || tail_exists ) {
+            
+            assert ( 0 == (( head_start_addr + head_size ) % file_ptr->fa.page_size) );
+        }
+        else {
+
+            assert( (( head_start_addr + head_size) - addr ) <= file_ptr->fa.page_size );
+        }
+
+        expected_addr += head_size;        
+    } 
+
+    if ( middle_exists ) {
+
+        assert( middle_start_addr == expected_addr ); 
+
+        expected_addr += middle_size;
+    }
+    
+    if ( tail_exists ) {
+
+        assert( tail_start_addr == expected_addr );
+    } 
+
+
+
+    /***** Performs write operation *****/
+
+    /***** Head operations *****/
+
+    if ( head_exists ) {
+
+        hash_code = H5FD__pb_calc_hash_code( file_ptr, head_page_addr );
+
+        head = H5FD__pb_ht_search_pageheader( file_ptr, head_page_addr, hash_code );
+
+        if ( head == NULL ) {
+
+            if ( NULL == ( head = H5FD__pb_get_pageheader( file_ptr, type, dxpl_id, head_page_addr, hash_code )) )
+                HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, "Head page could not be loaded");
+
+            /* Make sure the H5FD_pb_pageheader_t structure is not busy or invalid */
+            assert( 0 == ( head->flags & H5FD_PB_BUSY_FLAG ) );
+            assert( 0 == ( head->flags & H5FD_PB_INVALID_FLAG ) );
+
+            /* Sets the busy and write flag immediately */
+            head->flags |= ( H5FD_PB_BUSY_FLAG | H5FD_PB_WRITE_FLAG );
+
+            file_ptr->num_heads++;
+        }
+        else {
+
+            /* Make sure the H5FD_pb_pageheader_t structure is not busy or invalid */
+            assert( head );
+            assert( head->magic == H5FD_PB_PAGEHEADER_MAGIC );
+            assert( 0 == ( head->flags & H5FD_PB_BUSY_FLAG ) );
+            assert( 0 == ( head->flags & H5FD_PB_INVALID_FLAG ) );
+
+            /* Sets the busy and write flag immediately */
+            head->flags |= ( H5FD_PB_BUSY_FLAG | H5FD_PB_WRITE_FLAG );
+
+            if ( file_ptr->fa.rp == 0 ) {
+                H5FD__pb_rp_touch_pageheader( file_ptr, head );
+            }
+        }
+
+        assert( head );
+        assert( H5FD_PB_PAGEHEADER_MAGIC == head->magic );
+
+        head->flags |= ( H5FD_PB_BUSY_FLAG | H5FD_PB_WRITE_FLAG );
+
+        assert( head->flags & H5FD_PB_BUSY_FLAG );
+        assert( head->flags & H5FD_PB_WRITE_FLAG );
+        assert( 0 == ( head->flags & H5FD_PB_INVALID_FLAG ) );
+
+        H5MM_memcpy( head->page + ( head_start_addr - head_page_addr ), buf, head_size );
+
+        if ( 0 == (head->flags & H5FD_PB_DIRTY_FLAG )) {
+
+            head->flags |= H5FD_PB_DIRTY_FLAG;
+            file_ptr->rp_dirty_count++;
+        }
+
+        file_ptr->total_dirty++;
+
+        head->flags &= ~( H5FD_PB_BUSY_FLAG | H5FD_PB_WRITE_FLAG );
+
+        write_count++;
+    }
+
+
+    /***** Middle operations *****/
+
+    if ( middle_exists ) {
+
+        current_addr = middle_start_addr;
+
+        /* Iterates through all pages in the middle */
+        for ( middle_check_count = 0; middle_check_count < middle_page_count; middle_check_count++ ) {
+
+            hash_code = H5FD__pb_calc_hash_code( file_ptr, current_addr );
+
+            middle = H5FD__pb_ht_search_pageheader( file_ptr, current_addr, hash_code );
+
+            /* If a middle page exists in the ht invalidate it */
+            if ( middle != NULL ) {
+
+                assert( middle );
+                assert( H5FD_PB_PAGEHEADER_MAGIC == middle->magic );
+
+                H5FD__pb_invalidate_pageheader( file_ptr, middle );
+
+                assert( middle->flags & H5FD_PB_INVALID_FLAG );
+            }
+
+            current_addr += file_ptr->fa.page_size;
+
+        }
+
+        /* Writes all middle pages */
+        if ( H5FDwrite( file_ptr->file, type, dxpl_id, middle_start_addr, middle_size,
+                        (const void *)(((const char *)buf ) + head_size )) < 0 ) {
+            HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, \
+                        "Middle page could not be written from file or lower VFD");
+        }
+
+        file_ptr->total_middle_writes += middle_page_count;
+
+        write_count += middle_page_count;
+
+    }
+
+
+    /***** Tail operations *****/
+
+    if ( tail_exists ) {
+
+        hash_code = H5FD__pb_calc_hash_code( file_ptr, tail_start_addr );
+
+        tail = H5FD__pb_ht_search_pageheader( file_ptr, tail_start_addr, hash_code );
+
+        if ( tail == NULL ) {
+            
+            if ( NULL == ( tail = H5FD__pb_get_pageheader( file_ptr, type, dxpl_id, tail_start_addr, hash_code )) )
+                HGOTO_ERROR(H5E_VFL, H5E_READERROR, FAIL, "Tail page could not be loaded");
+
+            /* Make sure H5FD_pb_pageheader_t is not busy or invalid */
+            assert( 0 == ( tail->flags & H5FD_PB_BUSY_FLAG ) );
+            assert( 0 == ( tail->flags & H5FD_PB_INVALID_FLAG ) );
+
+            /* Sets the busy and write flags */
+            tail->flags |= ( H5FD_PB_BUSY_FLAG | H5FD_PB_WRITE_FLAG );
+
+            file_ptr->num_tails++;
+        }
+        else {
+
+            /* Make sure H5FD_pb_pageheader_t is not busy or invalid */
+            assert( tail );
+            assert( tail->magic == H5FD_PB_PAGEHEADER_MAGIC );
+            assert( 0 == ( tail->flags & H5FD_PB_BUSY_FLAG ) );
+            assert( 0 == ( tail->flags & H5FD_PB_INVALID_FLAG ) );
+
+            /* Sets the busy and write flags */
+            tail->flags |= ( H5FD_PB_BUSY_FLAG | H5FD_PB_WRITE_FLAG );
+
+            if ( file_ptr->fa.rp == 0 ) {
+                H5FD__pb_rp_touch_pageheader( file_ptr, tail );
+            }
+        }
+
+        assert( tail );
+        assert( tail->magic == H5FD_PB_PAGEHEADER_MAGIC );
+
+        assert( tail->flags & H5FD_PB_BUSY_FLAG );
+        assert( tail->flags & H5FD_PB_WRITE_FLAG );
+        assert( 0 == ( tail->flags & H5FD_PB_INVALID_FLAG ) );
+
+        H5MM_memcpy( tail->page, (const void *)(((const char *)buf ) + ( head_size + middle_size )), tail_size );
+
+        if ( 0 == (tail->flags & H5FD_PB_DIRTY_FLAG )) {
+
+            tail->flags |= H5FD_PB_DIRTY_FLAG;
+            file_ptr->rp_dirty_count++;
+        }
+
+        file_ptr->total_dirty++;
+
+        tail->flags &= ~( H5FD_PB_BUSY_FLAG | H5FD_PB_WRITE_FLAG );
+
+        write_count++;
+    }
+
+    assert( write_count == num_pages );
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_write() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_fapl_get
+ *
+ * Purpose:     Returns a file access property list which indicates how the
+ *              specified file is being accessed. The return list could be
+ *              used to access another file the same way.
+ *
+ * Return:      Success:    Ptr to new file access property list with all
+ *                          members copied from the file struct.
+ *              Failure:    NULL
+ *-------------------------------------------------------------------------
+ */
+static void *
+H5FD__pb_fapl_get(H5FD_t *_file)
+{
+    H5FD_pb_t *file      = (H5FD_pb_t *)_file;
+    void      *ret_value = NULL;
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    ret_value = H5FD__pb_fapl_copy(&(file->fa));
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_fapl_get() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_fapl_copy
+ *
+ * Purpose:     Copies the file access properties.
+ *
+ * Return:      Success:    Pointer to a new property list info structure.
+ *              Failure:    NULL
+ *-------------------------------------------------------------------------
+ */
+static void *
+H5FD__pb_fapl_copy(const void *_old_fa)
+{
+    const H5FD_pb_vfd_config_t *old_fa_ptr = (const H5FD_pb_vfd_config_t *)_old_fa;
+    H5FD_pb_vfd_config_t       *new_fa_ptr = NULL;
+    void                       *ret_value  = NULL;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    assert(old_fa_ptr);
+
+    new_fa_ptr = H5FL_CALLOC(H5FD_pb_vfd_config_t);
+    if (NULL == new_fa_ptr)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "unable to allocate log file FAPL");
+
+    H5MM_memcpy(new_fa_ptr, old_fa_ptr, sizeof(H5FD_pb_vfd_config_t));
+
+    /* Copy the FAPL */
+    if (H5FD__copy_plist(old_fa_ptr->fapl_id, &(new_fa_ptr->fapl_id)) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, NULL, "can't copy underlying FAPL");
+
+    ret_value = (void *)new_fa_ptr;
+
+done:
+
+    if (NULL == ret_value) {
+
+        if (new_fa_ptr) {
+
+            new_fa_ptr = H5FL_FREE(H5FD_pb_vfd_config_t, new_fa_ptr);
+        }
+    }
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_fapl_copy() */
+
+/*--------------------------------------------------------------------------
+ * Function:    H5FD__pb_fapl_free
+ *
+ * Purpose:     Releases the file access lists
+ *
+ * Return:      SUCCEED/FAIL
+ *--------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_fapl_free(void *_fapl)
+{
+    H5FD_pb_vfd_config_t *fapl      = (H5FD_pb_vfd_config_t *)_fapl;
+    herr_t                ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    /* Check arguments */
+    assert(fapl);
+
+    if (H5I_dec_ref(fapl->fapl_id) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTDEC, FAIL, "can't close underlying FAPL ID");
+
+    /* Free the property list */
+    fapl = H5FL_FREE(H5FD_pb_vfd_config_t, fapl);
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_fapl_free() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_open
+ *
+ * Purpose:     Create and/or opens a file as an HDF5 file, and initializes
+ *              the data structures for the Page Buffer VFD.
+ *
+ * Return:      Success:    A pointer to a new file data structure. The
+ *                          public fields will be initialized by the
+ *                          caller, which is always H5FD_open().
+ *              Failure:    NULL
+ *-------------------------------------------------------------------------
+ */
+static H5FD_t *
+H5FD__pb_open(const char *name, unsigned flags, hid_t pb_fapl_id, haddr_t maxaddr)
+{
+    H5FD_pb_t                  *file_ptr     = NULL; /* page buffer VFD info */
+    H5FD_t                     *ret_value    = NULL;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    /* Check arguments */
+    if (!name || !*name)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "invalid file name");
+
+    if (0 == maxaddr || HADDR_UNDEF == maxaddr)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, NULL, "bogus maxaddr");
+
+    if (ADDR_OVERFLOW(maxaddr))
+        HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, NULL, "bogus maxaddr");
+
+    if (H5FD_PB != H5Pget_driver(pb_fapl_id))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "driver is not page buffer");
+
+    file_ptr = (H5FD_pb_t *)H5FL_CALLOC(H5FD_pb_t);
+
+    if (NULL == file_ptr)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "unable to allocate file struct");
+
+    file_ptr->magic      = H5FD_PB_MAGIC;
+
+    file_ptr->fa.magic   = H5FD_PB_CONFIG_MAGIC;
+    file_ptr->fa.version = H5FD_CURR_PB_VFD_CONFIG_VERSION;
+    file_ptr->fa.fapl_id = H5I_INVALID_HID;
+
+    file_ptr->config_str = NULL;
+
+    if ( H5FD__pb_load_config(file_ptr, pb_fapl_id) < 0 ) 
+        HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, NULL, "can't load configuration");
+
+    /* open the underlying VFD / file */
+    if (H5FD_open(false, &file_ptr->file, name, flags, file_ptr->fa.fapl_id, HADDR_UNDEF) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTOPENFILE, NULL, "unable to open underlying file");
+
+    assert(NULL != file_ptr->file);
+
+    /* initialize the hash table */
+    for ( int32_t i = 0; i < H5FD_PB_DEFAULT_NUM_HASH_BUCKETS; i++ ) {
+        file_ptr->ht_bucket[i].index               = i;
+        file_ptr->ht_bucket[i].num_pages_in_bucket = 0;
+        file_ptr->ht_bucket[i].ht_head_ptr         = NULL;
+    }
+    
+    /* initialize the replacement policy */
+    file_ptr->rp_policy             = file_ptr->fa.rp;
+    file_ptr->rp_head_ptr           = NULL;
+    file_ptr->rp_tail_ptr           = NULL;
+    file_ptr->rp_pageheader_count   = 0;
+    file_ptr->rp_dirty_count        = 0;
+
+    /* initialize EOA management fields */
+    file_ptr->eoa_up                = 0;
+    file_ptr->eoa_down              = 0;
+
+#if 0 /* JRM */
+    /* eventually we will want a stats reset function -- don't do this now 
+     * unless you have time.
+     */
+#endif /* JRM */
+    
+    /* initialize statistics */
+    file_ptr->num_pages             = 0;
+    file_ptr->num_heads             = 0;
+    file_ptr->num_tails             = 0;
+    file_ptr->largest_num_in_bucket = 0;
+    file_ptr->num_hits              = 0;
+    file_ptr->num_misses            = 0;
+    file_ptr->total_middle_reads    = 0;
+    file_ptr->total_middle_writes   = 0;
+    file_ptr->max_search_depth      = 0;
+    file_ptr->total_success_depth   = 0;
+    file_ptr->total_fail_depth      = 0;
+    file_ptr->total_evictions       = 0;
+    file_ptr->total_dirty           = 0;
+    file_ptr->total_invalidated     = 0;
+    file_ptr->total_flushed         = 0;
+
+
+    ret_value = (H5FD_t *)file_ptr;
+
+done:
+
+    if ( NULL == ret_value ) {  /* do error cleanup */
+
+        if ( file_ptr ) {
+
+            if ( H5I_INVALID_HID != file_ptr->fa.fapl_id ) {
+
+                H5I_dec_ref( file_ptr->fa.fapl_id );
+            }
+
+            if ( file_ptr->file ) {
+
+                H5FD_close( file_ptr->file );
+            }
+
+            H5FL_FREE(H5FD_pb_t, file_ptr);
+        }
+    } /* end if error */
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_open() */
+
+/*-------------------------------------------------------------------------
+ *
+ * Function:    H5FD__pb_load_config
+ *
+ * Purpose:     Given the file pointer and the fapl ID, populate 
+ *              file_ptr->fa from the fapl file driver property.  Note 
+ *              that this property may contain pabe buffer configuration 
+ *              data in string format, binary format, or it may be 
+ *              omitted entirely.  In this later case, load file_ptr-fa 
+ *              with the default configuration.
+ *
+ * Return:      Success:    SUCCEED
+ *              Failure:    FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+
+herr_t
+H5FD__pb_load_config(H5FD_pb_t * file_ptr, hid_t pb_fapl_id)
+{
+    const char * config_str = NULL;
+    H5P_genplist_t  * plist_ptr  = NULL;
+    const H5FD_pb_vfd_config_t * config_ptr = NULL;
+    herr_t ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    assert(file_ptr);
+    assert(H5FD_PB_MAGIC == file_ptr->magic);
+    assert(H5FD_PB_CONFIG_MAGIC == file_ptr->fa.magic);
+    assert(NULL == file_ptr->config_str);
+    assert(H5FD_CURR_PB_VFD_CONFIG_VERSION == file_ptr->fa.version);
+    assert(H5FD_PB == H5Pget_driver(pb_fapl_id));
+
+    /* Get the driver-specific file access properties */
+    plist_ptr = (H5P_genplist_t *)H5I_object(pb_fapl_id);
+
+    if ( NULL == plist_ptr )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "supplied fapl doesn't exist?");
+
+    config_ptr = (const H5FD_pb_vfd_config_t *)H5P_peek_driver_info(plist_ptr);
+
+    config_str = H5P_peek_driver_config_str(plist_ptr);
+
+    assert( ! ( config_ptr && config_str ) );
+
+    if ( config_ptr ) {
+
+        assert(H5FD_PB_CONFIG_MAGIC == config_ptr->magic);
+
+        /* load the configuration from the instance of H5FD_pb_vfd_config_t in the fapl */
+        file_ptr->fa.magic         = H5FD_PB_CONFIG_MAGIC;
+        file_ptr->fa.version       = H5FD_CURR_PB_VFD_CONFIG_VERSION;
+
+        file_ptr->fa.page_size     = config_ptr->page_size;
+        file_ptr->fa.max_num_pages = config_ptr->max_num_pages;
+        file_ptr->fa.rp            = config_ptr->rp;
+
+        /* copy the FAPL for the underlying VFD */
+        if ( H5FD__copy_plist( config_ptr->fapl_id, &(file_ptr->fa.fapl_id)) < 0 )
+            HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "can't copy underlying FAPL");
+
+    } else if ( config_str ) {
+
+        /* first, load the configuration with default values. */
+        file_ptr->fa.magic         = H5FD_PB_CONFIG_MAGIC;
+        file_ptr->fa.version       = H5FD_CURR_PB_VFD_CONFIG_VERSION;
+        file_ptr->fa.page_size     = H5FD_PB_DEFAULT_PAGE_SIZE;
+        file_ptr->fa.max_num_pages = H5FD_PB_DEFAULT_MAX_NUM_PAGES;
+        file_ptr->fa.rp            = H5FD_PB_DEFAULT_REPLACEMENT_POLICY;
+        file_ptr->fa.fapl_id       = H5P_DEFAULT;
+        file_ptr->fa.testing       = H5FD_PB_DEFAULT_TESTING_OFF;
+
+        /* then call H5FD__pb_parse_config() to parse the configuration string
+         * and overwrite any field in file_ptr->fa with values that appear in 
+         * the configuration string.
+         */
+        if ( H5FD__pb_parse_config(config_str, &(file_ptr->fa)) < 0 )
+            HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "can't parse configuration string");
+
+        /* save a copy of the configuration string */
+        file_ptr->config_str = H5MM_strdup(config_str);
+
+    } else { /* just load the default configuration */
+
+        if ( H5FD__pb_populate_config( NULL, &(file_ptr->fa)) < 0 )
+            HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, "can't initialize driver configuration info");
+
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5FD__pb_load_config() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_parse_config
+ *
+ * Purpose:     Taking a string in the VFD configuration language as input,
+ *              parse the string and load its contents into an instance of 
+ *              H5FD_pb_vfd_config_t.  Note that default values are used 
+ *              for any values not specified in the configuration string.
+ *
+ * Return:      Success:    SUCCEED
+ *              Failure:    FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+
+herr_t
+H5FD__pb_parse_config(const char * config_str, H5FD_pb_vfd_config_t * config_ptr)
+{
+    int i;
+    char vfd_name[] = "page_buffer";
+    hid_t fapl_id = H5I_INVALID_HID;
+    H5CL_nv_pair_t nv_pairs[H5FD_PB__MAX_PARAMS];
+    herr_t ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    assert(config_str);
+    assert(H5FD_PB_CONFIG_MAGIC == config_ptr->magic);
+
+    for ( i = 0; i < H5FD_PB__MAX_PARAMS; i++ ) {
+
+        nv_pairs[i].struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
+
+        if ( H5CL_init_nv_pair(&(nv_pairs[i])) < 0 )
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't initialize nv_pairs.");
+
+    }
+
+    if ( H5CL_parse_config(config_str, vfd_name, &(nv_pairs[0]), H5FD_PB__MAX_PARAMS) < 0 )
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't parse config_str.");
+
+    for ( i = 0; i < H5FD_PB__MAX_PARAMS; i++ ) {
+
+        if ( H5CL_VAL_NONE != nv_pairs[i].val_type ) {
+
+            if ( 0 == strcmp("page_size", nv_pairs[i].name_ptr) ) {
+
+                if ( H5CL_VAL_INT == nv_pairs[i].val_type ) {
+
+                    config_ptr->page_size = (size_t)(nv_pairs[i].int_val);
+
+                } else {
+
+                    HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parameter name / type mismatch.");
+                }
+
+            } else if ( 0 == strcmp("max_num_pages", nv_pairs[i].name_ptr) ) {
+
+                if ( H5CL_VAL_INT == nv_pairs[i].val_type ) {
+
+                    config_ptr->max_num_pages = (size_t)(nv_pairs[i].int_val);
+
+                } else {
+
+                    HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parameter name / type mismatch.");
+                }
+
+            } else if ( 0 == strcmp("replacement_policy", nv_pairs[i].name_ptr) ) {
+
+                if ( H5CL_VAL_INT == nv_pairs[i].val_type ) {
+
+                    config_ptr->rp = (int32_t)(nv_pairs[i].int_val);
+
+                } else {
+
+                    HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parameter name / type mismatch.");
+                }
+
+            } else if ( 0 == strcmp("underlying_VFD", nv_pairs[i].name_ptr) ) {
+
+                if ( H5CL_VAL_INT == nv_pairs[i].val_type ) {
+
+                    fapl_id = (hid_t)(nv_pairs[i].int_val);
+
+                    if ( ( H5P_DEFAULT != fapl_id ) && ( false == H5P_isa_class(fapl_id, H5P_FILE_ACCESS) ) )
+
+                        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "Supplied FAPL ID isn't a FAPL ID.");
+
+                    config_ptr->fapl_id = fapl_id;
+
+                } else if ( H5CL_VAL_LIST == nv_pairs[i].val_type ) {
+
+                    /* construct a new FAPL and insert the configuration for the underlying 
+                     * VFD into it. 
+                     */
+                    H5P_genclass_t *pclass;
+
+                    if (NULL == (pclass = (H5P_genclass_t *)H5I_object_verify(H5P_FILE_ACCESS, H5I_GENPROP_CLS)))
+                        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "Can't get ptr to fapl class");
+
+                    if ( H5I_INVALID_HID == (fapl_id = H5P_create_id(pclass, false)) )
+                        HGOTO_ERROR(H5E_PLIST, H5E_CANTCREATE, FAIL, "can't create fapl for underlying VFD");
+
+                    if ( H5CL_load_vfd_config_str_into_fapl(fapl_id, (char *)(nv_pairs[i].vlen_val_ptr)) < 0 )
+                        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't set driver on fapl .");
+
+                    config_ptr->fapl_id = fapl_id;
+
+                } else {
+
+                    HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parameter name / type mismatch.");
+                }
+            } else if ( 0 == strcmp("testing", nv_pairs[i].name_ptr) ) {
+
+                if ( H5CL_VAL_INT == nv_pairs[i].val_type ) {
+
+                    config_ptr->testing = (bool)(nv_pairs[i].int_val);
+
+                } else {
+
+                    HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "parameter name / type mismatch.");
+                }
+
+            } else {
+
+                HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "unknown parameter name.");
+            }
+        }
+    }
+
+    if ( H5P_DEFAULT ==  config_ptr->fapl_id ) {
+
+        hid_t copy_fapl_id;
+        H5P_genplist_t *default_fapl_ptr = NULL;
+        H5P_genplist_t *copy_fapl_ptr = NULL;
+
+        /* Use a copy of default file access property list for underlying FAPL ID.
+         * The Sec2 driver is explicitly set on the FAPL ID, as the default
+         * driver might have been replaced with the page buffer VFD, which
+         * would cause recursion.
+         */
+
+        /* get a pointer to the default fapl */
+        if ( NULL == ( default_fapl_ptr = (H5P_genplist_t *)H5I_object(H5P_FILE_ACCESS_DEFAULT) ) )
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access property list");
+
+        /* make a copy of the default fapl */
+        if ( ( copy_fapl_id = H5P_copy_plist(default_fapl_ptr, false)) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTCOPY, FAIL, "can't copy property list");
+
+        /* get a pointer to the copy of the default fapl */
+        if (NULL == (copy_fapl_ptr = (H5P_genplist_t *)H5I_object(copy_fapl_id)))
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access property list");
+
+        /* force the copy of the default fapl to specify the sec2 VFD */
+        if (H5P_set_driver_by_value(copy_fapl_ptr, H5_VFD_SEC2, NULL, true) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, "can't set default driver on underlying FAPL");
+
+        /* overwrite config_ptr->fapl_id with the id of the copy of the default fapl */
+        config_ptr->fapl_id = copy_fapl_id;
+
+    } else {
+
+        /* config_ptr->fapl_id is not H5P_DEFAULT.  Just verify that it is a fapl */
+
+        if (false == H5P_isa_class(config_ptr->fapl_id, H5P_FILE_ACCESS))
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access list");
+    }
+
+    /* take down nv_pairs if it has been setup */
+    for ( i = 0; i < H5FD_PB__MAX_PARAMS; i++ ) {
+
+        if ( ( H5CL_NV_PAIR_STRUCT_TAG == nv_pairs[i].struct_tag ) && 
+             ( H5CL_take_down_nv_pair(&(nv_pairs[i])) < 0 ) )
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "can't take down nv_pair.");
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5FD__pb_parse_config() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_close
+ *
+ * Purpose:     Closes the underlying file and take down the page buffer.
+ *
+ *              To do this, we must:
+ *
+ *              1) flush the page buffer.
+ *
+ *              2) close the underlying VFD
+ *
+ *              3) Discard all pages in the page buffer,
+ *
+ *              4) If present, discard the copy of the configuration 
+ *                 string
+ *
+ *              6) Discard the instance of H5FD_pb_t.
+ *
+ * Return:      Success:    SUCCEED
+ *              Failure:    FAIL, file not closed.
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_close(H5FD_t *_file)
+{
+    int                    i;
+    H5FD_pb_t            * file_ptr  = (H5FD_pb_t *)_file;
+    H5FD_pb_pageheader_t * pageheader;
+    H5FD_pb_pageheader_t * discard_page_ptr;
+    herr_t     ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    /* Sanity check */
+    assert( file_ptr );
+    assert( H5FD_PB_MAGIC == file_ptr->magic );
+
+    /* must flush the page buffer as writes can occur after the flush on file close */
+    if ( H5FD__pb_flush( _file, H5P_DEFAULT, TRUE) < 0 ) 
+        HGOTO_ERROR(H5E_VFL, H5E_CANTFLUSH, FAIL, "unable to flush pagebuffer on close");
+
+
+    /* Verify there are no dirty pages in the page buffer */
+    assert( 0 == file_ptr->rp_dirty_count );
+
+
+    /* close the underlying VFD */
+    if ( H5I_dec_ref( file_ptr->fa.fapl_id ) < 0 )
+        HGOTO_ERROR(H5E_VFL, H5E_ARGS, FAIL, "can't close underlying VFD FAPL");
+
+    if ( file_ptr->file ) {
+
+        if ( H5FD_close( file_ptr->file ) == FAIL )
+            HGOTO_ERROR(H5E_VFL, H5E_CANTCLOSEFILE, FAIL, "unable to close underlying file");
+    }
+
+    /* discard page buffer data structures */
+
+    pageheader = file_ptr->rp_tail_ptr;
+
+    while ( pageheader ) {
+
+        discard_page_ptr = pageheader;
+
+        pageheader = pageheader->rp_prev_ptr;
+
+        /* remove the page from the replacement policy DLL */
+        if ( H5FD__pb_rp_remove_pageheader( file_ptr, discard_page_ptr ) != 0 )
+            HGOTO_ERROR(H5E_VFL, H5E_CANTCLOSEFILE, FAIL, "Can't remove page from RP list");
+
+        if ( 0 == ( discard_page_ptr->flags & H5FD_PB_INVALID_FLAG ) ) {
+
+            /* Invalid flag is not set, so page must be in the hash table -- remove it */
+            if ( H5FD__pb_ht_remove_pageheader( file_ptr, discard_page_ptr ) != 0 )
+                HGOTO_ERROR(H5E_VFL, H5E_CANTCLOSEFILE, FAIL, "Can't remove page from hash table");
+        }
+
+        discard_page_ptr->magic = 0;
+        free( discard_page_ptr );
+    }
+    assert( 0 == file_ptr->rp_pageheader_count );
+
+    /* verify that the hash table is empty */
+    for ( i = 0; i < H5FD_PB_DEFAULT_NUM_HASH_BUCKETS; i++ ) {
+
+        assert( i == file_ptr->ht_bucket[i].index );
+        assert( 0 == file_ptr->ht_bucket[i].num_pages_in_bucket );
+        assert( NULL == file_ptr->ht_bucket[i].ht_head_ptr );
+    }
+
+    /* Discard the configuration string if present */
+    if ( file_ptr->config_str ) {
+
+        file_ptr->config_str = H5MM_xfree(file_ptr->config_str);
+    }
+
+    /* Release the file info */
+    file_ptr = H5FL_FREE(H5FD_pb_t, file_ptr);
+    file_ptr = NULL;
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_close() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_get_eoa
+ *
+ * Purpose:     Returns the end-of-address marker for the file. The EOA
+ *              marker is the first address past the last byte allocated in
+ *              the format address space.
+ *
+ *              Due to the fact that the page buffer converts random I/O
+ *              to paged I/O, the EOA above the page buffer VFD is usually
+ *              different from that below.  Specfically, the lower EOA must
+ *              always be on a page boundary, and be greater than or ewual 
+ *              to the upper EOA.
+ *
+ *              Since we currently maintain the file_ptr->eoa_up and
+ *              file_ptr->eoa_down fields, in principle, it is sufficient to
+ *              simply return eoa_up.
+ *
+ *              However, as a sanity check, we request the eoa from the
+ *              underlying VFD, and fail if it doesn't match file_ptr->eoa_down.
+ *
+ *              If this test passes, we return file_ptr->eoa_up.
+ *
+ *              Note that we don't have to concern outselves with the
+ *              case in which the first get_eoa call arrives before the
+ *              first set_eoa call since since both eoa_up and eoa_down
+ *              are initialzed to zero on file open
+ *
+ * Return:      Success:    The end-of-address-marker
+ *
+ *              Failure:    HADDR_UNDEF
+ *-------------------------------------------------------------------------
+ */
+static haddr_t
+H5FD__pb_get_eoa(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
+{
+    haddr_t          eoa_down;
+    const H5FD_pb_t *file_ptr  = (const H5FD_pb_t *)_file;
+    haddr_t          ret_value = HADDR_UNDEF;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    /* Sanity check */
+    assert(file_ptr);
+    assert(file_ptr->file);
+    assert(H5FD_PB_MAGIC == file_ptr->magic);
+
+    if ((eoa_down = H5FD_get_eoa(file_ptr->file, type)) == HADDR_UNDEF) 
+        HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, HADDR_UNDEF, "unable to get eoa");
+
+    if ( H5_addr_ne(eoa_down, file_ptr->eoa_down) )
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, HADDR_UNDEF, "eoa_down mismatch");
+
+    ret_value = file_ptr->eoa_up;
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_get_eoa */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_set_eoa
+ *
+ * Purpose:     Set the end-of-address marker for the file. This function is
+ *              called shortly after an existing HDF5 file is opened in order
+ *              to tell the driver where the end of the HDF5 data is located.
+ *
+ *              In the page buffer VFD case, we must extend the supplied EOA
+ *              to the next page boundary.  and pass the result to the 
+ *              underlying VFD.  If the call is successful, set eoa_up and 
+ *              eoa_down to the supplied and computed values respectively, 
+ *              and then return.
+ *
+ * Return:      SUCCEED/FAIL
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_set_eoa(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, haddr_t addr)
+{
+    haddr_t    eoa_up;
+    haddr_t    eoa_down;
+    int64_t    page_num;
+    H5FD_pb_t *file_ptr = (H5FD_pb_t *)_file;
+    herr_t     ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__)
+
+    /* Sanity check */
+    assert(file_ptr);
+    assert(H5FD_PB_MAGIC == file_ptr->magic);
+    assert(file_ptr->file);
+
+    eoa_up = addr;
+
+    page_num = (int64_t)(addr / (haddr_t)((file_ptr->fa.page_size)));
+
+    assert(page_num >= 0);
+
+    if ( 0 < (addr % (haddr_t)(file_ptr->fa.page_size)) ) {
+
+        page_num++;
+    }
+
+    eoa_down = ((haddr_t)(page_num)) * ((haddr_t)(file_ptr->fa.page_size));
+
+    if (H5FD_set_eoa(file_ptr->file, type, eoa_down) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, "H5FD_set_eoa failed for underlying file");
+
+    file_ptr->eoa_up = eoa_up;
+    file_ptr->eoa_down = eoa_down;
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_set_eoa() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_get_eof
+ *
+ * Purpose:     Returns the end-of-address marker for the file. The EOA
+ *              marker is the first address past the last byte allocated in
+ *              the format address space.
+ *
+ * Return:      Success:    The end-of-address-marker
+ *
+ *              Failure:    HADDR_UNDEF
+ *-------------------------------------------------------------------------
+ */
+static haddr_t
+H5FD__pb_get_eof(const H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type)
+{
+    const H5FD_pb_t *file      = (const H5FD_pb_t *)_file;
+    haddr_t          ret_value = HADDR_UNDEF; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    /* Sanity check */
+    assert(file);
+    assert(file->file);
+
+    if (HADDR_UNDEF == (ret_value = H5FD_get_eof(file->file, type)))
+        HGOTO_ERROR(H5E_VFL, H5E_CANTGET, HADDR_UNDEF, "unable to get eof");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_get_eof */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_truncate
+ *
+ * Purpose:     Notify driver to truncate the file back to the allocated size.
+ *
+ * Return:      SUCCEED/FAIL
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_truncate(H5FD_t *_file, hid_t dxpl_id, bool closing)
+{
+    H5FD_pb_t *file      = (H5FD_pb_t *)_file;
+    herr_t     ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    assert(file);
+    assert(file->file);
+
+    /* need to to invalidate any pages truncated out of existance. 
+     * Need to think on how to handle any partially truncaed pages
+     */
+    if (H5FDtruncate(file->file, dxpl_id, closing) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTUPDATE, FAIL, "unable to truncate file");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_truncate */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_sb_size
+ *
+ * Purpose:     Obtains the number of bytes required to store the driver file
+ *              access data in the HDF5 superblock.
+ *
+ * Return:      Success:    Number of bytes required.
+ *
+ *              Failure:    0 if an error occurs or if the driver has no
+ *                          data to store in the superblock.
+ *
+ * NOTE: no public API for H5FD_sb_size, it needs to be added
+ *-------------------------------------------------------------------------
+ */
+static hsize_t
+H5FD__pb_sb_size(H5FD_t *_file)
+{
+    H5FD_pb_t *file      = (H5FD_pb_t *)_file;
+    hsize_t    ret_value = 0;
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    /* Sanity check */
+    assert(file);
+    assert(file->file);
+
+    if (file->file) {
+
+        ret_value = H5FD_sb_size(file->file);
+    }
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_sb_size */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_sb_encode
+ *
+ * Purpose:     Encode driver-specific data into the output arguments.
+ *
+ * Return:      SUCCEED/FAIL
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_sb_encode(H5FD_t *_file, char *name /*out*/, unsigned char *buf /*out*/)
+{
+    H5FD_pb_t *file      = (H5FD_pb_t *)_file;
+    herr_t     ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    /* Sanity check */
+    assert(file);
+    assert(file->file);
+
+    if (file->file && H5FD_sb_encode(file->file, name, buf) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTENCODE, FAIL, "unable to encode the superblock in file");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_sb_encode */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_sb_decode
+ *
+ * Purpose:     Decodes the driver information block.
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ * NOTE: no public API for H5FD_sb_size, need to add
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_sb_decode(H5FD_t *_file, const char *name, const unsigned char *buf)
+{
+    H5FD_pb_t *file      = (H5FD_pb_t *)_file;
+    herr_t     ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    /* Sanity check */
+    assert(file);
+    assert(file->file);
+
+    if (H5FD_sb_load(file->file, name, buf) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTDECODE, FAIL, "unable to decode the superblock in file");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_sb_decode */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_cmp
+ *
+ * Purpose:     Compare the keys of two files.
+ *
+ * Return:      Success:    A value like strcmp()
+ *              Failure:    Must never fail
+ *-------------------------------------------------------------------------
+ */
+static int
+H5FD__pb_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
+{
+    const H5FD_pb_t *f1 = (const H5FD_pb_t *)_f1;
+    const H5FD_pb_t *f2 = (const H5FD_pb_t *)_f2;
+    herr_t ret_value    = 0; /* Return value */
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    assert(f1);
+    assert(f2);
+
+    ret_value = H5FD_cmp(f1->file, f2->file);
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_cmp */
+
+/*--------------------------------------------------------------------------
+ * Function:    H5FD__pb_get_handle
+ *
+ * Purpose:     Returns a pointer to the file handle of low-level virtual
+ *              file driver.
+ *
+ * Return:      SUCCEED/FAIL
+ *--------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_get_handle(H5FD_t *_file, hid_t H5_ATTR_UNUSED fapl, void **file_handle)
+{
+    H5FD_pb_t *file      = (H5FD_pb_t *)_file;
+    herr_t     ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    /* Check arguments */
+    assert(file);
+    assert(file->file);
+    assert(file_handle);
+
+    if (H5FD_get_vfd_handle(file->file, file->fa.fapl_id, file_handle) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL, "unable to get handle of file");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_get_handle */
+
+/*--------------------------------------------------------------------------
+ * Function:    H5FD__pb_lock
+ *
+ * Purpose:     Sets a file lock.
+ *
+ * Return:      SUCCEED/FAIL
+ *--------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_lock(H5FD_t *_file, bool rw)
+{
+    H5FD_pb_t *file      = (H5FD_pb_t *)_file; /* VFD file struct */
+    herr_t     ret_value = SUCCEED;            /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    assert(file);
+    assert(file->file);
+
+    /* Place the lock on underlying file */
+    if (H5FD_lock(file->file, rw) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTLOCKFILE, FAIL, "unable to lock file");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_lock */
+
+/*--------------------------------------------------------------------------
+ * Function:    H5FD__pb_unlock
+ *
+ * Purpose:     Removes a file lock.
+ *
+ * Return:      SUCCEED/FAIL
+ *--------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_unlock(H5FD_t *_file)
+{
+    H5FD_pb_t *file      = (H5FD_pb_t *)_file; /* VFD file struct */
+    herr_t     ret_value = SUCCEED;            /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    /* Check arguments */
+    assert(file);
+    assert(file->file);
+
+    if (H5FD_unlock(file->file) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTUNLOCKFILE, FAIL, "unable to unlock file");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_unlock */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_ctl
+ *
+ * Purpose:     Page buffer VFD version of the ctl callback.
+ *
+ *              The desired operation is specified by the op_code
+ *              parameter.
+ *
+ *              The flags parameter controls management of op_codes that
+ *              are unknown to the callback
+ *
+ *              The input and output parameters allow op_code specific
+ *              input and output
+ *
+ *              At present, this VFD supports no op codes of its own and
+ *              simply passes ctl calls on to the underlying VFD
+ *
+ * Return:      Non-negative on success/Negative on failure
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_ctl(H5FD_t *_file, uint64_t op_code, uint64_t flags, const void *input, void **output)
+{
+    H5FD_pb_t *file      = (H5FD_pb_t *)_file;
+    herr_t     ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    /* Sanity checks */
+    assert(file);
+
+    switch (op_code) {
+
+        /* probably want to add options for displaying and reseting stats */
+
+        /* Unknown op code */
+        default:
+            if (flags & H5FD_CTL_ROUTE_TO_TERMINAL_VFD_FLAG) {
+
+                /* Pass ctl call down to underlying VFD */
+
+                if (H5FDctl(file->file, op_code, flags, input, output) < 0)
+                    HGOTO_ERROR(H5E_VFL, H5E_FCNTL, FAIL, "VFD ctl request failed");
+            }
+            else {
+                /* If no valid VFD routing flag is specified, fail for unknown op code
+                 * if H5FD_CTL_FAIL_IF_UNKNOWN_FLAG flag is set.
+                 */
+                if (flags & H5FD_CTL_FAIL_IF_UNKNOWN_FLAG)
+                    HGOTO_ERROR(H5E_VFL, H5E_FCNTL, FAIL,
+                                "VFD ctl request failed (unknown op code and fail if unknown flag is set)");
+            }
+
+            break;
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_ctl() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_query
+ *
+ * Purpose:     Set the flags that this VFL driver is capable of supporting.
+ *              (listed in H5FDpublic.h)
+ *
+ * Return:      SUCCEED/FAIL
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_query(const H5FD_t *_file, unsigned long *flags /* out */)
+{
+    const H5FD_pb_t *file      = (const H5FD_pb_t *)_file;
+    herr_t           ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    if (file) {
+        assert(file);
+        assert(file->file);
+
+        if (H5FDquery(file->file, flags) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTLOCK, FAIL, "unable to query R/W file");
+    }
+    else {
+        /* There is no file. Because this is a pure passthrough VFD,
+         * it has no features of its own.
+         */
+        if (flags)
+            *flags = 0;
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_query() */
+
+#if 0
+/* The current implementations of the alloc and free callbacks
+ * cause space allocation failures in the upper library.  This 
+ * has to be dealt with if we want the page buffer and encryption
+ * to run with VFDs that require it (split, multi).
+ * However, since targeting just the sec2 VFD is sufficient 
+ * for the Phase I prototype, we will bypass the issue
+ * for now.
+ *                                JRM -- 9/6/24
+ */
+#if 0
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_alloc
+ *
+ * Purpose:     Allocate file memory.
+ *
+ *              Handling this call as a pass through while maintaining the 
+ *              eoa_up and eoa_down is made more complicated by the fact 
+ *              that some VFDs treat this call as a set eoa call, and 
+ *              others (multi / split file driver only?) implement it as 
+ *              an addition to the current EOA (for the specified type).
+ *
+ *              This is a bit awkward for the page buffer.  For now, 
+ *              solve this by:
+ *
+ *              1) pass through the alloc call.
+ *
+ *              2) make a get eoa call on the underlying VFD to obtain
+ *                 the current eoa from below.  Call this value eoa_up
+ *
+ *              3) if eoa_up is not on a page boundary, increment it to
+ *                 the next page boundary, set the eoa of the underlying
+ *                 VFD to the is value, and save it in eoa_down.
+ * 
+ *              4) store the new values of eoa_up and eoa_down in *file_ptr.
+ * 
+ * Return:      Address of allocated space (HADDR_UNDEF if error).
+ *-------------------------------------------------------------------------
+ */
+
+static haddr_t
+H5FD__pb_alloc(H5FD_t *_file, H5FD_mem_t type, hid_t  dxpl_id, hsize_t size)
+{
+    haddr_t    eoa_up;
+    haddr_t    eoa_down;
+    int64_t    page_num;
+    H5FD_pb_t *file_ptr  = (H5FD_pb_t *)_file; /* VFD file struct */
+    haddr_t    ret_value = HADDR_UNDEF;        /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    /* Check arguments */
+    assert(file_ptr);
+    assert(H5FD_PB_MAGIC == file_ptr->magic);
+    assert(file_ptr->file);
+
+    /* 1) pass through the alloc call. */
+    if ((ret_value = H5FDalloc(file_ptr->file, type, dxpl_id, size)) == HADDR_UNDEF)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTINIT, HADDR_UNDEF, "unable to allocate for underlying file");
+    
+    /* 2) make a get eoa call on the underlying VFD to obtain
+     *    the current eoa from below.  Call this value eoa_up
+     */
+    if ((eoa_up = H5FD_get_eoa(file_ptr->file, type)) == HADDR_UNDEF)
+        HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, HADDR_UNDEF, "unable to get eoa");
+
+    /* 3) if eoa_up is not on a page boundary, increment it to
+     *    the next page boundary, set the eoa of the underlying
+     *    VFD to the is value, and save it in eoa_down.
+     */
+    page_num = (int64_t)(eoa_up / (haddr_t)((file_ptr->fa.page_size)));
+
+    assert(page_num >= 0);
+
+    if ( 0 < (eoa_up % (haddr_t)(file_ptr->fa.page_size)) ) {
+
+        page_num++;
+    }
+
+    eoa_down = ((haddr_t)(page_num)) * ((haddr_t)(file_ptr->fa.page_size));
+
+    if (H5FD_set_eoa(file_ptr->file, type, eoa_down) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTSET, HADDR_UNDEF, "H5FD_set_eoa failed for underlying file");
+
+    /* 4) store the new values of eoa_up and eoa_down in *file_ptr. */
+    file_ptr->eoa_up = eoa_up;
+    file_ptr->eoa_down = eoa_down;
+
+done:
+
+#if 0 /* JRM */
+    fprintf(stderr, "\nH5FD__pb_alloc(): size = 0x%llx,  eoa_up = 0x%llx, eoa_down = 0x%llx\n",
+           (unsigned long long)size,
+           (unsigned long long)(file_ptr->eoa_up),
+           (unsigned long long)(file_ptr->eoa_down));
+#endif
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_alloc() */
+
+#else
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_alloc
+ *
+ * Purpose:     Allocate file memory.
+ *
+ *              Handling this call as a pass through while maintaining the 
+ *              eoa_up and eoa_down is made more complicated by the fact 
+ *              that there seems to be some variation in how this call 
+ *              is implemented by the various VFDs.  Since the immediate
+ *              target is sec2, and sec2 (and any VFD that doesn't have an
+ *              alloc call) simply adds size bytes to the current EOA,
+ *              the page buffer alloc call will do the same with 
+ *              adjustments to the lower eoa to force it to fall on 
+ *              a page boundary.
+ *
+ *              This will have to be re-visited if we target VFDs that
+ *              don't handle their alloc calls this way.
+ *
+ *              Proceed as follows:
+ *
+ *              1) Add the size to the current eoa_up.
+ *
+ *              2) Set eoa_down equal to eoa_up.  If eoa_down, doesn't 
+ *                 lie on a page boundary, extend it to the next page
+ *                 boundary.
+ *
+ *              3) Call the set eoa function on the underlying VFD to 
+ *                 set its EOA to eoa_down.
+ *
+ *              4) Store the new values of eoa_up and eoa_down in
+ *                 the fields of that name in *file_ptr.
+ *
+ *              5) Return the new value of eoa_down.
+ *
+ *              Note that the calloc call of the underlying VFD is never
+ *              used -- the set eoa call is used instead.
+ * 
+ * Return:      Address of allocated space (HADDR_UNDEF if error).
+ *-------------------------------------------------------------------------
+ */
+
+static haddr_t
+H5FD__pb_alloc(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_id, hsize_t size)
+{
+    haddr_t    eoa_up;
+    haddr_t    eoa_down;
+    int64_t    page_num;
+    H5FD_pb_t *file_ptr  = (H5FD_pb_t *)_file; /* VFD file struct */
+    haddr_t    ret_value = HADDR_UNDEF;        /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    /* Check arguments */
+    assert(file_ptr);
+    assert(H5FD_PB_MAGIC == file_ptr->magic);
+    assert(file_ptr->file);
+
+    /* 1) Add the size to the current eoa_up. */
+
+    eoa_up = file_ptr->eoa_up + (haddr_t)size;
+ 
+
+    /* 2) Set eoa_down equal to eoa_up.  If eoa_down, doesn't 
+     *    lie on a page boundary, extend it to the next page
+     *    boundary.
+     */
+    page_num = (int64_t)(eoa_up / (haddr_t)((file_ptr->fa.page_size)));
+
+    assert(page_num >= 0);
+
+    if ( 0 < (eoa_up % (haddr_t)(file_ptr->fa.page_size)) ) {
+
+        page_num++;
+    }
+
+    eoa_down = ((haddr_t)(page_num)) * ((haddr_t)(file_ptr->fa.page_size));
+
+
+    /* 3) Call the set eoa function on the underlying VFD to 
+     *    set its EOA to eoa_down.
+     */
+    if (H5FD_set_eoa(file_ptr->file, type, eoa_down) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTSET, HADDR_UNDEF, "H5FD_set_eoa failed for underlying file");
+
+ 
+    /* 4) Store the new values of eoa_up and eoa_down in
+     *    the fields of that name in *file_ptr.
+     */
+    file_ptr->eoa_up = eoa_up;
+    file_ptr->eoa_down = eoa_down;
+
+
+    /* 5) Return the new value of eoa_down. */
+    ret_value = eoa_up;
+
+done:
+
+#if 0 /* JRM */
+    fprintf(stderr, "\nH5FD__pb_alloc(): size = 0x%llx,  eoa_up = 0x%llx, eoa_down = 0x%llx\n",
+           (unsigned long long)size,
+           (unsigned long long)(file_ptr->eoa_up),
+           (unsigned long long)(file_ptr->eoa_down));
+#endif
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_alloc() */
+#endif
+#endif
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_get_type_map
+ *
+ * Purpose:     Retrieve the memory type mapping for this file
+ *
+ * Return:      SUCCEED/FAIL
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_get_type_map(const H5FD_t *_file, H5FD_mem_t *type_map)
+{
+    const H5FD_pb_t *file      = (const H5FD_pb_t *)_file;
+    herr_t           ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    /* Check arguments */
+    assert(file);
+    assert(file->file);
+
+    /* Retrieve memory type mapping for the underlying file */
+    if (H5FD_get_fs_type_map(file->file, type_map) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL, "unable to get type map for the underlying file");
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_get_type_map() */
+
+#if 0
+/* The current implementations of the alloc and free callbacks
+ * cause space allocation failures in the upper library.  This 
+ * has to be dealt with if we want the page buffer and encryption
+ * to run with VFDs that require it (split, multi).
+ * However, since targeting just the sec2 VFD is sufficient 
+ * for the Phase I prototype, we will bypass the issue
+ * for now.
+ *                                JRM -- 9/6/24
+ */
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_free
+ *
+ * Purpose:     Pass the free call down to the underlying VFD.
+ *
+ * Return:      SUCCEED/FAIL
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_free(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_id, haddr_t addr, hsize_t size)
+{
+    int64_t    page_num;
+    haddr_t    eoa_up;
+    haddr_t    eoa_down;
+    H5FD_pb_t *file_ptr  = (H5FD_pb_t *)_file; /* VFD file struct */
+    herr_t     ret_value = SUCCEED;            /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    H5FD_PB_LOG_CALL(__func__);
+
+    /* Check arguments */
+    assert(file_ptr);
+    assert(file_ptr->file);
+
+    if ( file_ptr->eoa_up == (addr + (haddr_t)size) ) {
+
+        eoa_up = addr;
+
+        page_num = (int64_t)(eoa_up / (haddr_t)((file_ptr->fa.page_size)));
+
+        assert(page_num >= 0);
+
+        if ( 0 < (eoa_up % (haddr_t)(file_ptr->fa.page_size)) ) {
+
+            page_num++;
+        }
+
+        eoa_down = ((haddr_t)(page_num)) * ((haddr_t)(file_ptr->fa.page_size));
+
+        if (H5FD_set_eoa(file_ptr->file, type, eoa_down) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, "H5FD_set_eoa failed for underlying file");
+ 
+        file_ptr->eoa_up = eoa_up;
+        file_ptr->eoa_down = eoa_down;
+    }
+
+done:
+
+#if 0 /* JRM */
+    fprintf(stderr, "\nH5FD__pb_free(): addr / size = 0x%llx /0x%llx,  eoa_up = 0x%llx, eoa_down = 0x%llx\n",
+           (unsigned long long)addr,
+           (unsigned long long)size,
+           (unsigned long long)(file_ptr->eoa_up),
+           (unsigned long long)(file_ptr->eoa_down));
+#endif
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_free() */
+#endif
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__pb_delete
+ *
+ * Purpose:     Delete a file
+ *
+ * Return:      SUCCEED/FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__pb_delete(const char *filename, hid_t fapl_id)
+{
+    const H5FD_pb_vfd_config_t *fapl_ptr     = NULL;
+    H5FD_pb_vfd_config_t       *default_fapl = NULL;
+    H5P_genplist_t             *plist;
+    herr_t                      ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    assert(filename);
+
+    /* Get the driver info */
+    if (H5P_FILE_ACCESS_DEFAULT == fapl_id) {
+
+        if (NULL == (default_fapl = H5FL_CALLOC(H5FD_pb_vfd_config_t)))
+            HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, "unable to allocate file access property list struct");
+
+        if (H5FD__pb_populate_config(NULL, default_fapl) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, "can't initialize driver configuration info");
+
+        fapl_ptr = default_fapl;
+    }
+    else {
+
+        if (NULL == (plist = (H5P_genplist_t *)H5I_object(fapl_id)))
+            HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access property list");
+
+        if (NULL == (fapl_ptr = (const H5FD_pb_vfd_config_t *)H5P_peek_driver_info(plist))) {
+
+            if (NULL == (default_fapl = H5FL_CALLOC(H5FD_pb_vfd_config_t)))
+                HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL,
+                            "unable to allocate file access property list struct");
+
+            if (H5FD__pb_populate_config(NULL, default_fapl) < 0)
+                HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, "can't initialize driver configuration info");
+
+            fapl_ptr = default_fapl;
+        }
+    }
+
+    if (H5FDdelete(filename, fapl_ptr->fapl_id) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTDELETEFILE, FAIL, "unable to delete file");
+
+done:
+
+    if (default_fapl)
+        H5FL_FREE(H5FD_pb_vfd_config_t, default_fapl);
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5FD__pb_delete() */
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__pb_alloc_and_init_pageheader
+ *
+ * Purpose:     Allocates and initializes a H5FD_pb_pageheader_t structure.
+ *
+ * Return:      Success:    A pointer to the H5FD_pb_pageheader_t structure.
+ *              Failure:    NULL
+ *-----------------------------------------------------------------------------
+ */
+H5FD_pb_pageheader_t *
+H5FD__pb_alloc_and_init_pageheader(H5FD_pb_t * file_ptr, haddr_t addr, uint32_t hash_code)
+{
+    H5FD_pb_pageheader_t *pageheader = NULL;
+    H5FD_pb_pageheader_t *ret_value = NULL;
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    assert( file_ptr );
+    assert( H5FD_PB_MAGIC == file_ptr->magic );
+
+    /* Allocates space for the pageheader */
+    if ( NULL == (pageheader = (H5FD_pb_pageheader_t *)malloc(sizeof(H5FD_pb_pageheader_t) +
+                                                file_ptr->fa.page_size )))
+        HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "unable to allocate page header");
+
+
+    pageheader->magic           = H5FD_PB_PAGEHEADER_MAGIC;
+    pageheader->hash_code       = hash_code;
+    pageheader->ht_next_ptr     = NULL;
+    pageheader->ht_prev_ptr     = NULL;
+    pageheader->rp_next_ptr     = NULL;
+    pageheader->rp_prev_ptr     = NULL;
+    pageheader->flags           = 0;
+    pageheader->page_addr       = addr;
+    pageheader->type            = H5FD_MEM_DEFAULT;
+
+    ret_value = pageheader;
+
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value);
+
+} /* end H5FD__pb_alloc_and_init_pageheader() */
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__pb_invalidate_pageheader
+ *
+ * Purpose:     When a H5FD_pb_pageheader_t structure needs to be marked 
+ *              invalid. The invalid flag is set to signify that this page is 
+ *              not a valid page, and it is removed from the hash table and 
+ *              replacement policy (rp) list and then appended to the tail of 
+ *              the replacement policy list to ensure invalid pages are the 
+ *              next to be evicted.
+ *
+ * Return:      SUCCESS/FAIL
+ *
+ *-----------------------------------------------------------------------------
+ */
+herr_t
+H5FD__pb_invalidate_pageheader(H5FD_pb_t *file_ptr, H5FD_pb_pageheader_t *pageheader)
+{
+    herr_t ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+    assert( file_ptr );
+    assert( H5FD_PB_MAGIC == file_ptr->magic );
+    assert( pageheader );
+    assert( H5FD_PB_PAGEHEADER_MAGIC == pageheader->magic );
+
+    pageheader->flags |= H5FD_PB_INVALID_FLAG;
+    
+    if ( pageheader->flags & H5FD_PB_DIRTY_FLAG ) {
+
+        pageheader->flags &= ~H5FD_PB_DIRTY_FLAG;
+        file_ptr->rp_dirty_count--;
+    }
+    
+
+    assert( 0 == ( pageheader->flags & H5FD_PB_BUSY_FLAG ));
+    assert( 0 == ( pageheader->flags & H5FD_PB_DIRTY_FLAG ));
+    assert( 0 == ( pageheader->flags & H5FD_PB_READ_FLAG ));
+    assert( 0 == ( pageheader->flags & H5FD_PB_WRITE_FLAG ));
+    assert( pageheader->flags & H5FD_PB_INVALID_FLAG );
+
+    H5FD__pb_ht_remove_pageheader( file_ptr, pageheader );
+    H5FD__pb_rp_remove_pageheader( file_ptr, pageheader );
+    H5FD__pb_rp_append_pageheader( file_ptr, pageheader );
+
+    file_ptr->total_invalidated++;
+
+    FUNC_LEAVE_NOAPI(ret_value);
+
+} /* end H5FD__pb_invalidate_pageheader() */
+
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__pb_flush_page
+ *
+ * Purpose:     When a H5FD_pb_pageheader_t with a page flagged as dirty is 
+ *              selected to be evicted from the page buffer by the replacement
+ *              policy, upon the closing of the file, or any other reason a 
+ *              flush needs to occur, this function is called to write the
+ *              the dirty page to the file.
+ *
+ * Return:      void
+ *-----------------------------------------------------------------------------
+ */
+herr_t
+H5FD__pb_flush_page(H5FD_pb_t * file_ptr, hid_t dxpl_id, H5FD_pb_pageheader_t *pageheader)
+{
+    herr_t ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    assert( file_ptr );
+    assert( H5FD_PB_MAGIC == file_ptr->magic );
+    assert( pageheader );
+    assert( H5FD_PB_PAGEHEADER_MAGIC == pageheader->magic );
+
+    if ( H5FDwrite( file_ptr->file, pageheader->type, dxpl_id, pageheader->page_addr, 
+                    file_ptr->fa.page_size, pageheader->page ) < 0 )
+        HGOTO_ERROR(H5E_VFL, H5E_WRITEERROR, FAIL, "Page could not be flushed to underlying VFD.");
+
+    pageheader->flags &= ~H5FD_PB_DIRTY_FLAG;
+
+    file_ptr->rp_dirty_count--;
+    file_ptr->total_flushed++;
+
+    assert( pageheader->magic == H5FD_PB_PAGEHEADER_MAGIC );
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_flush_page() */
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__pb_get_pageheader
+ *
+ * Purpose:     Selects a H5FD_pb_pageheader_t structure, either by allocating 
+ *              a new one if not at the maximum number of pages, or if the 
+ *              maximum number of pages has been reached, by evicting a page 
+ *              from a H5FD_pb_pageheader_t structure from the replacement
+ *              policy list based on the selected replacement policy.
+ *
+ * Return:      Success:    A pointer to the H5FD_pb_pageheader_t structure.
+ *              Failure:    NULL
+ *-----------------------------------------------------------------------------
+ */
+H5FD_pb_pageheader_t*
+H5FD__pb_get_pageheader(H5FD_pb_t *file_ptr, H5FD_mem_t type, hid_t dxpl_id, 
+                        haddr_t addr, uint32_t hash_code)
+{
+    H5FD_pb_pageheader_t *pageheader = NULL;
+    H5FD_pb_pageheader_t *ret_value = NULL;
+
+    FUNC_ENTER_PACKAGE
+
+    assert( file_ptr );
+    assert( H5FD_PB_MAGIC == file_ptr->magic );
+
+
+    if ( file_ptr->rp_pageheader_count < H5FD_PB_DEFAULT_MAX_NUM_PAGES ) {
+
+        if ( NULL == (pageheader = H5FD__pb_alloc_and_init_pageheader( file_ptr, addr, hash_code )) )
+            HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "unable to allocate page");
+
+    }
+
+    else {
+
+        pageheader = H5FD__pb_rp_evict_pageheader( file_ptr, addr, hash_code );
+
+        if ( NULL == pageheader ) {
+            HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "unable to allocate page");
+        }
+    }
+
+    assert( pageheader );
+    assert( pageheader->magic == H5FD_PB_PAGEHEADER_MAGIC );
+    assert( pageheader->hash_code == hash_code );
+    assert( pageheader->page_addr == addr );
+
+    assert( 0 == ( pageheader->flags & H5FD_PB_BUSY_FLAG ));
+    assert( 0 == ( pageheader->flags & H5FD_PB_INVALID_FLAG ));
+    assert( 0 == ( pageheader->flags & H5FD_PB_READ_FLAG ));
+    assert( 0 == ( pageheader->flags & H5FD_PB_WRITE_FLAG ));
+    assert( 0 == ( pageheader->flags & H5FD_PB_DIRTY_FLAG ));
+
+    pageheader->type = type;
+
+    if (H5FDread( file_ptr->file, type, dxpl_id, addr, file_ptr->fa.page_size, pageheader->page ) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_READERROR, NULL, "Reading from underlying VFD failed");
+
+    if (H5FD__pb_rp_insert_pageheader( file_ptr, pageheader ) != 0) {
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, NULL, "Pageheader could not be inserted into rp");
+    }
+
+    if (H5FD__pb_ht_insert_pageheader( file_ptr, pageheader ) != 0) {
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, NULL, "Pageheader could not be inserted into ht");
+    }
+
+    assert( pageheader->magic == H5FD_PB_PAGEHEADER_MAGIC );
+
+    file_ptr->num_pages++;
+
+    ret_value = pageheader;
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_get_pageheader() */
+
+
+
+
+/*******************************/
+/**** Hash Table Functions *****/
+/*******************************/
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__pb_calc_hash_code
+ *
+ * Purpose:     Generates a hash code for a H5FD_pb_pageheader_t structure 
+ *              based on the address (addr) of the page contained within that
+ *              structure, to determine which bucket to store the pageheader.
+ *
+ *              The hash code is calculated by discarding the lower order bits
+ *              of the addr (which is based on the page size) and right
+ *              shifting the remaining bits. This gives us the page number
+ *              (this method is more efficient that division). The page number
+ *              is then taken modulo by the number of buckets in the hash table
+ *              to get the hash code for that page.
+ *
+ * Return:      uint32_t hash_code
+ *
+ *-----------------------------------------------------------------------------
+ */
+uint32_t
+H5FD__pb_calc_hash_code(H5FD_pb_t *file_ptr, haddr_t addr)
+{
+    uint32_t        hash_code;
+    uint64_t        lower_order_bits;
+    uint64_t        page_number;
+    uint32_t        ret_value;
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+    assert( file_ptr );
+    assert( H5FD_PB_MAGIC == file_ptr->magic );
+
+    /* Gets the number of lower order bits based on the page size */
+    lower_order_bits = (uint64_t)llrint(ceil(log2((double)(file_ptr->fa.page_size))));
+
+    /* Discards the lower order bits and right shits the remaing bits */
+    page_number = addr >> lower_order_bits;
+
+    /* Mod the page number by the number of buckets in the hash table */
+    hash_code = page_number % H5FD_PB_DEFAULT_NUM_HASH_BUCKETS;
+
+    ret_value = hash_code;
+
+    FUNC_LEAVE_NOAPI(ret_value);
+
+} /* end H5FD__pb_calc_hash_code() */
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__pb_ht_insert_pageheader
+ *
+ * Purpose:     Inserts a H5FD_pb_pageheader_t structure into the hash table 
+ *              (ht) at the bucket index that matches the hash code. Currently 
+ *              this insert function works by prepending the 
+ *              H5FD_pb_pageheader_t structure.
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+herr_t
+H5FD__pb_ht_insert_pageheader(H5FD_pb_t *file_ptr, 
+                              H5FD_pb_pageheader_t *pageheader)
+{
+    uint32_t                hash_code = pageheader->hash_code;
+    H5FD_pb_pageheader_t  **bucket_head_ptr = &file_ptr->ht_bucket[hash_code].ht_head_ptr;
+    int32_t               *num_pages_in_bucket = &file_ptr->ht_bucket[hash_code].num_pages_in_bucket;
+
+    herr_t ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+    assert(file_ptr);
+    assert(H5FD_PB_MAGIC == file_ptr->magic);
+    assert(pageheader);
+    assert(H5FD_PB_PAGEHEADER_MAGIC == pageheader->magic);
+
+    /* If the bucket is empty, the pageheader is inserted as the head */
+    if ( *bucket_head_ptr == NULL ) {
+
+        *bucket_head_ptr = pageheader;
+    }
+
+    else {
+
+        (*bucket_head_ptr)->ht_prev_ptr = pageheader;
+
+        pageheader->ht_next_ptr = *bucket_head_ptr;
+        
+        *bucket_head_ptr = pageheader;
+    }
+
+    /* stats update*/
+    assert(0 <= (*num_pages_in_bucket));
+
+    (*num_pages_in_bucket)++;
+
+    if ( (*num_pages_in_bucket) > (int32_t)(file_ptr->largest_num_in_bucket)) {
+
+        file_ptr->largest_num_in_bucket = (size_t)(*num_pages_in_bucket);
+
+    }
+    /* end stats update */
+
+    FUNC_LEAVE_NOAPI(ret_value);
+
+} /* end H5FD__pb_ht_insert_pageheader() */
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__pb_ht_remove_pageheader
+ *
+ * Purpose:     Removes a H5FD_pb_pageheader_t structure from the hash table
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+herr_t
+H5FD__pb_ht_remove_pageheader(H5FD_pb_t *file_ptr, 
+                              H5FD_pb_pageheader_t *pageheader)
+{
+    uint32_t               hash_code = pageheader->hash_code;
+    H5FD_pb_pageheader_t **bucket_head_ptr = &file_ptr->ht_bucket[hash_code].ht_head_ptr;
+    int32_t               *num_pages_in_bucket = &file_ptr->ht_bucket[hash_code].num_pages_in_bucket;
+
+
+    herr_t                ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+    assert(file_ptr);
+    assert(H5FD_PB_MAGIC == file_ptr->magic);
+    assert(pageheader);
+    assert(H5FD_PB_PAGEHEADER_MAGIC == pageheader->magic);
+
+    assert(*bucket_head_ptr);
+    assert(0 < *num_pages_in_bucket);
+
+    if ( pageheader->ht_next_ptr ) {
+
+        pageheader->ht_next_ptr->ht_prev_ptr = pageheader->ht_prev_ptr;
+    }
+
+    if ( pageheader->ht_prev_ptr ) {
+
+        pageheader->ht_prev_ptr->ht_next_ptr = pageheader->ht_next_ptr;
+    }
+
+    if ( pageheader == *bucket_head_ptr ) {
+
+        *bucket_head_ptr = pageheader->ht_next_ptr;
+    }
+
+    (*num_pages_in_bucket)--;
+
+
+    pageheader->ht_prev_ptr = NULL;
+    pageheader->ht_next_ptr = NULL;
+
+    FUNC_LEAVE_NOAPI(ret_value);
+
+} /* end H5FD__pb_ht_remove_pageheader() */
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__pb_ht_search_pageheader
+ *
+ * Purpose:     Searches the hash table (ht) for a H5FD_pb_pageheader_t 
+ *              structure based on its address (addr) and hash_code. The 
+ *              hash_code determines which bucket (the index of the hash table)
+ *              to search, and the addr is unique to that page specifying
+ *              exactly which page to search for. If the H5FD_pb_pageheader_t 
+ *              with that hash_code and addr is found, it is returned, 
+ *              otherwise NULL is returned.
+ *
+ * Return:      Success:    A pointer to the H5FD_pb_pageheader_t structure.
+ *              Failure:    NULL
+ *-----------------------------------------------------------------------------
+ */
+H5FD_pb_pageheader_t*
+H5FD__pb_ht_search_pageheader(H5FD_pb_t *file_ptr, haddr_t addr, 
+                              uint32_t hash_code)
+{
+    int32_t               search_depth; /* Stats varaibles */
+    H5FD_pb_pageheader_t *pageheader = NULL;
+    H5FD_pb_pageheader_t *ret_value = NULL;
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+    assert( file_ptr );
+    assert( H5FD_PB_MAGIC == file_ptr->magic );
+
+    pageheader = file_ptr->ht_bucket[hash_code].ht_head_ptr;
+    search_depth = 0;
+
+    while ( pageheader != NULL ) {
+
+        assert( pageheader );
+        assert( pageheader->magic == H5FD_PB_PAGEHEADER_MAGIC );
+
+        search_depth++;
+
+        if ( pageheader->page_addr == addr ) {
+
+            ret_value = pageheader;
+
+            /* stats update */
+            file_ptr->num_hits++;
+            file_ptr->total_success_depth += (size_t)search_depth;
+            /* end stats update*/
+            break;
+        }
+
+        pageheader = pageheader->ht_next_ptr;
+
+    } /* end while */
+
+    if ( pageheader ) {
+
+        assert( file_ptr->ht_bucket[hash_code].num_pages_in_bucket > 0 );
+        assert( pageheader->magic == H5FD_PB_PAGEHEADER_MAGIC );
+    }
+
+
+    /* stats update */
+    if ( (size_t)search_depth > file_ptr->max_search_depth ) {
+
+        file_ptr->max_search_depth = (size_t)search_depth;
+    }
+
+    if ( ret_value == NULL ) {
+
+        file_ptr->num_misses++;
+        file_ptr->total_fail_depth += (size_t)search_depth;
+    }
+    /* End stats update*/
+
+    FUNC_LEAVE_NOAPI(ret_value);
+
+} /* end H5FD__pb_ht_search_pageheader() */
+
+
+
+/*******************************************/
+/**** Replacement Policy List Functions ****/
+/*******************************************/
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__pb_rp_insert_pageheader
+ *
+ * Purpose:     Inserts a H5FD_pb_pageheader_t strucutre into the replacement 
+ *              policy (rp) list according to the selected rp or other factors 
+ *              (i.e. invalid flag will cause the H5FD_pb_pageheader_t to be 
+ *              inserted to the tail, making it the next evicted).
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+herr_t
+H5FD__pb_rp_insert_pageheader(H5FD_pb_t *file_ptr, 
+                              H5FD_pb_pageheader_t *pageheader)
+{
+    herr_t ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    assert( file_ptr );
+    assert( H5FD_PB_MAGIC == file_ptr->magic );
+    assert( pageheader );
+    assert( H5FD_PB_PAGEHEADER_MAGIC == pageheader->magic );
+
+    /* If the page is invalid, it's appended to be evicted next */
+    if ( pageheader->flags & H5FD_PB_INVALID_FLAG )
+    {
+        H5FD__pb_rp_append_pageheader( file_ptr, pageheader );
+
+        assert( pageheader->rp_next_ptr == NULL );
+        assert( file_ptr->rp_tail_ptr = pageheader );
+    }
+
+    else if ( file_ptr->fa.rp == 0 || file_ptr->fa.rp == 1 ) {
+
+        H5FD__pb_rp_prepend_pageheader( file_ptr, pageheader );
+
+        assert( pageheader->rp_prev_ptr == NULL );
+        assert( file_ptr->rp_head_ptr = pageheader );
+    }
+
+    else {
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, FAIL, "unsupported replacement policy");
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value);
+
+} /* end H5FD__pb_rp_insert_pageheader() */
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__pb_rp_prepend_pageheader
+ *
+ * Purpose:     Prepends a H5FD_pb_pageheader_t structure to the replacement 
+ *              policy (inserts it at the head of the list to be evicted last).
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+herr_t
+H5FD__pb_rp_prepend_pageheader(H5FD_pb_t *file_ptr, 
+                                H5FD_pb_pageheader_t *pageheader)
+{
+    herr_t ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+    assert( file_ptr );
+    assert( H5FD_PB_MAGIC == file_ptr->magic );
+    assert( pageheader );
+    assert( H5FD_PB_PAGEHEADER_MAGIC == pageheader->magic );
+
+
+    if ( file_ptr->rp_head_ptr == NULL ) {
+
+        file_ptr->rp_head_ptr = pageheader;
+
+        file_ptr->rp_tail_ptr = pageheader;
+    }
+
+
+    else {
+
+        file_ptr->rp_head_ptr->rp_prev_ptr = pageheader;
+
+        pageheader->rp_next_ptr = file_ptr->rp_head_ptr;
+
+        file_ptr->rp_head_ptr = pageheader;
+    }
+
+    file_ptr->rp_pageheader_count++; 
+
+    FUNC_LEAVE_NOAPI(ret_value);
+
+} /* end H5FD__pb_rp_prepend_pageheader() */
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__pb_rp_append_pageheader
+ *
+ * Purpose:     Appends a H5FD_pb_pageheader_t structure to the replacement 
+ *              policy (inserts it at the tail of the list to be evicted next).
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+herr_t
+H5FD__pb_rp_append_pageheader(H5FD_pb_t *file_ptr, 
+                              H5FD_pb_pageheader_t *pageheader)
+{
+    herr_t ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+    assert( file_ptr );
+    assert( H5FD_PB_MAGIC == file_ptr->magic );
+    assert( pageheader );
+    assert( H5FD_PB_PAGEHEADER_MAGIC == pageheader->magic );
+
+    if (file_ptr->rp_tail_ptr == NULL) {
+        
+        file_ptr->rp_head_ptr = pageheader;
+        file_ptr->rp_tail_ptr = pageheader;
+    }
+
+    else {
+
+        file_ptr->rp_tail_ptr->rp_next_ptr = pageheader;
+
+        pageheader->rp_prev_ptr = file_ptr->rp_tail_ptr;
+        
+        file_ptr->rp_tail_ptr = pageheader;
+    }
+
+    file_ptr->rp_pageheader_count++;
+
+    FUNC_LEAVE_NOAPI(ret_value);
+
+} /* end H5FD__pb_rp_append_pageheader() */
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__pb_rp_remove_pageheader
+ *
+ * Purpose:     Removes a H5FD_pb_pageheader_t strucutre from the replacement 
+ *              policy list.
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+herr_t
+H5FD__pb_rp_remove_pageheader(H5FD_pb_t * file_ptr, 
+                                H5FD_pb_pageheader_t *pageheader)
+{
+    herr_t ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+    assert( file_ptr );
+    assert( H5FD_PB_MAGIC == file_ptr->magic );
+    assert( pageheader );
+    assert( H5FD_PB_PAGEHEADER_MAGIC == pageheader->magic );
+
+    if ( pageheader->rp_next_ptr ) {
+
+        pageheader->rp_next_ptr->rp_prev_ptr = pageheader->rp_prev_ptr;
+    }
+
+    if ( pageheader->rp_prev_ptr ) {
+
+        pageheader->rp_prev_ptr->rp_next_ptr = pageheader->rp_next_ptr;
+    }
+
+    if ( file_ptr->rp_head_ptr == pageheader ) {
+
+        file_ptr->rp_head_ptr = pageheader->rp_next_ptr;
+    }
+
+    if ( file_ptr->rp_tail_ptr == pageheader ) {
+
+        file_ptr->rp_tail_ptr = pageheader->rp_prev_ptr;
+    }
+
+    pageheader->rp_prev_ptr = NULL;
+    pageheader->rp_next_ptr = NULL;
+
+    file_ptr->rp_pageheader_count--;
+
+    assert( file_ptr->rp_pageheader_count >= 0 );
+
+    FUNC_LEAVE_NOAPI(ret_value);
+
+} /* end H5FD__pb_rp_remove_pageheader() */
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__pb_touch_pageheader
+ *
+ * Purpose:     Updates a H5FD_pb_pageheader_t structure's position in the 
+ *              replacement policy (rp), depending on the selected rp.
+ * 
+ *              Current supported replacement policies:
+ *                RP 0 == LRU (least recently used)
+ *                RP 1 == FIFO (first in first out)  
+ *                
+ *              NOTE: FIFO does not call this function because touch doesn't
+ *              affect FIFO order
+ *
+ * Return:      SUCCEED/FAIL
+ *-----------------------------------------------------------------------------
+ */
+herr_t
+H5FD__pb_rp_touch_pageheader(H5FD_pb_t *file_ptr, 
+                             H5FD_pb_pageheader_t *pageheader)
+{
+    herr_t ret_value = SUCCEED;
+
+    FUNC_ENTER_PACKAGE
+
+    assert( file_ptr );
+    assert( H5FD_PB_MAGIC == file_ptr->magic );
+    assert( pageheader );
+    assert( H5FD_PB_PAGEHEADER_MAGIC == pageheader->magic );
+
+    /* Replacement Policy 0 == LRU (least recently used) */
+    if ( 0 == file_ptr->fa.rp ) {
+
+        H5FD__pb_rp_remove_pageheader( file_ptr, pageheader );
+        H5FD__pb_rp_prepend_pageheader( file_ptr, pageheader );
+    }
+
+    else {
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, FAIL, "unsupported replacement policy");
+    }
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_touch_pageheader() */
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FD__pb_rp_evict_pageheader
+ *
+ * Purpose:     When the maximum number of pages (and therefore 
+ *              H5FD_pb_pageheader_t structures) has been reached, and a new
+ *              page must be added to the page buffer, the replacement policy
+ *              selects an eviction candidate, if dirty flushes the associated 
+ *              page evicts it, and re-uses the H5FD_pb_pageheader_t 
+ *              structure to store the new page in the page buffer.
+ *              
+ *              Replacement Policy 0 == LRU (least recently used)
+ *              Replacement Policy 1 == FIFO (first in first out)
+ *
+ * Return:      void
+ *-----------------------------------------------------------------------------
+ */
+H5FD_pb_pageheader_t*
+H5FD__pb_rp_evict_pageheader(H5FD_pb_t *file_ptr, haddr_t addr, uint32_t hash_code)
+{
+    H5FD_pb_pageheader_t *pageheader = NULL;
+    H5FD_pb_pageheader_t *ret_value = NULL;
+
+    FUNC_ENTER_PACKAGE
+
+    assert( file_ptr );
+    assert( H5FD_PB_MAGIC == file_ptr->magic );
+
+
+    /** 
+     * rp_policy:
+     * 0 == LRU 
+     * 1 == FIFO
+     */   
+    /* If the policy is LRU or FIFO the eviction is done the same way */
+    if ( file_ptr->rp_policy == 0 || file_ptr->rp_policy == 1 ) {
+
+        pageheader = file_ptr->rp_tail_ptr;
+
+        assert( pageheader);
+        assert( pageheader->magic == H5FD_PB_PAGEHEADER_MAGIC );
+
+        /* If busy check the next H5FD_pb_pageheader_t structure in the list */
+        while ( pageheader->flags == H5FD_PB_BUSY_FLAG ) {
+
+            pageheader = pageheader->rp_prev_ptr;
+        }
+
+        /* If dirty flush to file/lower VFD before evicting */
+        if ( pageheader->flags == H5FD_PB_DIRTY_FLAG ) {
+
+            H5FD__pb_flush_page(file_ptr, H5P_DEFAULT, pageheader);
+
+            assert( pageheader->magic == H5FD_PB_PAGEHEADER_MAGIC );
+        } 
+
+        if ( H5FD__pb_rp_remove_pageheader( file_ptr, pageheader ) != 0 ) 
+            HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, NULL, "Pageheader could not be removed from rp");
+
+        /** 
+         * If the H5FD_pb_pageheader_t structure is valid it must be removed from the hash table.
+         * Otherwise it was removed when it was invalidated.
+         */
+        if ( 0 == ( pageheader->flags & H5FD_PB_INVALID_FLAG )) { 
+
+            if ( H5FD__pb_ht_remove_pageheader( file_ptr, pageheader ) != 0 )
+                HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, NULL, "Pageheader could not be removed from ht");
+        }
+    }
+
+    else {
+
+        HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, NULL, "Replacement policy not supported");
+    }
+
+    pageheader->flags       = 0;
+    pageheader->hash_code   = hash_code;
+    pageheader->page_addr = addr;
+
+    file_ptr->total_evictions++;
+
+    ret_value = pageheader;
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FD__pb_rp_evict_pageheader() */
+
+
+
+
+/****************************/
+/**** Testing Functions *****/
+/****************************/
+
+
+/*-----------------------------------------------------------------------------
+ * Function:    H5FDpb_rp_eviction_check
+ *
+ * Purpose:     Testing function to return the H5FD_pb_pageheader_t structure 
+ *              being evicted to compared it to the H5FD_pb_pageheader_t
+ *              expected to be evicted, ensuring the correct instance of 
+ *              H5FD_pb_pageheader_t is the one being evicted.
+ *
+ * Return:      Success:    A pointer to the H5FD_pb_pageheader_t structure.
+ * 
+ *              Failure:    NULL
+ *-----------------------------------------------------------------------------
+ */
+haddr_t*
+H5FD__pb_rp_eviction_check(H5FD_t *_file, haddr_t *current_rp_addrs)
+{
+    H5FD_pb_t            *file_ptr = (H5FD_pb_t *)_file;
+    H5FD_pb_pageheader_t *pageheader = NULL;
+    int32_t               i;
+    haddr_t              *ret_value = NULL;
+
+    FUNC_ENTER_PACKAGE_NOERR
+
+    assert( file_ptr );
+    assert( H5FD_PB_MAGIC == file_ptr->magic );
+
+    pageheader = file_ptr->rp_tail_ptr;
+
+    i = 0;
+    while ( pageheader ) {
+
+        assert( pageheader) ;
+        assert( pageheader->magic == H5FD_PB_PAGEHEADER_MAGIC );
+
+        current_rp_addrs[i] = pageheader->page_addr;
+        i++;
+        pageheader = pageheader->rp_prev_ptr;
+
+    }
+
+    ret_value = current_rp_addrs;
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* end H5FDpb_rp_eviction_check() */
+
+
+

--- a/hdf5/hdf5-1.14.6/src/H5FDpb.h
+++ b/hdf5/hdf5-1.14.6/src/H5FDpb.h
@@ -1,0 +1,151 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by Lifeboat, LLC                                                *
+ * All rights reserved.                                                      *
+ *                                                                           * 
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/*
+ * Purpose:	The public header file for the page buffer file driver (VFD)
+ */
+
+#ifndef H5FDpb_H
+#define H5FDpb_H
+
+/** Semi-unique constant used to help identify Page Buffer Config structure pointers */
+#define H5FD_PB_CONFIG_MAGIC                0x504200
+
+/** Semi-unique constant used to help identify Page Buffer structure pointers */
+#define H5FD_PB_MAGIC                       0x504201
+
+/** Initializer for the page buffer VFD */
+#define H5FD_PB (H5FDperform_init(H5FD_pb_init))
+
+/** Identifier for the page buffer VFD */
+#define H5FD_PB_VALUE H5_VFD_PB
+
+/** The version of the H5FD_pb_vfd_config_t structure used */
+#define H5FD_CURR_PB_VFD_CONFIG_VERSION 	   1
+
+/** The default page buffer page size in bytes */
+#define H5FD_PB_DEFAULT_PAGE_SIZE		4096
+
+/** The default maximum number of pages resident in the page buffer at any one time */
+#define H5FD_PB_DEFAULT_MAX_NUM_PAGES	  	  64
+
+/** The default default replacement policy to be used by the page buffer */
+#define H5FD_PB_DEFAULT_REPLACEMENT_POLICY 	   0 /* 0 = Least Recently Used (LRU) */
+
+/** Testing is false (turned off) by default */
+#define H5FD_PB_DEFAULT_TESTING_OFF			false
+
+
+/******************************************************************************
+ * Structure:   H5FD_pb_vfd_config_t
+ *
+ * Description:
+ *
+ * Configuration options for setting up the page buffer VFD.
+ *
+ * Fields:
+ *
+ * magic (int):
+ *      Magic number to identify this struct. Must be H5FD_PB_CONFIG_MAGIC.
+ *
+ * version (unsigned int):
+ *      Version number of this struct. Currently must be
+ *      H5FD_CURR_PB_VFD_CONFIG_VERSION.
+ *
+ * page_size (size_t):
+ *      Size of pages in the page buffer.
+ *
+ * max_num_pages (int):
+ *      Maximum number of pages resident in the page buffer.
+ *
+ * rp (int):
+ *      Integer code specifying the replacement policy to be used by the page
+ *      buffer.
+ *      Integer code: 0 = Least Recently Used (LRU)
+ *                    1 = First In First Out (FIFO)
+ * 
+ * fapl_id (hid_t):
+ *      File-access property list for setting up the VFD stack  
+ * 
+ * testing (bool):
+ *      Flag to indicate if the page buffer VFD is being used for testing.
+ *      If true, testing functions are enabled.
+ *
+ ******************************************************************************
+ */
+//! <!-- [H5FD_pb_vfd_config_t_snip] -->
+/**
+ * Configuration options for setting up the page buffer VFD
+ */
+typedef struct H5FD_pb_vfd_config_t {
+    int32_t      magic;         /**< Magic number to identify this struct. Must be \p H5FD_PB_CONFIG_MAGIC. */
+    unsigned int version;       /**< Version number of this struct. Currently must be \p
+                                     H5FD_CURR_PB_VFD_CONFIG_VERSION. */
+    size_t       page_size;     /**< Size of pages in the page buffer. */
+    size_t       max_num_pages; /**< Maximum number of pages resident in the page buffer. */
+    int32_t      rp;            /**< Integer code specifying the replacement policy to be used \p
+                                     by the page buffer. */
+    hid_t       fapl_id;        /**< File-access property list for setting up the VFD stack below the page \p
+                                     buffer VFD. Can be H5P_DEFAULT. */
+    bool        testing;        /**< Flag to indicate if the page buffer VFD is being used for testing. */
+} H5FD_pb_vfd_config_t;
+//! <!-- [H5FD_pb_vfd_config_t_snip] -->
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @private
+ *
+ * \brief Private initializer for the page buffer VFD
+ */
+H5_DLL hid_t H5FD_pb_init(void);
+
+/**
+ * \ingroup FAPL
+ *
+ * \brief Sets the file access property list to use the page buffer driver
+ *
+ * \fapl_id
+ * \param[in] config_ptr Configuration options for the VFD
+ * \returns \herr_t
+ *
+ * \details H5Pset_fapl_pb() sets the file access property list identifier,
+ *          \p fapl_id, to use the page buffer driver.
+ *
+ *          The page buffer VFD converts randon I/O requests to paged I/O
+ *          requests as required, and then relays the paged I/O requests to 
+ *	    the underlying VFD stack.
+ *
+ * \since 1.10.7, 1.12.1
+ */
+H5_DLL herr_t H5Pset_fapl_pb(hid_t fapl_id, H5FD_pb_vfd_config_t *config_ptr);
+
+/**
+ * \ingroup FAPL
+ *
+ * \brief Gets bage buffer VFD configuration properties from the the file access property list
+ *
+ * \fapl_id
+ * \param[out] config_ptr Configuration options for the VFD
+ * \returns \herr_t
+ *
+ * \details H5Pget_fapl_pb() retrieves a copy of the H5FD_pb_vfd_config_t from the 
+ *          indicated FAPL.
+ *
+ *          The page buffer VFD converts randon I/O requests to paged I/O
+ *          requests as required, and then relays the paged I/O requests to 
+ *	    the underlying VFD stack.
+ *
+ * \since 1.10.7, 1.12.1
+ */
+H5_DLL herr_t H5Pget_fapl_pb(hid_t fapl_id, H5FD_pb_vfd_config_t *config_ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/hdf5/hdf5-1.14.6/src/H5FDpublic.h
+++ b/hdf5/hdf5-1.14.6/src/H5FDpublic.h
@@ -42,6 +42,8 @@
 #define H5_VFD_SUBFILING ((H5FD_class_value_t)(12))
 #define H5_VFD_IOC       ((H5FD_class_value_t)(13))
 #define H5_VFD_ONION     ((H5FD_class_value_t)(14))
+#define H5_VFD_PB        ((H5FD_class_value_t)(15))
+#define H5_VFD_CRYPT     ((H5FD_class_value_t)(16))
 
 /* VFD IDs below this value are reserved for library use. */
 #define H5_VFD_RESERVED 256

--- a/hdf5/hdf5-1.14.6/src/H5Pfapl.c
+++ b/hdf5/hdf5-1.14.6/src/H5Pfapl.c
@@ -45,6 +45,8 @@
 #include "H5FDlog.h"
 #include "H5FDfamily.h"
 #include "H5FDmulti.h"
+#include "H5FDpb.h"    /* page buffer -- converts random I/O to paged I/O */
+#include "H5FDcrypt.h" /* encryption VFD -- encrypts / decrypts paged I/O */
 #include "H5FDstdio.h" /* Standard C buffered I/O                  */
 #include "H5FDsplitter.h"
 #ifdef H5_HAVE_PARALLEL
@@ -426,7 +428,6 @@ static herr_t H5P__facc_mpi_info_close(const char *name, size_t size, void *valu
 #endif /* H5_HAVE_PARALLEL */
 
 /* Internal routines */
-static herr_t H5P__facc_set_def_driver_check_predefined(const char *driver_name, hid_t *driver_id);
 
 /*********************/
 /* Package Variables */
@@ -885,7 +886,7 @@ H5P__facc_set_def_driver(void)
         } /* end else-if */
         else {
             /* Check for VFL drivers that ship with the library */
-            if (H5P__facc_set_def_driver_check_predefined(driver_env_var, &driver_id) < 0)
+            if (H5P_facc_set_def_driver_check_predefined(driver_env_var, &driver_id) < 0)
                 HGOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL, "can't check for predefined VFL driver name");
             else if (driver_id > 0) {
                 if (H5I_inc_ref(driver_id, true) < 0)
@@ -938,7 +939,7 @@ done:
 } /* end H5P__facc_set_def_driver() */
 
 /*-------------------------------------------------------------------------
- * Function:    H5P__facc_set_def_driver_check_predefined
+ * Function:    H5P_facc_set_def_driver_check_predefined
  *
  * Purpose:     Checks a given driver name against a list of predefined
  *              names for VFL drivers that are internal to HDF5. If a name
@@ -950,12 +951,12 @@ done:
  *
  *-------------------------------------------------------------------------
  */
-static herr_t
-H5P__facc_set_def_driver_check_predefined(const char *driver_name, hid_t *driver_id)
+herr_t
+H5P_facc_set_def_driver_check_predefined(const char *driver_name, hid_t *driver_id)
 {
     herr_t ret_value = SUCCEED;
 
-    FUNC_ENTER_PACKAGE
+    FUNC_ENTER_NOAPI(FAIL)
 
     assert(driver_name);
     assert(driver_id);
@@ -1043,6 +1044,17 @@ H5P__facc_set_def_driver_check_predefined(const char *driver_name, hid_t *driver
 #else
         HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "Windows VFD is not enabled");
 #endif
+
+#if 1 /* extend function for page buffer and encryption VFDs.  Not sure if this code will stay */
+    }
+    else if (!strcmp(driver_name, "page_buffer")) {
+        if ((*driver_id = H5FD_PB) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_UNINITIALIZED, FAIL, "couldn't initialize page buffer VFD");
+    }
+    else if (!strcmp(driver_name, "encryption_VFD")) {
+        if ((*driver_id = H5FD_CRYPT) < 0)
+            HGOTO_ERROR(H5E_VFL, H5E_UNINITIALIZED, FAIL, "couldn't initialize log VFD");
+#endif
     }
     else {
         *driver_id = H5I_INVALID_HID;
@@ -1050,7 +1062,7 @@ H5P__facc_set_def_driver_check_predefined(const char *driver_name, hid_t *driver
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
-} /* end H5P__facc_set_def_driver_check_predefined() */
+} /* end H5P_facc_set_def_driver_check_predefined() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5Pset_alignment

--- a/hdf5/hdf5-1.14.6/src/H5Pprivate.h
+++ b/hdf5/hdf5-1.14.6/src/H5Pprivate.h
@@ -200,6 +200,7 @@ H5_DLL herr_t H5P_get_filter_by_id(H5P_genplist_t *plist, H5Z_filter_t id, unsig
                                    size_t *cd_nelmts, unsigned cd_values[], size_t namelen, char name[],
                                    unsigned *filter_config);
 H5_DLL htri_t H5P_filter_in_pline(H5P_genplist_t *plist, H5Z_filter_t id);
+H5_DLL herr_t H5P_facc_set_def_driver_check_predefined(const char *driver_name, hid_t *driver_id);
 
 /* Query internal fields of the property list struct */
 H5_DLL hid_t           H5P_get_plist_id(const H5P_genplist_t *plist);

--- a/hdf5/hdf5-1.14.6/src/Makefile.am
+++ b/hdf5/hdf5-1.14.6/src/Makefile.am
@@ -53,9 +53,9 @@ libhdf5_la_SOURCES= H5.c H5build_settings.c H5checksum.c H5dbg.c H5system.c \
         H5FA.c H5FAcache.c H5FAdbg.c H5FAdblock.c H5FAdblkpage.c H5FAhdr.c \
         H5FAint.c H5FAstat.c H5FAtest.c \
         H5CL.c \
-        H5FD.c H5FDcore.c H5FDfamily.c H5FDint.c H5FDlog.c H5FDmulti.c \
+        H5FD.c H5FDcore.c H5FDcrypt.c H5FDfamily.c H5FDint.c H5FDlog.c H5FDmulti.c \
         H5FDonion.c H5FDonion_header.c H5FDonion_history.c H5FDonion_index.c \
-        H5FDperform.c H5FDsec2.c H5FDspace.c \
+        H5FDpb.c H5FDperform.c H5FDsec2.c H5FDspace.c \
         H5FDsplitter.c H5FDstdio.c H5FDtest.c H5FDwindows.c \
         H5FL.c H5FO.c H5FS.c H5FScache.c H5FSdbg.c H5FSint.c H5FSsection.c \
         H5FSstat.c H5FStest.c \

--- a/hdf5/hdf5-1.14.6/src/Makefile.in
+++ b/hdf5/hdf5-1.14.6/src/Makefile.in
@@ -230,56 +230,56 @@ am__libhdf5_la_SOURCES_DIST = H5.c H5build_settings.c H5checksum.c \
 	H5Fquery.c H5Fsfile.c H5Fspace.c H5Fsuper.c H5Fsuper_cache.c \
 	H5Ftest.c H5FA.c H5FAcache.c H5FAdbg.c H5FAdblock.c \
 	H5FAdblkpage.c H5FAhdr.c H5FAint.c H5FAstat.c H5FAtest.c \
-	H5CL.c H5FD.c H5FDcore.c H5FDfamily.c H5FDint.c H5FDlog.c \
-	H5FDmulti.c H5FDonion.c H5FDonion_header.c H5FDonion_history.c \
-	H5FDonion_index.c H5FDperform.c H5FDsec2.c H5FDspace.c \
-	H5FDsplitter.c H5FDstdio.c H5FDtest.c H5FDwindows.c H5FL.c \
-	H5FO.c H5FS.c H5FScache.c H5FSdbg.c H5FSint.c H5FSsection.c \
-	H5FSstat.c H5FStest.c H5G.c H5Gbtree2.c H5Gcache.c \
-	H5Gcompact.c H5Gdense.c H5Gdeprec.c H5Gent.c H5Gint.c \
-	H5Glink.c H5Gloc.c H5Gname.c H5Gnode.c H5Gobj.c H5Goh.c \
-	H5Groot.c H5Gstab.c H5Gtest.c H5Gtraverse.c H5HF.c \
-	H5HFbtree2.c H5HFcache.c H5HFdbg.c H5HFdblock.c H5HFdtable.c \
-	H5HFhdr.c H5HFhuge.c H5HFiblock.c H5HFiter.c H5HFman.c \
-	H5HFsection.c H5HFspace.c H5HFstat.c H5HFtest.c H5HFtiny.c \
-	H5HG.c H5HGcache.c H5HGdbg.c H5HGquery.c H5HL.c H5HLcache.c \
-	H5HLdbg.c H5HLint.c H5HLprfx.c H5HLdblk.c H5I.c H5Idbg.c \
-	H5Iint.c H5Itest.c H5L.c H5Ldeprec.c H5Lexternal.c H5Lint.c \
-	H5M.c H5MF.c H5MFaggr.c H5MFdbg.c H5MFsection.c H5MM.c H5O.c \
-	H5Odeprec.c H5Oainfo.c H5Oalloc.c H5Oattr.c H5Oattribute.c \
-	H5Obogus.c H5Obtreek.c H5Ocache.c H5Ocache_image.c H5Ochunk.c \
-	H5Ocont.c H5Ocopy.c H5Ocopy_ref.c H5Odbg.c H5Odrvinfo.c \
-	H5Odtype.c H5Oefl.c H5Ofill.c H5Oflush.c H5Ofsinfo.c \
-	H5Oginfo.c H5Oint.c H5Olayout.c H5Olinfo.c H5Olink.c \
-	H5Omessage.c H5Omtime.c H5Oname.c H5Onull.c H5Opline.c \
-	H5Orefcount.c H5Osdspace.c H5Oshared.c H5Oshmesg.c H5Ostab.c \
-	H5Otest.c H5Ounknown.c H5P.c H5Pacpl.c H5Pdapl.c H5Pdcpl.c \
-	H5Pdeprec.c H5Pdxpl.c H5Pencdec.c H5Pfapl.c H5Pfcpl.c \
-	H5Pfmpl.c H5Pgcpl.c H5Pint.c H5Plapl.c H5Plcpl.c H5Pmapl.c \
-	H5Pmcpl.c H5Pocpl.c H5Pocpypl.c H5Pstrcpl.c H5Ptest.c H5PB.c \
-	H5PL.c H5PLint.c H5PLpath.c H5PLplugin_cache.c H5R.c \
-	H5Rdeprec.c H5Rint.c H5UC.c H5RS.c H5S.c H5Sall.c H5Sdbg.c \
-	H5Sdeprec.c H5Shyper.c H5Snone.c H5Spoint.c H5Sselect.c \
-	H5Stest.c H5SL.c H5SM.c H5SMbtree2.c H5SMcache.c H5SMmessage.c \
-	H5SMtest.c H5T.c H5Tarray.c H5Tbit.c H5Tcommit.c H5Tcompound.c \
-	H5Tconv.c H5Tconv_integer.c H5Tconv_float.c H5Tconv_string.c \
-	H5Tconv_bitfield.c H5Tconv_compound.c H5Tconv_reference.c \
-	H5Tconv_enum.c H5Tconv_vlen.c H5Tconv_array.c H5Tcset.c \
-	H5Tdbg.c H5Tdeprec.c H5Tenum.c H5Tfields.c H5Tfixed.c \
-	H5Tfloat.c H5Tinit_float.c H5Tnative.c H5Toffset.c H5Toh.c \
-	H5Topaque.c H5Torder.c H5Tref.c H5Tpad.c H5Tprecis.c \
-	H5Tstrpad.c H5Tvisit.c H5Tvlen.c H5TS.c H5VL.c H5VLcallback.c \
-	H5VLdyn_ops.c H5VLint.c H5VLnative.c H5VLnative_attr.c \
-	H5VLnative_blob.c H5VLnative_dataset.c H5VLnative_datatype.c \
-	H5VLnative_file.c H5VLnative_group.c H5VLnative_link.c \
-	H5VLnative_introspect.c H5VLnative_object.c H5VLnative_token.c \
-	H5VLpassthru.c H5VLtest.c H5VM.c H5WB.c H5Z.c H5Zdeflate.c \
-	H5Zfletcher32.c H5Znbit.c H5Zshuffle.c H5Zscaleoffset.c \
-	H5Zszip.c H5Ztrans.c H5mpi.c H5ACmpio.c H5Cmpio.c H5Dmpio.c \
-	H5Fmpi.c H5FDmpi.c H5FDmpio.c H5Smpio.c \
-	H5FDsubfiling/H5FDsubfiling.c H5FDsubfiling/H5FDsubfile_int.c \
-	H5FDsubfiling/H5FDioc.c H5FDsubfiling/H5FDioc_int.c \
-	H5FDsubfiling/H5FDioc_threads.c \
+	H5CL.c H5FD.c H5FDcore.c H5FDcrypt.c H5FDfamily.c H5FDint.c \
+	H5FDlog.c H5FDmulti.c H5FDonion.c H5FDonion_header.c \
+	H5FDonion_history.c H5FDonion_index.c H5FDpb.c H5FDperform.c \
+	H5FDsec2.c H5FDspace.c H5FDsplitter.c H5FDstdio.c H5FDtest.c \
+	H5FDwindows.c H5FL.c H5FO.c H5FS.c H5FScache.c H5FSdbg.c \
+	H5FSint.c H5FSsection.c H5FSstat.c H5FStest.c H5G.c \
+	H5Gbtree2.c H5Gcache.c H5Gcompact.c H5Gdense.c H5Gdeprec.c \
+	H5Gent.c H5Gint.c H5Glink.c H5Gloc.c H5Gname.c H5Gnode.c \
+	H5Gobj.c H5Goh.c H5Groot.c H5Gstab.c H5Gtest.c H5Gtraverse.c \
+	H5HF.c H5HFbtree2.c H5HFcache.c H5HFdbg.c H5HFdblock.c \
+	H5HFdtable.c H5HFhdr.c H5HFhuge.c H5HFiblock.c H5HFiter.c \
+	H5HFman.c H5HFsection.c H5HFspace.c H5HFstat.c H5HFtest.c \
+	H5HFtiny.c H5HG.c H5HGcache.c H5HGdbg.c H5HGquery.c H5HL.c \
+	H5HLcache.c H5HLdbg.c H5HLint.c H5HLprfx.c H5HLdblk.c H5I.c \
+	H5Idbg.c H5Iint.c H5Itest.c H5L.c H5Ldeprec.c H5Lexternal.c \
+	H5Lint.c H5M.c H5MF.c H5MFaggr.c H5MFdbg.c H5MFsection.c \
+	H5MM.c H5O.c H5Odeprec.c H5Oainfo.c H5Oalloc.c H5Oattr.c \
+	H5Oattribute.c H5Obogus.c H5Obtreek.c H5Ocache.c \
+	H5Ocache_image.c H5Ochunk.c H5Ocont.c H5Ocopy.c H5Ocopy_ref.c \
+	H5Odbg.c H5Odrvinfo.c H5Odtype.c H5Oefl.c H5Ofill.c H5Oflush.c \
+	H5Ofsinfo.c H5Oginfo.c H5Oint.c H5Olayout.c H5Olinfo.c \
+	H5Olink.c H5Omessage.c H5Omtime.c H5Oname.c H5Onull.c \
+	H5Opline.c H5Orefcount.c H5Osdspace.c H5Oshared.c H5Oshmesg.c \
+	H5Ostab.c H5Otest.c H5Ounknown.c H5P.c H5Pacpl.c H5Pdapl.c \
+	H5Pdcpl.c H5Pdeprec.c H5Pdxpl.c H5Pencdec.c H5Pfapl.c \
+	H5Pfcpl.c H5Pfmpl.c H5Pgcpl.c H5Pint.c H5Plapl.c H5Plcpl.c \
+	H5Pmapl.c H5Pmcpl.c H5Pocpl.c H5Pocpypl.c H5Pstrcpl.c \
+	H5Ptest.c H5PB.c H5PL.c H5PLint.c H5PLpath.c \
+	H5PLplugin_cache.c H5R.c H5Rdeprec.c H5Rint.c H5UC.c H5RS.c \
+	H5S.c H5Sall.c H5Sdbg.c H5Sdeprec.c H5Shyper.c H5Snone.c \
+	H5Spoint.c H5Sselect.c H5Stest.c H5SL.c H5SM.c H5SMbtree2.c \
+	H5SMcache.c H5SMmessage.c H5SMtest.c H5T.c H5Tarray.c H5Tbit.c \
+	H5Tcommit.c H5Tcompound.c H5Tconv.c H5Tconv_integer.c \
+	H5Tconv_float.c H5Tconv_string.c H5Tconv_bitfield.c \
+	H5Tconv_compound.c H5Tconv_reference.c H5Tconv_enum.c \
+	H5Tconv_vlen.c H5Tconv_array.c H5Tcset.c H5Tdbg.c H5Tdeprec.c \
+	H5Tenum.c H5Tfields.c H5Tfixed.c H5Tfloat.c H5Tinit_float.c \
+	H5Tnative.c H5Toffset.c H5Toh.c H5Topaque.c H5Torder.c \
+	H5Tref.c H5Tpad.c H5Tprecis.c H5Tstrpad.c H5Tvisit.c H5Tvlen.c \
+	H5TS.c H5VL.c H5VLcallback.c H5VLdyn_ops.c H5VLint.c \
+	H5VLnative.c H5VLnative_attr.c H5VLnative_blob.c \
+	H5VLnative_dataset.c H5VLnative_datatype.c H5VLnative_file.c \
+	H5VLnative_group.c H5VLnative_link.c H5VLnative_introspect.c \
+	H5VLnative_object.c H5VLnative_token.c H5VLpassthru.c \
+	H5VLtest.c H5VM.c H5WB.c H5Z.c H5Zdeflate.c H5Zfletcher32.c \
+	H5Znbit.c H5Zshuffle.c H5Zscaleoffset.c H5Zszip.c H5Ztrans.c \
+	H5mpi.c H5ACmpio.c H5Cmpio.c H5Dmpio.c H5Fmpi.c H5FDmpi.c \
+	H5FDmpio.c H5Smpio.c H5FDsubfiling/H5FDsubfiling.c \
+	H5FDsubfiling/H5FDsubfile_int.c H5FDsubfiling/H5FDioc.c \
+	H5FDsubfiling/H5FDioc_int.c H5FDsubfiling/H5FDioc_threads.c \
 	H5FDsubfiling/H5subfiling_common.c H5FDdirect.c H5FDhdfs.c \
 	H5FDmirror.c H5FDros3.c H5FDs3comms.c \
 	H5FDsubfiling/mercury/src/util/mercury_thread.c \
@@ -327,19 +327,19 @@ am_libhdf5_la_OBJECTS = H5.lo H5build_settings.lo H5checksum.lo \
 	H5Fsfile.lo H5Fspace.lo H5Fsuper.lo H5Fsuper_cache.lo \
 	H5Ftest.lo H5FA.lo H5FAcache.lo H5FAdbg.lo H5FAdblock.lo \
 	H5FAdblkpage.lo H5FAhdr.lo H5FAint.lo H5FAstat.lo H5FAtest.lo \
-	H5CL.lo H5FD.lo H5FDcore.lo H5FDfamily.lo H5FDint.lo \
-	H5FDlog.lo H5FDmulti.lo H5FDonion.lo H5FDonion_header.lo \
-	H5FDonion_history.lo H5FDonion_index.lo H5FDperform.lo \
-	H5FDsec2.lo H5FDspace.lo H5FDsplitter.lo H5FDstdio.lo \
-	H5FDtest.lo H5FDwindows.lo H5FL.lo H5FO.lo H5FS.lo \
-	H5FScache.lo H5FSdbg.lo H5FSint.lo H5FSsection.lo H5FSstat.lo \
-	H5FStest.lo H5G.lo H5Gbtree2.lo H5Gcache.lo H5Gcompact.lo \
-	H5Gdense.lo H5Gdeprec.lo H5Gent.lo H5Gint.lo H5Glink.lo \
-	H5Gloc.lo H5Gname.lo H5Gnode.lo H5Gobj.lo H5Goh.lo H5Groot.lo \
-	H5Gstab.lo H5Gtest.lo H5Gtraverse.lo H5HF.lo H5HFbtree2.lo \
-	H5HFcache.lo H5HFdbg.lo H5HFdblock.lo H5HFdtable.lo H5HFhdr.lo \
-	H5HFhuge.lo H5HFiblock.lo H5HFiter.lo H5HFman.lo \
-	H5HFsection.lo H5HFspace.lo H5HFstat.lo H5HFtest.lo \
+	H5CL.lo H5FD.lo H5FDcore.lo H5FDcrypt.lo H5FDfamily.lo \
+	H5FDint.lo H5FDlog.lo H5FDmulti.lo H5FDonion.lo \
+	H5FDonion_header.lo H5FDonion_history.lo H5FDonion_index.lo \
+	H5FDpb.lo H5FDperform.lo H5FDsec2.lo H5FDspace.lo \
+	H5FDsplitter.lo H5FDstdio.lo H5FDtest.lo H5FDwindows.lo \
+	H5FL.lo H5FO.lo H5FS.lo H5FScache.lo H5FSdbg.lo H5FSint.lo \
+	H5FSsection.lo H5FSstat.lo H5FStest.lo H5G.lo H5Gbtree2.lo \
+	H5Gcache.lo H5Gcompact.lo H5Gdense.lo H5Gdeprec.lo H5Gent.lo \
+	H5Gint.lo H5Glink.lo H5Gloc.lo H5Gname.lo H5Gnode.lo H5Gobj.lo \
+	H5Goh.lo H5Groot.lo H5Gstab.lo H5Gtest.lo H5Gtraverse.lo \
+	H5HF.lo H5HFbtree2.lo H5HFcache.lo H5HFdbg.lo H5HFdblock.lo \
+	H5HFdtable.lo H5HFhdr.lo H5HFhuge.lo H5HFiblock.lo H5HFiter.lo \
+	H5HFman.lo H5HFsection.lo H5HFspace.lo H5HFstat.lo H5HFtest.lo \
 	H5HFtiny.lo H5HG.lo H5HGcache.lo H5HGdbg.lo H5HGquery.lo \
 	H5HL.lo H5HLcache.lo H5HLdbg.lo H5HLint.lo H5HLprfx.lo \
 	H5HLdblk.lo H5I.lo H5Idbg.lo H5Iint.lo H5Itest.lo H5L.lo \
@@ -450,19 +450,20 @@ am__depfiles_remade = ./$(DEPDIR)/H5.Plo ./$(DEPDIR)/H5A.Plo \
 	./$(DEPDIR)/H5FAhdr.Plo ./$(DEPDIR)/H5FAint.Plo \
 	./$(DEPDIR)/H5FAstat.Plo ./$(DEPDIR)/H5FAtest.Plo \
 	./$(DEPDIR)/H5FD.Plo ./$(DEPDIR)/H5FDcore.Plo \
-	./$(DEPDIR)/H5FDdirect.Plo ./$(DEPDIR)/H5FDfamily.Plo \
-	./$(DEPDIR)/H5FDhdfs.Plo ./$(DEPDIR)/H5FDint.Plo \
-	./$(DEPDIR)/H5FDlog.Plo ./$(DEPDIR)/H5FDmirror.Plo \
-	./$(DEPDIR)/H5FDmpi.Plo ./$(DEPDIR)/H5FDmpio.Plo \
-	./$(DEPDIR)/H5FDmulti.Plo ./$(DEPDIR)/H5FDonion.Plo \
-	./$(DEPDIR)/H5FDonion_header.Plo \
+	./$(DEPDIR)/H5FDcrypt.Plo ./$(DEPDIR)/H5FDdirect.Plo \
+	./$(DEPDIR)/H5FDfamily.Plo ./$(DEPDIR)/H5FDhdfs.Plo \
+	./$(DEPDIR)/H5FDint.Plo ./$(DEPDIR)/H5FDlog.Plo \
+	./$(DEPDIR)/H5FDmirror.Plo ./$(DEPDIR)/H5FDmpi.Plo \
+	./$(DEPDIR)/H5FDmpio.Plo ./$(DEPDIR)/H5FDmulti.Plo \
+	./$(DEPDIR)/H5FDonion.Plo ./$(DEPDIR)/H5FDonion_header.Plo \
 	./$(DEPDIR)/H5FDonion_history.Plo \
-	./$(DEPDIR)/H5FDonion_index.Plo ./$(DEPDIR)/H5FDperform.Plo \
-	./$(DEPDIR)/H5FDros3.Plo ./$(DEPDIR)/H5FDs3comms.Plo \
-	./$(DEPDIR)/H5FDsec2.Plo ./$(DEPDIR)/H5FDspace.Plo \
-	./$(DEPDIR)/H5FDsplitter.Plo ./$(DEPDIR)/H5FDstdio.Plo \
-	./$(DEPDIR)/H5FDtest.Plo ./$(DEPDIR)/H5FDwindows.Plo \
-	./$(DEPDIR)/H5FL.Plo ./$(DEPDIR)/H5FO.Plo ./$(DEPDIR)/H5FS.Plo \
+	./$(DEPDIR)/H5FDonion_index.Plo ./$(DEPDIR)/H5FDpb.Plo \
+	./$(DEPDIR)/H5FDperform.Plo ./$(DEPDIR)/H5FDros3.Plo \
+	./$(DEPDIR)/H5FDs3comms.Plo ./$(DEPDIR)/H5FDsec2.Plo \
+	./$(DEPDIR)/H5FDspace.Plo ./$(DEPDIR)/H5FDsplitter.Plo \
+	./$(DEPDIR)/H5FDstdio.Plo ./$(DEPDIR)/H5FDtest.Plo \
+	./$(DEPDIR)/H5FDwindows.Plo ./$(DEPDIR)/H5FL.Plo \
+	./$(DEPDIR)/H5FO.Plo ./$(DEPDIR)/H5FS.Plo \
 	./$(DEPDIR)/H5FScache.Plo ./$(DEPDIR)/H5FSdbg.Plo \
 	./$(DEPDIR)/H5FSint.Plo ./$(DEPDIR)/H5FSsection.Plo \
 	./$(DEPDIR)/H5FSstat.Plo ./$(DEPDIR)/H5FStest.Plo \
@@ -1276,54 +1277,55 @@ libhdf5_la_SOURCES = H5.c H5build_settings.c H5checksum.c H5dbg.c \
 	H5Fquery.c H5Fsfile.c H5Fspace.c H5Fsuper.c H5Fsuper_cache.c \
 	H5Ftest.c H5FA.c H5FAcache.c H5FAdbg.c H5FAdblock.c \
 	H5FAdblkpage.c H5FAhdr.c H5FAint.c H5FAstat.c H5FAtest.c \
-	H5CL.c H5FD.c H5FDcore.c H5FDfamily.c H5FDint.c H5FDlog.c \
-	H5FDmulti.c H5FDonion.c H5FDonion_header.c H5FDonion_history.c \
-	H5FDonion_index.c H5FDperform.c H5FDsec2.c H5FDspace.c \
-	H5FDsplitter.c H5FDstdio.c H5FDtest.c H5FDwindows.c H5FL.c \
-	H5FO.c H5FS.c H5FScache.c H5FSdbg.c H5FSint.c H5FSsection.c \
-	H5FSstat.c H5FStest.c H5G.c H5Gbtree2.c H5Gcache.c \
-	H5Gcompact.c H5Gdense.c H5Gdeprec.c H5Gent.c H5Gint.c \
-	H5Glink.c H5Gloc.c H5Gname.c H5Gnode.c H5Gobj.c H5Goh.c \
-	H5Groot.c H5Gstab.c H5Gtest.c H5Gtraverse.c H5HF.c \
-	H5HFbtree2.c H5HFcache.c H5HFdbg.c H5HFdblock.c H5HFdtable.c \
-	H5HFhdr.c H5HFhuge.c H5HFiblock.c H5HFiter.c H5HFman.c \
-	H5HFsection.c H5HFspace.c H5HFstat.c H5HFtest.c H5HFtiny.c \
-	H5HG.c H5HGcache.c H5HGdbg.c H5HGquery.c H5HL.c H5HLcache.c \
-	H5HLdbg.c H5HLint.c H5HLprfx.c H5HLdblk.c H5I.c H5Idbg.c \
-	H5Iint.c H5Itest.c H5L.c H5Ldeprec.c H5Lexternal.c H5Lint.c \
-	H5M.c H5MF.c H5MFaggr.c H5MFdbg.c H5MFsection.c H5MM.c H5O.c \
-	H5Odeprec.c H5Oainfo.c H5Oalloc.c H5Oattr.c H5Oattribute.c \
-	H5Obogus.c H5Obtreek.c H5Ocache.c H5Ocache_image.c H5Ochunk.c \
-	H5Ocont.c H5Ocopy.c H5Ocopy_ref.c H5Odbg.c H5Odrvinfo.c \
-	H5Odtype.c H5Oefl.c H5Ofill.c H5Oflush.c H5Ofsinfo.c \
-	H5Oginfo.c H5Oint.c H5Olayout.c H5Olinfo.c H5Olink.c \
-	H5Omessage.c H5Omtime.c H5Oname.c H5Onull.c H5Opline.c \
-	H5Orefcount.c H5Osdspace.c H5Oshared.c H5Oshmesg.c H5Ostab.c \
-	H5Otest.c H5Ounknown.c H5P.c H5Pacpl.c H5Pdapl.c H5Pdcpl.c \
-	H5Pdeprec.c H5Pdxpl.c H5Pencdec.c H5Pfapl.c H5Pfcpl.c \
-	H5Pfmpl.c H5Pgcpl.c H5Pint.c H5Plapl.c H5Plcpl.c H5Pmapl.c \
-	H5Pmcpl.c H5Pocpl.c H5Pocpypl.c H5Pstrcpl.c H5Ptest.c H5PB.c \
-	H5PL.c H5PLint.c H5PLpath.c H5PLplugin_cache.c H5R.c \
-	H5Rdeprec.c H5Rint.c H5UC.c H5RS.c H5S.c H5Sall.c H5Sdbg.c \
-	H5Sdeprec.c H5Shyper.c H5Snone.c H5Spoint.c H5Sselect.c \
-	H5Stest.c H5SL.c H5SM.c H5SMbtree2.c H5SMcache.c H5SMmessage.c \
-	H5SMtest.c H5T.c H5Tarray.c H5Tbit.c H5Tcommit.c H5Tcompound.c \
-	H5Tconv.c H5Tconv_integer.c H5Tconv_float.c H5Tconv_string.c \
-	H5Tconv_bitfield.c H5Tconv_compound.c H5Tconv_reference.c \
-	H5Tconv_enum.c H5Tconv_vlen.c H5Tconv_array.c H5Tcset.c \
-	H5Tdbg.c H5Tdeprec.c H5Tenum.c H5Tfields.c H5Tfixed.c \
-	H5Tfloat.c H5Tinit_float.c H5Tnative.c H5Toffset.c H5Toh.c \
-	H5Topaque.c H5Torder.c H5Tref.c H5Tpad.c H5Tprecis.c \
-	H5Tstrpad.c H5Tvisit.c H5Tvlen.c H5TS.c H5VL.c H5VLcallback.c \
-	H5VLdyn_ops.c H5VLint.c H5VLnative.c H5VLnative_attr.c \
-	H5VLnative_blob.c H5VLnative_dataset.c H5VLnative_datatype.c \
-	H5VLnative_file.c H5VLnative_group.c H5VLnative_link.c \
-	H5VLnative_introspect.c H5VLnative_object.c H5VLnative_token.c \
-	H5VLpassthru.c H5VLtest.c H5VM.c H5WB.c H5Z.c H5Zdeflate.c \
-	H5Zfletcher32.c H5Znbit.c H5Zshuffle.c H5Zscaleoffset.c \
-	H5Zszip.c H5Ztrans.c $(am__append_1) $(am__append_2) \
-	$(am__append_3) $(am__append_4) $(am__append_5) \
-	$(am__append_6) $(am__append_7)
+	H5CL.c H5FD.c H5FDcore.c H5FDcrypt.c H5FDfamily.c H5FDint.c \
+	H5FDlog.c H5FDmulti.c H5FDonion.c H5FDonion_header.c \
+	H5FDonion_history.c H5FDonion_index.c H5FDpb.c H5FDperform.c \
+	H5FDsec2.c H5FDspace.c H5FDsplitter.c H5FDstdio.c H5FDtest.c \
+	H5FDwindows.c H5FL.c H5FO.c H5FS.c H5FScache.c H5FSdbg.c \
+	H5FSint.c H5FSsection.c H5FSstat.c H5FStest.c H5G.c \
+	H5Gbtree2.c H5Gcache.c H5Gcompact.c H5Gdense.c H5Gdeprec.c \
+	H5Gent.c H5Gint.c H5Glink.c H5Gloc.c H5Gname.c H5Gnode.c \
+	H5Gobj.c H5Goh.c H5Groot.c H5Gstab.c H5Gtest.c H5Gtraverse.c \
+	H5HF.c H5HFbtree2.c H5HFcache.c H5HFdbg.c H5HFdblock.c \
+	H5HFdtable.c H5HFhdr.c H5HFhuge.c H5HFiblock.c H5HFiter.c \
+	H5HFman.c H5HFsection.c H5HFspace.c H5HFstat.c H5HFtest.c \
+	H5HFtiny.c H5HG.c H5HGcache.c H5HGdbg.c H5HGquery.c H5HL.c \
+	H5HLcache.c H5HLdbg.c H5HLint.c H5HLprfx.c H5HLdblk.c H5I.c \
+	H5Idbg.c H5Iint.c H5Itest.c H5L.c H5Ldeprec.c H5Lexternal.c \
+	H5Lint.c H5M.c H5MF.c H5MFaggr.c H5MFdbg.c H5MFsection.c \
+	H5MM.c H5O.c H5Odeprec.c H5Oainfo.c H5Oalloc.c H5Oattr.c \
+	H5Oattribute.c H5Obogus.c H5Obtreek.c H5Ocache.c \
+	H5Ocache_image.c H5Ochunk.c H5Ocont.c H5Ocopy.c H5Ocopy_ref.c \
+	H5Odbg.c H5Odrvinfo.c H5Odtype.c H5Oefl.c H5Ofill.c H5Oflush.c \
+	H5Ofsinfo.c H5Oginfo.c H5Oint.c H5Olayout.c H5Olinfo.c \
+	H5Olink.c H5Omessage.c H5Omtime.c H5Oname.c H5Onull.c \
+	H5Opline.c H5Orefcount.c H5Osdspace.c H5Oshared.c H5Oshmesg.c \
+	H5Ostab.c H5Otest.c H5Ounknown.c H5P.c H5Pacpl.c H5Pdapl.c \
+	H5Pdcpl.c H5Pdeprec.c H5Pdxpl.c H5Pencdec.c H5Pfapl.c \
+	H5Pfcpl.c H5Pfmpl.c H5Pgcpl.c H5Pint.c H5Plapl.c H5Plcpl.c \
+	H5Pmapl.c H5Pmcpl.c H5Pocpl.c H5Pocpypl.c H5Pstrcpl.c \
+	H5Ptest.c H5PB.c H5PL.c H5PLint.c H5PLpath.c \
+	H5PLplugin_cache.c H5R.c H5Rdeprec.c H5Rint.c H5UC.c H5RS.c \
+	H5S.c H5Sall.c H5Sdbg.c H5Sdeprec.c H5Shyper.c H5Snone.c \
+	H5Spoint.c H5Sselect.c H5Stest.c H5SL.c H5SM.c H5SMbtree2.c \
+	H5SMcache.c H5SMmessage.c H5SMtest.c H5T.c H5Tarray.c H5Tbit.c \
+	H5Tcommit.c H5Tcompound.c H5Tconv.c H5Tconv_integer.c \
+	H5Tconv_float.c H5Tconv_string.c H5Tconv_bitfield.c \
+	H5Tconv_compound.c H5Tconv_reference.c H5Tconv_enum.c \
+	H5Tconv_vlen.c H5Tconv_array.c H5Tcset.c H5Tdbg.c H5Tdeprec.c \
+	H5Tenum.c H5Tfields.c H5Tfixed.c H5Tfloat.c H5Tinit_float.c \
+	H5Tnative.c H5Toffset.c H5Toh.c H5Topaque.c H5Torder.c \
+	H5Tref.c H5Tpad.c H5Tprecis.c H5Tstrpad.c H5Tvisit.c H5Tvlen.c \
+	H5TS.c H5VL.c H5VLcallback.c H5VLdyn_ops.c H5VLint.c \
+	H5VLnative.c H5VLnative_attr.c H5VLnative_blob.c \
+	H5VLnative_dataset.c H5VLnative_datatype.c H5VLnative_file.c \
+	H5VLnative_group.c H5VLnative_link.c H5VLnative_introspect.c \
+	H5VLnative_object.c H5VLnative_token.c H5VLpassthru.c \
+	H5VLtest.c H5VM.c H5WB.c H5Z.c H5Zdeflate.c H5Zfletcher32.c \
+	H5Znbit.c H5Zshuffle.c H5Zscaleoffset.c H5Zszip.c H5Ztrans.c \
+	$(am__append_1) $(am__append_2) $(am__append_3) \
+	$(am__append_4) $(am__append_5) $(am__append_6) \
+	$(am__append_7)
 
 # Public headers
 
@@ -1609,6 +1611,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/H5FAtest.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/H5FD.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/H5FDcore.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/H5FDcrypt.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/H5FDdirect.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/H5FDfamily.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/H5FDhdfs.Plo@am__quote@ # am--include-marker
@@ -1622,6 +1625,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/H5FDonion_header.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/H5FDonion_history.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/H5FDonion_index.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/H5FDpb.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/H5FDperform.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/H5FDros3.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/H5FDs3comms.Plo@am__quote@ # am--include-marker
@@ -2332,6 +2336,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/H5FAtest.Plo
 	-rm -f ./$(DEPDIR)/H5FD.Plo
 	-rm -f ./$(DEPDIR)/H5FDcore.Plo
+	-rm -f ./$(DEPDIR)/H5FDcrypt.Plo
 	-rm -f ./$(DEPDIR)/H5FDdirect.Plo
 	-rm -f ./$(DEPDIR)/H5FDfamily.Plo
 	-rm -f ./$(DEPDIR)/H5FDhdfs.Plo
@@ -2345,6 +2350,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/H5FDonion_header.Plo
 	-rm -f ./$(DEPDIR)/H5FDonion_history.Plo
 	-rm -f ./$(DEPDIR)/H5FDonion_index.Plo
+	-rm -f ./$(DEPDIR)/H5FDpb.Plo
 	-rm -f ./$(DEPDIR)/H5FDperform.Plo
 	-rm -f ./$(DEPDIR)/H5FDros3.Plo
 	-rm -f ./$(DEPDIR)/H5FDs3comms.Plo
@@ -2737,6 +2743,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/H5FAtest.Plo
 	-rm -f ./$(DEPDIR)/H5FD.Plo
 	-rm -f ./$(DEPDIR)/H5FDcore.Plo
+	-rm -f ./$(DEPDIR)/H5FDcrypt.Plo
 	-rm -f ./$(DEPDIR)/H5FDdirect.Plo
 	-rm -f ./$(DEPDIR)/H5FDfamily.Plo
 	-rm -f ./$(DEPDIR)/H5FDhdfs.Plo
@@ -2750,6 +2757,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/H5FDonion_header.Plo
 	-rm -f ./$(DEPDIR)/H5FDonion_history.Plo
 	-rm -f ./$(DEPDIR)/H5FDonion_index.Plo
+	-rm -f ./$(DEPDIR)/H5FDpb.Plo
 	-rm -f ./$(DEPDIR)/H5FDperform.Plo
 	-rm -f ./$(DEPDIR)/H5FDros3.Plo
 	-rm -f ./$(DEPDIR)/H5FDs3comms.Plo

--- a/hdf5/hdf5-1.14.6/src/hdf5.h
+++ b/hdf5/hdf5-1.14.6/src/hdf5.h
@@ -64,6 +64,8 @@
 #include "H5FDmpi.h"      /* MPI-based file drivers                   */
 #include "H5FDmulti.h"    /* Usage-partitioned file family            */
 #include "H5FDonion.h"    /* Onion file I/O                           */
+#include "H5FDpb.h"       /* page buffer -- converts random I/O to paged I/O */
+#include "H5FDcrypt.h"    /* encryption VFD -- encrypts / decrypts paged I/O */
 #include "H5FDros3.h"     /* R/O S3 "file" I/O                        */
 #include "H5FDsec2.h"     /* POSIX unbuffered file I/O                */
 #include "H5FDsplitter.h" /* Twin-channel (R/W & R/O) I/O passthrough */

--- a/hdf5/hdf5-1.14.6/test/vfd.c
+++ b/hdf5/hdf5-1.14.6/test/vfd.c
@@ -15,6 +15,10 @@
  */
 
 #include "h5test.h"
+#include "H5Iprivate.h"
+#include "H5Pprivate.h"
+#include "H5CLprivate.h"
+#include <gcrypt.h>
 
 #define KB            1024U
 #define FAMILY_NUMBER 4
@@ -60,6 +64,8 @@ static const char *FILENAME[] = {"sec2_file",            /*0*/
                                  "splitter.log",         /*13*/
                                  "ctl_file",             /*14*/
                                  "ctl_splitter_wo_file", /*15*/
+                                 "pb_test_file",         /*16*/
+                                 "crypt_test_file",      /*17*/
                                  NULL};
 
 #define LOG_FILENAME "log_vfd_out.log"
@@ -67,6 +73,12 @@ static const char *FILENAME[] = {"sec2_file",            /*0*/
 #define COMPAT_BASENAME       "family_v16"
 #define MULTI_COMPAT_BASENAME "multi_file_v16"
 #define SPLITTER_DATASET_NAME "dataset"
+
+#define PB_DS_SIZE 8
+#define PB_DATASET_NAME "dataset"
+
+#define CRYPT_DS_SIZE 8
+#define CRYPT_DATASET_NAME "dataset"
 
 /* Macro: HEXPRINT()
  * Helper macro to pretty-print hexadecimal output of a buffer of known size.
@@ -148,6 +160,28 @@ struct splitter_dataset_def {
     int            n_dims;      /* rank */
 };
 
+/* Helper structure to pass around dataset information in page buffer VFD tests.
+ */
+struct pb_dataset_def {
+    void          *buf;         /* contents of dataset */
+    const char    *dset_name;   /* dataset name, always added to root group */
+    hid_t          mem_type_id; /* datatype */
+    const hsize_t *dims;        /* dimensions */
+    int            n_dims;      /* rank */
+};
+
+/* Helper structure to pass around dataset information in encryption VFD tests.
+ */
+struct crypt_dataset_def {
+    void          *buf;         /* contents of dataset */
+    const char    *dset_name;   /* dataset name, always added to root group */
+    hid_t          mem_type_id; /* datatype */
+    const hsize_t *dims;        /* dimensions */
+    int            n_dims;      /* rank */
+};
+
+
+
 /* Op code type enum for ctl callback test */
 typedef enum {
     CTL_OPC_KNOWN_PASSTHROUGH, /* op code known to passthrough VFD */
@@ -164,6 +198,50 @@ static int run_splitter_test(const struct splitter_dataset_def *data, bool ignor
 static int splitter_RO_test(const struct splitter_dataset_def *data, hid_t child_fapl_id);
 static int splitter_tentative_open_test(hid_t child_fapl_id);
 static int file_exists(const char *filename, hid_t fapl_id);
+
+static int compare_pb_config_info(hid_t fapl_id, H5FD_pb_vfd_config_t *info, bool skip_fapl_id);
+static int compare_pb_config_str(hid_t fapl_id, char *cannonical_str);
+static int run_pb_test(const struct pb_dataset_def *data, const hid_t sub_fapl_id, bool cl_config);
+static int pb_RO_test(const struct pb_dataset_def *data, hid_t child_fapl_id, bool cl_config);
+static int pb_create_single_file_at(const char *filename, hid_t fapl_id, const struct pb_dataset_def *data);
+static int pb_compare_expected_data(hid_t file_id, const struct pb_dataset_def *data);
+static int pb_test_create_write_read(bool cl_config);
+static int pb_test_head_middle_tail(bool cl_config);
+static int pb_test_rp_eviction_and_invalidation(bool cl_config);
+static int pb_test_rp_eviction_and_invalidation_fifo(bool cl_config);
+static int pb_test_page_combinations(bool cl_config);
+static int pb_test_specific_cases(bool cl_config);
+static herr_t test_pb(bool cl_config);
+
+
+/* H5FDpb.c test function */
+haddr_t *H5FD__pb_rp_eviction_check(H5FD_t *file_ptr, haddr_t *returned_addrs);
+
+static int compare_crypt_config_info(hid_t fapl_id, H5FD_crypt_vfd_config_t *info);
+static int compare_crypt_config_str(hid_t fapl_id, char *cannonical_str);
+static int test_crypt_fapl(bool cl_config);
+static int crypt_test_create(bool cl_config);
+static int crypt_test_create_and_write(bool cl_config);
+static int crypt_test_verify_create_and_encryption(bool cl_config);
+static int crypt_test_write_and_read_aes256(size_t num_pages, bool cl_config);
+#if 0
+static int crypt_test_write_3pages(void);
+static int crypt_test_write_15pages(void);
+static int crypt_test_write_16pages(void);
+static int crypt_test_write_17pages(void);
+static int crypt_test_write_18pages(void);
+static int crypt_test_write_32pages(void);
+static int crypt_test_write_33pages(void);
+#endif
+static int crypt_test_create_and_write_twofish(bool cl_config);
+static int crypt_test_verify_create_and_encryption_twofish(bool cl_config);
+static int crypt_test_write_and_read_twofish(size_t num_pages, H5FD_crypt_vfd_config_t *vfd_config, 
+                                             char * config_str, bool cl_config);
+static int run_crypt_test(const struct crypt_dataset_def *data, const hid_t sub_fapl_id, bool cl_config);
+static int crypt_RO_test(const struct crypt_dataset_def *data, hid_t child_fapl_id, bool cl_config);
+static int crypt_create_single_file_at(const char *filename, hid_t fapl_id, const struct crypt_dataset_def *data);
+static int crypt_compare_expected_data(hid_t file_id, const struct crypt_dataset_def *data);
+static herr_t test_crypt(bool cl_config);
 
 static herr_t  run_ctl_test(uint64_t op_code, uint64_t flags, ctl_test_opc_type opc_type, hid_t fapl_id);
 static H5FD_t *H5FD__ctl_test_vfd_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr);
@@ -3433,6 +3511,5188 @@ error:
 
 #undef SPLITTER_TEST_FAULT
 
+#if 1 /* page buffer VFD test code */
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * Macro: PB_TEST_FAULT()
+ *
+ * utility macro, helps create stack-like backtrace on error.
+ * requires defined in the calling function:
+ *    * variable `int ret_value` (return -1 on error)`
+ *    * label `done` for exit on fault
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ */
+#define PB_TEST_FAULT(mesg)                                                                            \
+    do {                                                                                               \
+        H5_FAILED();                                                                                   \
+        AT();                                                                                          \
+        fprintf(stderr, mesg);                                                                         \
+        H5Eprint2(H5E_DEFAULT, stderr);                                                                \
+        fflush(stderr);                                                                                \
+        ret_value = -1;                                                                                \
+        goto done;                                                                                     \
+    } while (0)
+
+/*-------------------------------------------------------------------------
+ * Function:    compare_pb_config_info
+ *
+ * Purpose:     Helper function to compare configuration info found in a
+ *              FAPL against a canonical structure.
+ *
+ * Return:      Success:  0, if config info in FAPL matches info structure.
+ *              Failure: -1, if difference detected.
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+compare_pb_config_info(hid_t fapl_id, H5FD_pb_vfd_config_t *info, bool skip_fapl_id)
+{
+    int                   ret_value    = 0;
+    H5FD_pb_vfd_config_t *fetched_info = NULL;
+
+    if (NULL == (fetched_info = calloc(1, sizeof(H5FD_pb_vfd_config_t))))
+        PB_TEST_FAULT("memory allocation for fetched_info struct failed");
+
+    fetched_info->magic      = H5FD_PB_CONFIG_MAGIC;
+    fetched_info->version    = H5FD_CURR_SPLITTER_VFD_CONFIG_VERSION;
+    fetched_info->fapl_id    = H5I_INVALID_HID;
+
+    if (H5Pget_fapl_pb(fapl_id, fetched_info) < 0) {
+        PB_TEST_FAULT("can't get page buffer info");
+    }
+
+    if ( ( info->page_size != fetched_info->page_size ) ||
+         ( info->max_num_pages != fetched_info->max_num_pages ) ||
+         ( info->rp != fetched_info->rp ) ) {
+
+        PB_TEST_FAULT("page size, max num pages, or replacement policy mismatch\n");
+    }
+
+    if ( ! skip_fapl_id ) {
+
+        if (info->fapl_id == H5P_DEFAULT) {
+
+            if (H5Pget_driver(fetched_info->fapl_id) != H5Pget_driver(H5P_FILE_ACCESS_DEFAULT)) {
+
+                PB_TEST_FAULT("underlying driver mismatch (default)\n");
+            }
+        }
+        else {
+
+            if (H5Pget_driver(fetched_info->fapl_id) != H5Pget_driver(info->fapl_id)) {
+
+                 PB_TEST_FAULT("underlying driver mismatch\n");
+            }
+
+            if ( H5Pclose(fetched_info->fapl_id) < 0) {
+
+                PB_TEST_FAULT("can't close fetched_info->fapl_id)\n");
+            }
+        }
+    }
+
+done:
+
+    free(fetched_info);
+
+    return ret_value;
+
+} /* end compare_pb_config_info() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    compare_pb_config_str
+ *
+ * Purpose:     Helper function to compare configuration strings found in a
+ *              FAPL against a canonical string
+ *
+ * Return:      Success:  0, if config string in FAPL matches the 
+ *                           cannonical string
+ *              Failure: -1, if difference detected.
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+compare_pb_config_str(hid_t fapl_id, char *cannonical_str)
+{
+    const char                 * config_str = NULL;
+    H5P_genplist_t             * plist_ptr  = NULL;
+    const H5FD_pb_vfd_config_t * config_ptr = NULL;
+    int                          ret_value    = 0;
+
+    plist_ptr = (H5P_genplist_t *)H5I_object(fapl_id);
+
+    if ( NULL == plist_ptr )
+        PB_TEST_FAULT("Supplied fapl doesn't exist?");
+
+    config_ptr = (const H5FD_pb_vfd_config_t *)H5P_peek_driver_info(plist_ptr);
+
+    config_str = H5P_peek_driver_config_str(plist_ptr);
+
+    if ( config_ptr && config_str )
+        PB_TEST_FAULT("fapl driver info contains both config and string pointers.");
+
+    if ( ! config_str ) 
+        PB_TEST_FAULT("fapl driver info doesn't have a configuration string.");
+
+    if ( 0 != strcmp(config_str, cannonical_str) )
+        PB_TEST_FAULT("fapl and cannonical configuration strings differ.");
+
+done:
+
+    return ret_value;
+
+} /* end compare_pb_config_str() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    run_pb_test
+ *
+ * Purpose:     Auxiliary function for test_pb().
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ * Description:
+ *              Perform basic open-write-close with the page buffer VFD.
+ *              Prior to operations, removes files from a previous run,
+ *              if they exist.
+ *              After writing, verify the contents.
+ *              Includes FAPL sanity testing.
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+run_pb_test(const struct pb_dataset_def *data, const hid_t sub_fapl_id, bool cl_config)
+{
+    char                  config_str_sub_sec2[] =
+        "( page_buffer "
+        "  ( ( page_size 4096 )"
+        "    ( max_num_pages 64 )"
+        "    ( replacement_policy 0 )"
+        "    ( underlying_VFD ( sec2 () ) )"
+        "  )"
+        ")";
+    char                  config_str_sub_default[] =
+        "( page_buffer "
+        "  ( ( page_size 4096 )"
+        "    ( max_num_pages 64 )"
+        "    ( replacement_policy 0 )"
+        "  )"
+        ")";
+    hid_t                 file_id         = H5I_INVALID_HID;
+    hid_t                 fapl_id         = H5I_INVALID_HID;
+    hid_t                 dset_id         = H5I_INVALID_HID;
+    hid_t                 space_id        = H5I_INVALID_HID;
+    hid_t                 fapl_id_out     = H5I_INVALID_HID;
+    hid_t                 fapl_id_cpy     = H5I_INVALID_HID;
+    H5FD_pb_vfd_config_t *vfd_config      = NULL;
+    char                 *filename        = NULL;
+    int                   ret_value        = 0;
+
+    if (NULL == (vfd_config = calloc(1, sizeof(H5FD_pb_vfd_config_t))))
+        PB_TEST_FAULT("memory allocation for vfd_config struct failed");
+
+    if (NULL == (filename = calloc(H5FD_SPLITTER_PATH_MAX + 1, sizeof(char))))
+        PB_TEST_FAULT("memory allocation for filename string failed");
+
+    vfd_config->magic          = H5FD_PB_CONFIG_MAGIC;
+    vfd_config->version        = H5FD_CURR_PB_VFD_CONFIG_VERSION;
+    vfd_config->page_size      = H5FD_PB_DEFAULT_PAGE_SIZE;
+    vfd_config->max_num_pages  = H5FD_PB_DEFAULT_MAX_NUM_PAGES;
+    vfd_config->rp             = H5FD_PB_DEFAULT_REPLACEMENT_POLICY;
+    vfd_config->fapl_id        = sub_fapl_id;
+    vfd_config->testing        = H5FD_PB_DEFAULT_TESTING_OFF;
+
+
+    /* setup the target file name, and delete any existing instance */
+
+    h5_fixname(FILENAME[16], vfd_config->fapl_id, filename, 1024);
+    HDremove(filename);
+
+
+    /* Create a new fapl to use the page buffer file driver */
+
+    if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) == H5I_INVALID_HID) {
+        PB_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if ( cl_config ) {
+
+        /* load the desired configuration string into the FAPL */
+        /* replace with public API call when ready */
+
+        if ( H5P_DEFAULT == sub_fapl_id ) {
+
+            if (H5CL_load_vfd_config_str_into_fapl(fapl_id, config_str_sub_default) < 0) {
+                PB_TEST_FAULT("can't load config string into fapl\n");
+            }
+        } else if ( H5FD_SEC2 == H5Pget_driver(sub_fapl_id) ) {
+
+            if (H5CL_load_vfd_config_str_into_fapl(fapl_id, config_str_sub_sec2) < 0) {
+                PB_TEST_FAULT("can't load config string into fapl\n");
+            }
+        } else {
+
+            PB_TEST_FAULT("unknown sub_fapl_id\n");
+        }
+    } else {
+
+        if (H5Pset_fapl_pb(fapl_id, vfd_config) < 0) {
+            PB_TEST_FAULT("can't set page buffer FAPL\n");
+        }
+    }
+
+    if (H5Pget_driver(fapl_id) != H5FD_PB) {
+        PB_TEST_FAULT("set FAPL not page buffer\n");
+    }
+
+    if ( cl_config ) {
+
+        if ( H5P_DEFAULT == sub_fapl_id ) {
+
+            if ( compare_pb_config_str(fapl_id, config_str_sub_default) != 0 ) {
+                PB_TEST_FAULT("information mismatch\n");
+            } 
+        } else if ( H5FD_SEC2 == H5Pget_driver(sub_fapl_id) ) {
+
+            if ( compare_pb_config_str(fapl_id, config_str_sub_sec2) != 0 ) {
+                PB_TEST_FAULT("information mismatch\n");
+            } 
+        } else {
+
+            PB_TEST_FAULT("unknown sub_fapl_id\n");
+        }
+    } else {
+
+        if (compare_pb_config_info(fapl_id, vfd_config, false) < 0) {
+            PB_TEST_FAULT("information mismatch\n");
+        }
+    }
+
+    /*
+     * Copy property list, light compare, and close the copy.
+     * Helps test driver-implemented FAPL-copying and library ID management.
+     */
+
+    fapl_id_cpy = H5Pcopy(fapl_id);
+    if (H5I_INVALID_HID == fapl_id_cpy) {
+        PB_TEST_FAULT("can't copy FAPL\n");
+    }
+
+    if ( cl_config ) {
+
+        if ( H5P_DEFAULT == sub_fapl_id ) {
+
+            if ( compare_pb_config_str(fapl_id_cpy, config_str_sub_default) != 0 ) {
+                PB_TEST_FAULT("information mismatch\n");
+            } 
+        } else if ( H5FD_SEC2 == H5Pget_driver(sub_fapl_id) ) {
+
+            if ( compare_pb_config_str(fapl_id_cpy, config_str_sub_sec2) != 0 ) {
+                PB_TEST_FAULT("information mismatch\n");
+            } 
+        } else {
+
+            PB_TEST_FAULT("unknown sub_fapl_id\n");
+        }
+    } else {
+
+        if (compare_pb_config_info(fapl_id_cpy, vfd_config, false) < 0) {
+            PB_TEST_FAULT("information mismatch\n");
+        }
+    }
+
+    if (H5Pclose(fapl_id_cpy) < 0) {
+        PB_TEST_FAULT("can't close fapl copy\n");
+    }
+
+
+    /* Proceed with test. Create file. */
+
+    file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
+    if (file_id < 0) {
+        PB_TEST_FAULT("can't create file\n");
+    }
+
+
+
+    /* Check driver from file */
+
+    fapl_id_out = H5Fget_access_plist(file_id);
+
+    if (H5I_INVALID_HID == fapl_id_out) {
+        PB_TEST_FAULT("can't get file's FAPL\n");
+    }
+
+    if (H5Pget_driver(fapl_id_out) != H5FD_PB) {
+        PB_TEST_FAULT("wrong file FAPL driver\n");
+    }
+
+    if (compare_pb_config_info(fapl_id_out, vfd_config, false) < 0) {
+        PB_TEST_FAULT("information mismatch\n");
+    }
+
+    if (H5Pclose(fapl_id_out) < 0) {
+        PB_TEST_FAULT("can't close file's FAPL\n");
+    }
+
+    /* Create and write the dataset */
+
+    space_id = H5Screate_simple(data->n_dims, data->dims, NULL);
+
+    if (space_id < 0) {
+        PB_TEST_FAULT("can't create dataspace\n");
+    }
+
+    dset_id = H5Dcreate2(file_id, data->dset_name, data->mem_type_id, space_id, 
+                         H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+
+    if (dset_id < 0) {
+        PB_TEST_FAULT("can't create dataset\n");
+    }
+
+    if (H5Dwrite(dset_id, data->mem_type_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, data->buf) < 0) {
+        PB_TEST_FAULT("can't write data to dataset\n");
+    }
+
+    if (pb_compare_expected_data(file_id, data) < 0) {
+        PB_TEST_FAULT("data mismatch in file\n");
+    }
+
+
+
+    /* Close everything */
+
+    if (H5Dclose(dset_id) < 0) {
+        PB_TEST_FAULT("can't close dset\n");
+    }
+
+    if (H5Sclose(space_id) < 0) {
+        PB_TEST_FAULT("can't close space\n");
+    }
+
+    if (H5Pclose(fapl_id) < 0) {
+        PB_TEST_FAULT("can't close fapl\n");
+    }
+
+    if (H5Fclose(file_id) < 0) {
+        PB_TEST_FAULT("can't close file\n");
+    }
+
+
+done:
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Dclose(dset_id);
+            H5Sclose(space_id);
+            H5Pclose(fapl_id_out);
+            H5Pclose(fapl_id_cpy);
+            H5Pclose(fapl_id);
+            H5Fclose(file_id);
+        }
+        H5E_END_TRY
+    }
+
+    free(vfd_config);
+    free(filename);
+
+    return ret_value;
+
+} /* end run_pb_test() */
+
+
+
+/*-------------------------------------------------------------------------
+ * Function:    pb_RO_test
+ *
+ * Purpose:     Verify page buffer VFD with the Read-Only access flag.
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ * Description: Attempt read-only opening of file that eithr does or 
+ *              does not exist.
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+pb_RO_test(const struct pb_dataset_def *data, hid_t child_fapl_id, bool cl_config)
+{
+    char                  filename[1024];
+    char                  config_str[] =
+        "( page_buffer "       
+        "  ( ( page_size 4096 )" 
+        "    ( max_num_pages 16 )"
+        "    ( replacement_policy 0 )"
+        "    ( underlying_VFD ( sec2 () ) )"
+        "  )"
+        ")";
+    H5FD_pb_vfd_config_t *vfd_config     = NULL;
+    hid_t                 fapl_id        = H5I_INVALID_HID;
+    hid_t                 file_id        = H5I_INVALID_HID;
+    int                   ret_value      = 0;
+
+    if (NULL == (vfd_config = calloc(1, sizeof(H5FD_pb_vfd_config_t))))
+        PB_TEST_FAULT("memory allocation for vfd_config struct failed");
+
+    vfd_config->magic          = H5FD_PB_CONFIG_MAGIC;
+    vfd_config->version        = H5FD_CURR_PB_VFD_CONFIG_VERSION;
+    vfd_config->page_size      = H5FD_PB_DEFAULT_PAGE_SIZE;
+    vfd_config->max_num_pages  = H5FD_PB_DEFAULT_MAX_NUM_PAGES;
+    vfd_config->rp             = H5FD_PB_DEFAULT_REPLACEMENT_POLICY;
+    vfd_config->fapl_id        = child_fapl_id;
+    vfd_config->testing        = H5FD_PB_DEFAULT_TESTING_OFF;
+
+
+    /* setup the target file name, and delete any existing instance */
+
+    h5_fixname(FILENAME[16], vfd_config->fapl_id, filename, 1024);
+    HDremove(filename);
+
+
+    /* Create a new fapl to use the page buffer file driver */
+
+    fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+
+    if (H5I_INVALID_HID == fapl_id) {
+        PB_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if ( cl_config ) {
+
+        if (H5CL_load_vfd_config_str_into_fapl(fapl_id, config_str) < 0) {
+            PB_TEST_FAULT("can't load config string into fapl\n");
+        }
+    } else {
+
+        if (H5Pset_fapl_pb(fapl_id, vfd_config) < 0) {
+            PB_TEST_FAULT("can't set pb FAPL\n");
+        }
+    } 
+
+    if (H5Pget_driver(fapl_id) != H5FD_PB) {
+        PB_TEST_FAULT("set FAPL not PB\n");
+    }
+
+
+    /* Attempt R/O open when target file doesn't exist.
+     * Should fail.
+     */
+
+    H5E_BEGIN_TRY
+    {
+        file_id = H5Fopen(filename, H5F_ACC_RDONLY, fapl_id);
+    }
+    H5E_END_TRY
+
+    if (file_id >= 0) {
+        PB_TEST_FAULT("R/O open on nonexistent file unexpectedly successful\n");
+    }
+
+
+
+    /* Attempt R/O open when file exists */
+
+    if (pb_create_single_file_at(filename, child_fapl_id, data) < 0) {
+        PB_TEST_FAULT("can't create file\n");
+    }
+
+    file_id = H5Fopen(filename, H5F_ACC_RDONLY, fapl_id);
+
+    if (file_id < 0) {
+        PB_TEST_FAULT("R/O open on extant file failed\n");
+    }
+
+    if (pb_compare_expected_data(file_id, data) < 0) {
+        PB_TEST_FAULT("data mismatch in file\n");
+    }
+
+    if (H5Fclose(file_id) < 0) {
+        PB_TEST_FAULT("can't close file(s)\n");
+    }
+
+    file_id = H5I_INVALID_HID;
+
+
+
+    /* Cleanup */
+
+    if (H5Pclose(fapl_id) < 0) {
+        PB_TEST_FAULT("can't close FAPL ID\n");
+    }
+
+    fapl_id = H5I_INVALID_HID;
+
+done:
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Pclose(fapl_id);
+            H5Fclose(file_id);
+        }
+        H5E_END_TRY
+    }
+
+    free(vfd_config);
+
+    return ret_value;
+
+} /* end pb_RO_test() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    pb_create_single_file_at
+ *
+ * Purpose:     Create a file, optionally w/ dataset.
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ * Description:
+ *              Create a file at the given location with the given FAPL,
+ *              and write data as defined in `data` in a pre-determined 
+ *              location in the file.
+ *
+ *              If the dataset definition pointer is NULL, no data is written
+ *              to the file.
+ *
+ *              Will always overwrite an existing file with the given 
+ *              name/path.
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+pb_create_single_file_at(const char *filename, hid_t fapl_id, const struct pb_dataset_def *data)
+{
+    hid_t file_id   = H5I_INVALID_HID;
+    hid_t space_id  = H5I_INVALID_HID;
+    hid_t dset_id   = H5I_INVALID_HID;
+    int   ret_value = 0;
+
+    if (filename == NULL || *filename == '\0') {
+        PB_TEST_FAULT("filename is invalid\n");
+    }
+
+    /* TODO: sanity-check fapl id? */
+
+    file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
+
+    if (file_id < 0) {
+        PB_TEST_FAULT("can't create file\n");
+    }
+
+    if (data) {
+
+        /* TODO: sanity-check data, if it exists? */
+
+        space_id = H5Screate_simple(data->n_dims, data->dims, NULL);
+
+        if (space_id < 0) {
+            PB_TEST_FAULT("can't create dataspace\n");
+        }
+
+        dset_id = H5Dcreate2(file_id, data->dset_name, data->mem_type_id, space_id, 
+                             H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+
+        if (dset_id < 0) {
+            PB_TEST_FAULT("can't create dataset\n");
+        }
+
+        if (H5Dwrite(dset_id, data->mem_type_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, data->buf) < 0) {
+            PB_TEST_FAULT("can't write data to dataset\n");
+        }
+
+        if (H5Dclose(dset_id) < 0) {
+            PB_TEST_FAULT("can't close dset\n");
+        }
+
+        if (H5Sclose(space_id) < 0) {
+            PB_TEST_FAULT("can't close space\n");
+        }
+
+        if (pb_compare_expected_data(file_id, data) < 0) {
+            PB_TEST_FAULT("data mismatch in file\n");
+        }
+
+        if (H5Fclose(file_id) < 0) {
+            PB_TEST_FAULT("can't close file\n");
+        }
+
+        /* re-open the file and verify its contents */
+        file_id = H5Fopen(filename, H5F_ACC_RDWR, fapl_id);
+
+        if (file_id < 0) {
+            PB_TEST_FAULT("R/W open on extant file failed\n");
+        }
+
+        if (pb_compare_expected_data(file_id, data) < 0) {
+            PB_TEST_FAULT("data mismatch in file\n");
+        }
+
+    } /* end if data definition is provided */
+
+    if (H5Fclose(file_id) < 0) {
+        PB_TEST_FAULT("can't close file\n");
+    }
+
+done:
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Dclose(dset_id);
+            H5Sclose(space_id);
+            H5Fclose(file_id);
+        }
+        H5E_END_TRY
+    } /* end if error */
+
+    return ret_value;
+
+} /* end pb_create_single_file_at() */
+
+/*-------------------------------------------------------------------------
+ * Function:    pb_compare_expected_data
+ *
+ * Purpose:     Compare data within a predermined dataset.
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ * Description: Read data from the file at a predetermined location, and
+ *              compare its contents byte-for-byte with that expected in
+ *              the `data` definition structure.
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+pb_compare_expected_data(hid_t file_id, const struct pb_dataset_def *data)
+{
+    hid_t  dset_id = H5I_INVALID_HID;
+    int    buf[PB_DS_SIZE][PB_DS_SIZE];
+    int    expected[PB_DS_SIZE][PB_DS_SIZE];
+    size_t i         = 0;
+    size_t j         = 0;
+    int    ret_value = 0;
+
+    if (sizeof((void *)buf) != sizeof(data->buf)) {
+        PB_TEST_FAULT("invariant size of expected data does not match that received!\n");
+    }
+
+    memcpy(expected, data->buf, sizeof(expected));
+
+    dset_id = H5Dopen2(file_id, data->dset_name, H5P_DEFAULT);
+
+    if (dset_id < 0) {
+        PB_TEST_FAULT("can't open dataset\n");
+    }
+
+    if (H5Dread(dset_id, data->mem_type_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, (void *)buf) < 0) {
+        PB_TEST_FAULT("can't read dataset\n");
+    }
+
+    for (i = 0; i < PB_DS_SIZE; i++) {
+        for (j = 0; j < PB_DS_SIZE; j++) {
+            if (buf[i][j] != expected[i][j]) {
+                PB_TEST_FAULT("mismatch in expected data\n");
+            }
+        }
+    }
+
+    if (H5Dclose(dset_id) < 0) {
+        PB_TEST_FAULT("can't close dataset\n");
+    }
+
+done:
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Dclose(dset_id);
+        }
+        H5E_END_TRY
+    }
+
+    return ret_value;
+
+} /* end pb_compare_expected_data() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    pb_test_create_write_read
+ *
+ * Purpose:     Creates a file and does a write and read test.
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ * Description: Creates a file, and then tests the write and read function 
+ *              by writing a full page (middle) and then reading it
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+pb_test_create_write_read(bool cl_config)
+{
+    char                  filename[1024];
+    hid_t                 fapl_id        = H5I_INVALID_HID;
+    H5FD_t               *file_ptr       = NULL;
+    int                   ret_value      = 0;
+    char                  config_str[] =
+        "( page_buffer "
+        "  ( ( page_size 4096 )"
+        "    ( max_num_pages 64 )"
+        "    ( replacement_policy 0 )"
+        "  )"
+        ")";
+    H5FD_pb_vfd_config_t vfd_config =
+    {
+        /* magic            = */ H5FD_PB_CONFIG_MAGIC,
+        /* version          = */ H5FD_CURR_PB_VFD_CONFIG_VERSION,
+        /* page_size        = */ H5FD_PB_DEFAULT_PAGE_SIZE,
+        /* max_num_pages    = */ H5FD_PB_DEFAULT_MAX_NUM_PAGES,
+        /* rp               = */ H5FD_PB_DEFAULT_REPLACEMENT_POLICY,
+        /* fapl_id          = */ H5P_DEFAULT,
+        /* testing          = */ H5FD_PB_DEFAULT_TESTING_OFF
+    };
+
+    unsigned char        *page     = NULL;
+    unsigned char        *read_buf = NULL;
+
+    /* setup the target file name, and delete any existing instance */
+
+    h5_fixname(FILENAME[16], vfd_config.fapl_id, filename, 1024);
+    HDremove(filename);
+
+
+    /* Create a new fapl to use the page buffer file driver */
+
+    fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+
+    if (H5I_INVALID_HID == fapl_id) {
+        PB_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if ( cl_config ) {
+
+        if (H5CL_load_vfd_config_str_into_fapl(fapl_id, config_str) < 0) {
+            PB_TEST_FAULT("can't load config string into fapl\n");
+        }
+    } else {
+
+        if (H5Pset_fapl_pb(fapl_id, &vfd_config) < 0) {
+            PB_TEST_FAULT("can't set pb FAPL\n");
+        }
+    }
+
+    if (H5Pget_driver(fapl_id) != H5FD_PB) {
+        PB_TEST_FAULT("set FAPL not PB\n");
+    }
+
+
+    /* Opens a file that doesn't exist, should create the file */
+
+    if (NULL == (file_ptr = H5FDopen(filename, H5F_ACC_RDWR | H5F_ACC_CREAT,
+                    fapl_id, HADDR_UNDEF))) 
+        PB_TEST_FAULT("couldn't get pointer to H5FD_t structure\n");
+
+    
+    /***** Write middle test *****/
+
+    page = (unsigned char *)malloc(vfd_config.page_size);
+    if (NULL == page) 
+        PB_TEST_FAULT("couldn't allocate memory for buffer (page)\n");
+
+
+    /* Fill the buffer with random characters to simulate data */
+
+    for (size_t i = 0; i < vfd_config.page_size; i++)
+        page[i] = (unsigned char)rand() % 256;
+
+
+    /* set the eoa so we can write the page of data */
+
+    if ( H5FDset_eoa(file_ptr, H5FD_MEM_DEFAULT, (haddr_t)(vfd_config.page_size)) < 0 )
+        PB_TEST_FAULT("couldn't set file eoa\n");
+
+
+    /* Write the data to the file */
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, 
+                    vfd_config.page_size, page) < 0)
+        PB_TEST_FAULT("couldn't write data to file\n");
+
+    
+    /***** Read middle test *****/
+    
+    read_buf = (unsigned char *)malloc(vfd_config.page_size);
+    if (NULL == read_buf) 
+        PB_TEST_FAULT("couldn't allocate memory for buffer (read_buf)\n");
+    
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0,  
+                    vfd_config.page_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    if (memcmp(page, read_buf, vfd_config.page_size) != 0) 
+        PB_TEST_FAULT("data read from file doesn't match data written\n");
+    
+    
+    if (H5Pclose(fapl_id) < 0) 
+        PB_TEST_FAULT("can't close FAPL ID\n");
+    
+    if (H5FDclose(file_ptr) < 0)
+        PB_TEST_FAULT("can't close file\n");
+
+
+done:
+
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Pclose(fapl_id);
+            H5FDclose(file_ptr);
+        }
+        H5E_END_TRY
+    }
+
+    if (page) 
+        free(page);
+    
+    if (read_buf)
+        free(read_buf);
+
+    return ret_value;
+
+} /* end pb_test_create_write_read */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    pb_test_head_middle_tail
+ *
+ * Purpose:     Writes and reads a head, middle, and tail.
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ * Description: Opens a file and writes 96 pages in the file to test 
+ *              reading and writing with a non-blank file. Then closes the
+ *              the file and reopens it to start fresh. Then writes and 
+ *              reads head, middle, and tail pages, and compares read data
+ *              to ensure file is correct after write and reads.
+ *              
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+pb_test_head_middle_tail(bool cl_config)
+{
+    char                  filename[1024];
+    hid_t                 fapl_id        = H5I_INVALID_HID;
+    H5FD_t               *file_ptr       = NULL;
+    int                   ret_value      = 0;
+    char                  config_str[] =
+        "( page_buffer "       
+        "  ( ( page_size 4096 )" 
+        "    ( max_num_pages 64 )"
+        "    ( replacement_policy 0 )"
+        "  )"
+        ")";
+    H5FD_pb_vfd_config_t vfd_config =
+    {
+        /* magic            = */ H5FD_PB_CONFIG_MAGIC,
+        /* version          = */ H5FD_CURR_PB_VFD_CONFIG_VERSION,
+        /* page_size        = */ H5FD_PB_DEFAULT_PAGE_SIZE,
+        /* max_num_pages    = */ H5FD_PB_DEFAULT_MAX_NUM_PAGES,
+        /* rp               = */ H5FD_PB_DEFAULT_REPLACEMENT_POLICY,
+        /* fapl_id          = */ H5P_DEFAULT,
+        /* testing          = */ H5FD_PB_DEFAULT_TESTING_OFF
+    };
+    unsigned char        *setup_buf  = NULL;
+    unsigned char        *page         = NULL;
+    unsigned char        *read_buf     = NULL;
+    size_t                partial_page_size = vfd_config.page_size / 2;
+
+    /* setup the target file name, and delete any existing instance */
+
+    h5_fixname(FILENAME[16], vfd_config.fapl_id, filename, 1024);
+    HDremove(filename);
+
+    /* Create a new fapl to use the page buffer file driver */
+
+    fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+
+    if (H5I_INVALID_HID == fapl_id) {
+        PB_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if ( cl_config ) {
+
+        if (H5CL_load_vfd_config_str_into_fapl(fapl_id, config_str) < 0) {
+            PB_TEST_FAULT("can't load config string into fapl\n");
+        }
+    } else {
+
+        if (H5Pset_fapl_pb(fapl_id, &vfd_config) < 0) {
+            PB_TEST_FAULT("can't set pb FAPL\n");
+        }
+    }
+
+    if (H5Pget_driver(fapl_id) != H5FD_PB) {
+        PB_TEST_FAULT("set FAPL not PB\n");
+    }
+
+    
+    /* Opens a file that doesn't exist, should create the file */
+    
+    if (NULL == (file_ptr = H5FDopen(filename, H5F_ACC_RDWR | H5F_ACC_CREAT,
+                    fapl_id, HADDR_UNDEF))) 
+        PB_TEST_FAULT("couldn't get pointer to H5FD_t structure\n");
+
+    
+    
+    /***** Sets up file to be non-empty *****/
+    
+    setup_buf = (unsigned char *)malloc(vfd_config.page_size * 96);
+    if (NULL == setup_buf) 
+        PB_TEST_FAULT("couldn't allocate memory for buffer (setup_buf)\n");
+    
+    for (size_t i = 0; i < vfd_config.page_size * 96; i++)
+        setup_buf[i] = (unsigned char)rand() % 256;
+
+    if ( H5FDset_eoa(file_ptr, H5FD_MEM_DEFAULT, (haddr_t)(vfd_config.page_size * 96)) < 0 )
+        PB_TEST_FAULT("couldn't set file eoa\n");
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, 
+                    vfd_config.page_size * 96, setup_buf) < 0)
+        PB_TEST_FAULT("couldn't write create_file to file\n");
+
+
+
+    /* Closes the file and fapl to start tests fresh */
+    if (H5Pclose(fapl_id) < 0) 
+        PB_TEST_FAULT("can't close FAPL ID\n");
+    
+    if (H5FDclose(file_ptr) < 0)
+        PB_TEST_FAULT("can't close file\n");
+
+
+
+    /***** Creates new fapl and reopens file for tests *****/
+    
+    fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+
+    if (H5I_INVALID_HID == fapl_id) {
+        PB_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if (H5Pset_fapl_pb(fapl_id, &vfd_config) < 0) {
+        PB_TEST_FAULT("can't set pb FAPL\n");
+    }
+
+    if (H5Pget_driver(fapl_id) != H5FD_PB) {
+        PB_TEST_FAULT("set FAPL not PB\n");
+    }
+
+    if (NULL == (file_ptr = H5FDopen(filename, H5F_ACC_RDWR | H5F_ACC_CREAT,
+                    fapl_id, HADDR_UNDEF))) 
+        PB_TEST_FAULT("couldn't get pointer to H5FD_t structure\n");
+
+    if ( H5FDset_eoa(file_ptr, H5FD_MEM_DEFAULT, (haddr_t)(vfd_config.page_size * 96)) < 0 )
+        PB_TEST_FAULT("couldn't set file eoa\n");
+
+
+    /**********************/
+    /***** Head Tests *****/
+    /**********************/
+
+    page = (unsigned char *)malloc(vfd_config.page_size);
+    if (NULL == page) 
+        PB_TEST_FAULT("couldn't allocate memory for buffer (page)\n");
+
+    for (size_t i = 0; i < vfd_config.page_size; i++)
+        page[i] = (unsigned char)rand() % 256;
+
+    read_buf = (unsigned char *)malloc(vfd_config.page_size);
+    if (NULL == read_buf) 
+        PB_TEST_FAULT("couldn't allocate memory for buffer (read_buf)\n");
+
+
+
+    /***** Write head when page is NOT in page buffer *****/
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 2048, partial_page_size, page) < 0)
+        PB_TEST_FAULT("couldn't write head to file\n");
+
+
+    /***** Read head when page is NOT in page buffer *****/
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 6144, partial_page_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read head from file\n");
+    
+    if (memcmp(setup_buf + 6144, read_buf, partial_page_size) != 0) 
+        PB_TEST_FAULT("head read from file doesn't match data written\n");
+
+
+
+    /***** Write head when page is in page buffer *****/
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 6144, partial_page_size, page) < 0)
+        PB_TEST_FAULT("couldn't write head to file\n");
+
+
+    /***** Read head when page is in page buffer *****/
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 2048, partial_page_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read head from file\n");
+
+    if (memcmp(page, read_buf, partial_page_size) != 0) 
+        PB_TEST_FAULT("head read from file doesn't match data written\n");
+
+
+
+    /***** Write head when data starts and ends inside of a page *****/
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 1000, partial_page_size, page) < 0)
+        PB_TEST_FAULT("couldn't write head to file\n");
+
+    
+    /***** Read head when data starts and ends inside of a page *****/
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 1000, partial_page_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read head from file\n");
+
+    if (memcmp(page, read_buf, partial_page_size) != 0) 
+        PB_TEST_FAULT("head read from file doesn't match data written\n");
+
+
+
+    /************************/
+    /***** Middle Tests *****/
+    /************************/
+
+    /***** Write middle when page is NOT in page buffer *****/
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 8191, vfd_config.page_size, page) < 0)
+        PB_TEST_FAULT("couldn't write data to file\n");
+
+    
+    /***** Read middle when page is NOT in page buffer *****/
+    
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 12288, vfd_config.page_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    if (memcmp(setup_buf + 12288, read_buf, vfd_config.page_size) != 0) 
+        PB_TEST_FAULT("data read from file doesn't match data written\n");
+
+    
+    
+    /***** Write middle when page is in page buffer *****/
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 4096, vfd_config.page_size, page) < 0)
+        PB_TEST_FAULT("couldn't write data to file\n");
+    
+
+
+    /***** Read middle when page is in page buffer *****/
+
+    /* head read to get the needed page for the middle read test in the page buffer */
+    if(H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 14336, partial_page_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 12288, vfd_config.page_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    if (memcmp(setup_buf + 12288, read_buf, vfd_config.page_size) != 0) 
+        PB_TEST_FAULT("data read from file doesn't match data written\n");
+
+
+
+
+    /**********************/
+    /***** Tail Tests *****/
+    /**********************/
+
+
+    /***** Write tail when page is NOT in page buffer *****/
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 16384, partial_page_size, page) < 0)
+        PB_TEST_FAULT("couldn't write tail to file\n");
+
+    
+    /***** Read tail when page is NOT in page buffer *****/
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 20480, partial_page_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read tail from file\n");
+
+    if (memcmp(setup_buf + 20480, read_buf, partial_page_size) != 0) 
+        PB_TEST_FAULT("tail read from file doesn't match data written\n");
+
+    
+
+
+    /***** Write tail when page is in page buffer *****/
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 20480, partial_page_size, page) < 0)
+        PB_TEST_FAULT("couldn't write tail to file\n");
+
+    
+    /***** Read tail when page is in page buffer *****/
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 16384, partial_page_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read tail from file\n");
+
+    if (memcmp(page, read_buf, partial_page_size) != 0) 
+        PB_TEST_FAULT("tail read from file doesn't match data written\n");
+
+
+
+    /***** End Tests *****/   
+
+    if (H5Pclose(fapl_id) < 0) 
+        PB_TEST_FAULT("can't close FAPL ID\n");
+    
+    if (H5FDclose(file_ptr) < 0)
+        PB_TEST_FAULT("can't close file\n");
+
+
+done:
+
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Pclose(fapl_id);
+            H5FDclose(file_ptr);
+        }
+        H5E_END_TRY
+    }
+
+    if (setup_buf) 
+        free(setup_buf);
+
+    if (page) 
+        free(page);
+    
+    if (read_buf)
+        free(read_buf);
+
+    return ret_value;
+
+} /* end pb_test_head_middle_tail */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    pb_test_rp_eviction_and_invalidation
+ *
+ * Purpose:     Ensures the replacement policy (rp)'s eviction and
+ *              invalidation functions work as expected.
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ * Description: Opens a file and writes 64 tail pages to it (tail pages 
+ *              are used because they're easier to calculate the offset),
+ *              to fill the page buffer with the max number of pages it 
+ *              can hold. 
+ * 
+ *              Eviction:
+ *              Then a new partial page is read to evict a page in the rp 
+ *              list for the new page. An array with the expected addrs of 
+ *              the pages that should be in the rp list is created (in the 
+ *              same order as they should be in the rp list). A testing 
+ *              function is called to read the rp list and return the
+ *              actual addrs of the pages in the rp list. The expected and
+ *              actual addrs are compared to ensure they match.
+ * 
+ *              Four more partial pages are read, that exists in the hash
+ *              table (ht) to touch them updating their postion based on
+ *              Least Recently Used (LRU) replacement policy. The expected
+ *              addr array is updated to reflect the new order of what the
+ *              pages in the rp list should be. The testing function is
+ *              called again to get the actual addrs of the pages in the rp
+ *              list. The expected and actual addrs are compared to ensure
+ *              they match.
+ * 
+ *              Invalidate:
+ *              A middle write is performed to invalidate a page
+ *              in the page buffer. This should move the page to be the
+ *              next page to be evicted. A tail read is done with the
+ *              addr of the page that was just invalidated. This checks to 
+ *              ensure the invalidated page will not be used to satisfy the
+ *              tail read, and it will have to read the page from the file
+ *              evicting the invalidated page for the one from file.
+ *              The expected addr array is updated to reflect the new order
+ *              of the rp list, and the testing function is called to get 
+ *              the actual addrs of the pages in the rp list. The expected 
+ *              and actual addrs are compared to ensure they match.
+ * 
+ *              An invalidation test is done again, but this time a
+ *              different page is being read in than what was invalidated.
+ * 
+ *              
+ *-------------------------------------------------------------------------
+ */
+static int
+pb_test_rp_eviction_and_invalidation(bool cl_config)
+{
+
+    char                  filename[1024];
+    hid_t                 fapl_id        = H5I_INVALID_HID;
+    H5FD_t               *file_ptr       = NULL;
+    haddr_t               expected_rp_addrs_after_eviction[64];
+    haddr_t               actual_rp_addrs_after_eviction[64];
+    haddr_t              *returned_array = NULL;
+
+    int                   ret_value      = 0;
+    char                  config_str[] =
+        "( page_buffer "
+        "  ( ( page_size 4096 )"
+        "    ( max_num_pages 64 )"
+        "    ( replacement_policy 0 )"
+        "    ( testing 1 )"
+        "  )"
+        ")";
+    H5FD_pb_vfd_config_t vfd_config =
+    {
+        /* magic            = */ H5FD_PB_CONFIG_MAGIC,
+        /* version          = */ H5FD_CURR_PB_VFD_CONFIG_VERSION,
+        /* page_size        = */ H5FD_PB_DEFAULT_PAGE_SIZE,
+        /* max_num_pages    = */ H5FD_PB_DEFAULT_MAX_NUM_PAGES,
+        /* rp               = */ H5FD_PB_DEFAULT_REPLACEMENT_POLICY,
+        /* fapl_id          = */ H5P_DEFAULT,
+        /* testing          = */ true
+    };
+    unsigned char        *setup_buf    = NULL;
+    unsigned char        *page         = NULL;
+    unsigned char        *read_buf     = NULL;
+    size_t                partial_page_size = vfd_config.page_size / 2;
+    size_t                i            = 0;
+
+    /* setup the target file name */
+
+    h5_fixname(FILENAME[16], vfd_config.fapl_id, filename, 1024);
+
+
+    /* Create a new fapl to use the page buffer file driver */
+
+    fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+
+    if (H5I_INVALID_HID == fapl_id) {
+        PB_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if ( cl_config ) {
+
+        if (H5CL_load_vfd_config_str_into_fapl(fapl_id, config_str) < 0) {
+            PB_TEST_FAULT("can't load config string into fapl\n");
+        }
+    } else {
+
+        if (H5Pset_fapl_pb(fapl_id, &vfd_config) < 0) {
+            PB_TEST_FAULT("can't set pb FAPL\n");
+        }
+    }
+
+    if (H5Pget_driver(fapl_id) != H5FD_PB) {
+        PB_TEST_FAULT("set FAPL not PB\n");
+    }
+
+    /* Opens a file that does exist */
+
+    if (NULL == (file_ptr = H5FDopen(filename, H5F_ACC_RDWR | H5F_ACC_CREAT,
+                    fapl_id, HADDR_UNDEF))) 
+        PB_TEST_FAULT("couldn't get pointer to H5FD_t structure\n");
+
+    /***** Sets up file to be non-empty *****/
+
+    setup_buf = (unsigned char *)malloc(vfd_config.page_size);
+    if (NULL == setup_buf) 
+        PB_TEST_FAULT("couldn't allocate memory for buffer (setup_buf)\n");
+    
+    for (i = 0; i < vfd_config.page_size; i++)
+        setup_buf[i] = (unsigned char)rand() % 256;
+
+    if ( H5FDset_eoa(file_ptr, H5FD_MEM_DEFAULT, (haddr_t)(vfd_config.page_size * 96)) < 0 )
+        PB_TEST_FAULT("couldn't set file eoa\n");
+
+
+    /* loops 64 times to fill the page buffer to it's maximum pages */
+    for (i = 0; i < 64; i++) {
+
+        if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, i * vfd_config.page_size, 
+                        partial_page_size, setup_buf) < 0)
+            PB_TEST_FAULT("couldn't write page to file\n");
+    }
+
+    page = (unsigned char *)malloc(vfd_config.page_size);
+    if (NULL == page) 
+        PB_TEST_FAULT("couldn't allocate memory for buffer (page)\n");
+
+    for (i = 0; i < vfd_config.page_size; i++)
+        page[i] = (unsigned char)rand() % 256;
+
+    read_buf = (unsigned char *)malloc(vfd_config.page_size);
+    if (NULL == read_buf) 
+        PB_TEST_FAULT("couldn't allocate memory for buffer (read_buf)\n");
+
+
+
+    /*************************/
+    /***** Eviction Test *****/
+    /*************************/
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 64 * vfd_config.page_size,  
+                    partial_page_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    for (i = 0; i < 64; i++) {
+
+        expected_rp_addrs_after_eviction[i] = (i + 1) * vfd_config.page_size;
+    }
+
+    returned_array = (haddr_t *)malloc(H5FD_PB_DEFAULT_MAX_NUM_PAGES * sizeof(haddr_t));
+    if (NULL == returned_array) 
+        PB_TEST_FAULT("unable to allocate memory for current_rp_addrs\n");
+
+    if (NULL == H5FD__pb_rp_eviction_check(file_ptr, returned_array)) 
+        PB_TEST_FAULT("couldn't get replacement policy addresses\n");
+
+    memcpy(actual_rp_addrs_after_eviction, returned_array, 64 * sizeof(haddr_t));
+
+    if (memcmp(expected_rp_addrs_after_eviction, actual_rp_addrs_after_eviction, 64 * sizeof(haddr_t)) != 0) 
+        PB_TEST_FAULT("expected pages in rp don't match the actual pages in rp.\n");
+
+
+
+
+    /***** Rearranging rp list with touches *****/
+
+    for (i = 1; i < 5; i++) {
+
+        if ( H5FDread ( file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, i * 4096, partial_page_size, read_buf ) < 0 )
+            PB_TEST_FAULT("couldn't read data from file\n");
+    }
+
+    for (i = 0; i < 64; i++) {
+
+        if ( i < 60 ) {
+
+            expected_rp_addrs_after_eviction[i] = (i + 5) * vfd_config.page_size;
+        }
+
+        else {
+
+            expected_rp_addrs_after_eviction[i] = (i - 59) * vfd_config.page_size;
+        } 
+    }
+
+
+    returned_array = H5FD__pb_rp_eviction_check(file_ptr, returned_array);
+    if (returned_array == NULL) 
+        PB_TEST_FAULT("couldn't get replacement policy addresses\n");
+
+    memcpy(actual_rp_addrs_after_eviction, returned_array, 64 * sizeof(haddr_t));
+
+    if (memcmp(expected_rp_addrs_after_eviction, actual_rp_addrs_after_eviction, 64 * sizeof(haddr_t)) != 0) 
+        PB_TEST_FAULT("expected pages in rp don't match the actual pages in rp.\n");
+
+
+
+
+    /*****************************/
+    /***** Invalidation Test *****/
+    /*****************************/
+
+    /***** middle write to invalidate a page putting it next to be evicted *****/
+
+    /* reading same page that was invalidated */
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 24 * vfd_config.page_size, 
+                    vfd_config.page_size, page) < 0)
+        PB_TEST_FAULT("couldn't write data to file\n");
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 24 * vfd_config.page_size,  
+                    partial_page_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    
+    for ( i = 0; i < 64; i++) {
+
+        if ( i < 19 ) {
+            expected_rp_addrs_after_eviction[i] = (i + 5) * vfd_config.page_size;
+        }
+
+        else if ( i >= 19 && i < 59 ) {
+            expected_rp_addrs_after_eviction[i] = (i + 6) * vfd_config.page_size;
+        }
+
+        else if ( i >= 59 && i < 63 ) {
+            expected_rp_addrs_after_eviction[i] = (i - 58) * vfd_config.page_size;
+        }
+
+        else {
+            expected_rp_addrs_after_eviction[i] = 24 * vfd_config.page_size;
+        }
+    }
+
+    returned_array = H5FD__pb_rp_eviction_check(file_ptr, returned_array);
+    if (returned_array == NULL) 
+        PB_TEST_FAULT("couldn't get replacement policy addresses\n");
+
+    memcpy(actual_rp_addrs_after_eviction, returned_array, 64 * sizeof(haddr_t));
+
+    if (memcmp(expected_rp_addrs_after_eviction, actual_rp_addrs_after_eviction, 64 * sizeof(haddr_t)) != 0) 
+        PB_TEST_FAULT("expected pages in rp don't match the actual pages in rp.\n");
+
+
+
+    /***** middle write to invalidate a page putting it next to be evicted *****/
+
+    /* reading different page that was invalidated */
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 16 * vfd_config.page_size, 
+                    vfd_config.page_size, page) < 0)
+        PB_TEST_FAULT("couldn't write data to file\n");
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0 * vfd_config.page_size,  
+                    partial_page_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    
+    for ( i = 11; i < 64; i++) {
+
+        if ( i < 18 ) {
+            expected_rp_addrs_after_eviction[i] = (i + 6) * vfd_config.page_size;
+        }
+
+        else if ( i >= 18 && i < 58 ) {
+            expected_rp_addrs_after_eviction[i] = (i + 7) * vfd_config.page_size;
+        }
+
+        else if ( i >= 58 && i < 62 ) {
+            expected_rp_addrs_after_eviction[i] = (i - 57) * vfd_config.page_size;
+        }
+
+        else if ( i == 62 ) {
+            expected_rp_addrs_after_eviction[i] = 24 * vfd_config.page_size;
+        }
+
+        else {
+            expected_rp_addrs_after_eviction[i] = 0 * vfd_config.page_size;
+        }
+    }
+
+    returned_array = H5FD__pb_rp_eviction_check(file_ptr, returned_array);
+    if (returned_array == NULL) 
+        PB_TEST_FAULT("couldn't get replacement policy addresses\n");
+
+    memcpy(actual_rp_addrs_after_eviction, returned_array, 64 * sizeof(haddr_t));
+
+    if (memcmp(expected_rp_addrs_after_eviction, actual_rp_addrs_after_eviction, 64 * sizeof(haddr_t)) != 0) 
+        PB_TEST_FAULT("expected pages in rp don't match the actual pages in rp.\n");
+
+
+
+
+    /***** End Tests *****/   
+
+    if (H5Pclose(fapl_id) < 0) 
+        PB_TEST_FAULT("can't close FAPL ID\n");
+    
+    if (H5FDclose(file_ptr) < 0)
+        PB_TEST_FAULT("can't close file\n");
+
+
+done:
+
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Pclose(fapl_id);
+            H5FDclose(file_ptr);
+        }
+        H5E_END_TRY
+    }
+
+    if (setup_buf) 
+        free(setup_buf);
+
+    if (page) 
+        free(page);
+    
+    if (read_buf)
+        free(read_buf);
+
+    if (returned_array)
+        free(returned_array);
+
+    return ret_value;
+
+} /* end pb_test_rp_eviction_and_invalidation */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    pb_test_rp_eviction_and_invalidation_fifo
+ *
+ * Purpose:     Ensures the replacement policy (rp)'s eviction and
+ *              invalidation functions work as expected.
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ * Description: The same tests are done as the previous test function 
+ *              (pb_test_rp_eviction_and_invalidation), but this time with
+ *              first in first out (FIFO) replacement policy, excluding the 
+ *              touch tests, because touch doesn't matter in FIFO. 
+ * 
+ *              
+ *-------------------------------------------------------------------------
+ */
+static int
+pb_test_rp_eviction_and_invalidation_fifo(bool cl_config)
+{
+
+    char                  filename[1024];
+    hid_t                 fapl_id        = H5I_INVALID_HID;
+    H5FD_t               *file_ptr       = NULL;
+    haddr_t               expected_rp_addrs_after_eviction[64];
+    haddr_t               actual_rp_addrs_after_eviction[64];
+    haddr_t              *returned_array = NULL;
+
+    int                   ret_value      = 0;
+    char                  config_str[] =
+        "( page_buffer "       
+        "  ( ( page_size 4096 )" 
+        "    ( max_num_pages 64 )"
+        "    ( replacement_policy 1 )"
+        "    ( testing 1 )"
+        "  )"
+        ")"; 
+    H5FD_pb_vfd_config_t vfd_config =
+    {
+        /* magic            = */ H5FD_PB_CONFIG_MAGIC,
+        /* version          = */ H5FD_CURR_PB_VFD_CONFIG_VERSION,
+        /* page_size        = */ H5FD_PB_DEFAULT_PAGE_SIZE,
+        /* max_num_pages    = */ H5FD_PB_DEFAULT_MAX_NUM_PAGES,
+        /* rp               = */ 1, /* FIFO */
+        /* fapl_id          = */ H5P_DEFAULT,
+        /* testing          = */ true
+    };
+    unsigned char        *setup_buf    = NULL;
+    unsigned char        *page         = NULL;
+    unsigned char        *read_buf     = NULL;
+    size_t                partial_page_size = vfd_config.page_size / 2;
+    size_t                i            = 0;
+
+    /* setup the target file name */
+
+    h5_fixname(FILENAME[16], vfd_config.fapl_id, filename, 1024);
+
+
+    /* Create a new fapl to use the page buffer file driver */
+
+    fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+
+    if (H5I_INVALID_HID == fapl_id) {
+        PB_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if ( cl_config ) {
+
+        if (H5CL_load_vfd_config_str_into_fapl(fapl_id, config_str) < 0) {
+            PB_TEST_FAULT("can't load config string into fapl\n");
+        }
+    } else {
+
+        if (H5Pset_fapl_pb(fapl_id, &vfd_config) < 0) {
+            PB_TEST_FAULT("can't set pb FAPL\n");
+        }
+    }
+
+    if (H5Pget_driver(fapl_id) != H5FD_PB) {
+        PB_TEST_FAULT("set FAPL not PB\n");
+    }
+
+    /* Opens a file that does exist */
+
+    if (NULL == (file_ptr = H5FDopen(filename, H5F_ACC_RDWR | H5F_ACC_CREAT,
+                    fapl_id, HADDR_UNDEF))) 
+        PB_TEST_FAULT("couldn't get pointer to H5FD_t structure\n");
+
+    /***** Sets up file to be non-empty *****/
+
+    setup_buf = (unsigned char *)malloc(vfd_config.page_size);
+    if (NULL == setup_buf) 
+        PB_TEST_FAULT("couldn't allocate memory for buffer (setup_buf)\n");
+    
+    for (i = 0; i < vfd_config.page_size; i++)
+        setup_buf[i] = (unsigned char)rand() % 256;
+
+    if ( H5FDset_eoa(file_ptr, H5FD_MEM_DEFAULT, (haddr_t)(vfd_config.page_size * 96)) < 0 )
+        PB_TEST_FAULT("couldn't set file eoa\n");
+
+
+    /* loops 64 times to fill the page buffer to it's maximum pages */
+    for (i = 0; i < 64; i++) {
+
+        if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, i * vfd_config.page_size, 
+                        partial_page_size, setup_buf) < 0)
+            PB_TEST_FAULT("couldn't write page to file\n");
+    }
+
+    page = (unsigned char *)malloc(vfd_config.page_size);
+    if (NULL == page) 
+        PB_TEST_FAULT("couldn't allocate memory for buffer (page)\n");
+
+    for (i = 0; i < vfd_config.page_size; i++)
+        page[i] = (unsigned char)rand() % 256;
+
+    read_buf = (unsigned char *)malloc(vfd_config.page_size);
+    if (NULL == read_buf) 
+        PB_TEST_FAULT("couldn't allocate memory for buffer (read_buf)\n");
+
+
+
+    /************************************/
+    /***** Eviction Test Using FIFO *****/
+    /************************************/
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 64 * vfd_config.page_size,  
+                    partial_page_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    for (i = 0; i < 64; i++) {
+
+        expected_rp_addrs_after_eviction[i] = (i + 1) * vfd_config.page_size;
+    }
+
+    returned_array = (haddr_t *)malloc(H5FD_PB_DEFAULT_MAX_NUM_PAGES * sizeof(haddr_t));
+    if (NULL == returned_array) 
+        PB_TEST_FAULT("unable to allocate memory for current_rp_addrs\n");
+
+    returned_array = H5FD__pb_rp_eviction_check(file_ptr, returned_array);
+    if (returned_array == NULL) 
+        PB_TEST_FAULT("couldn't get replacement policy addresses\n");
+
+    memcpy(actual_rp_addrs_after_eviction, returned_array, 64 * sizeof(haddr_t));
+
+    if (memcmp(expected_rp_addrs_after_eviction, actual_rp_addrs_after_eviction, 64 * sizeof(haddr_t)) != 0) 
+        PB_TEST_FAULT("expected pages in rp don't match the actual pages in rp.\n");
+
+
+
+    /***** Touching a page in the page buffer, should not rearrange the rp list with FIFO */
+
+    for (i = 1; i < 5; i++) {
+
+        if ( H5FDread ( file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, i * 4096, partial_page_size, read_buf ) < 0 )
+            PB_TEST_FAULT("couldn't read data from file\n");
+    }
+
+    returned_array = H5FD__pb_rp_eviction_check(file_ptr, returned_array);
+    if (returned_array == NULL) 
+        PB_TEST_FAULT("couldn't get replacement policy addresses\n");
+
+    memcpy(actual_rp_addrs_after_eviction, returned_array, 64 * sizeof(haddr_t));
+
+    if (memcmp(expected_rp_addrs_after_eviction, actual_rp_addrs_after_eviction, 64 * sizeof(haddr_t)) != 0) 
+        PB_TEST_FAULT("expected pages in rp don't match the actual pages in rp.\n");
+
+
+
+
+    /*****************************/
+    /***** Invalidation Test *****/
+    /*****************************/
+
+    /***** middle write to invalidate a page putting it next to be evicted *****/
+
+    /* reading same page that was invalidated */
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 24 * vfd_config.page_size, 
+                    vfd_config.page_size, page) < 0)
+        PB_TEST_FAULT("couldn't write data to file\n");
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 24 * vfd_config.page_size,  
+                    partial_page_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    
+    for ( i = 0; i < 64; i++ ) {
+
+        if ( i < 23 ) {
+            
+            expected_rp_addrs_after_eviction[i] = ( i + 1 ) * vfd_config.page_size;
+        }
+
+        else if ( i >= 23 && i < 63 ) {
+
+            expected_rp_addrs_after_eviction[i] = ( i + 2 ) * vfd_config.page_size;
+        }
+
+        else {
+
+            expected_rp_addrs_after_eviction[i] = 24 * vfd_config.page_size;
+        }
+    }
+
+    
+
+    returned_array = H5FD__pb_rp_eviction_check(file_ptr, returned_array);
+    if (returned_array == NULL) 
+        PB_TEST_FAULT("couldn't get replacement policy addresses\n");
+
+    memcpy(actual_rp_addrs_after_eviction, returned_array, 64 * sizeof(haddr_t));
+
+
+    if (memcmp(expected_rp_addrs_after_eviction, actual_rp_addrs_after_eviction, 64 * sizeof(haddr_t)) != 0) 
+        PB_TEST_FAULT("expected pages in rp don't match the actual pages in rp.\n");
+
+
+
+    /***** middle write to invalidate a page putting it next to be evicted *****/
+
+    /* reading different page that was invalidated */
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 16 * vfd_config.page_size, 
+                    vfd_config.page_size, page) < 0)
+        PB_TEST_FAULT("couldn't write data to file\n");
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0 * vfd_config.page_size,  
+                    partial_page_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    
+    for ( i = 15; i < 64; i++ ) {
+
+        if ( i >= 15 && i < 22 ) {
+
+            expected_rp_addrs_after_eviction[i] = ( i + 2 ) * vfd_config.page_size;
+        }
+
+        else if ( i >= 22 && i < 62 ) {
+
+            expected_rp_addrs_after_eviction[i] = ( i + 3 ) * vfd_config.page_size;
+        }
+
+        else if ( i == 62 ) {
+
+            expected_rp_addrs_after_eviction[i] = 24 * vfd_config.page_size;
+        }
+
+        else {
+
+            expected_rp_addrs_after_eviction[i] = 0;
+        }
+    }
+
+
+    returned_array = H5FD__pb_rp_eviction_check(file_ptr, returned_array);
+    if (returned_array == NULL) 
+        PB_TEST_FAULT("couldn't get replacement policy addresses\n");
+
+    memcpy(actual_rp_addrs_after_eviction, returned_array, 64 * sizeof(haddr_t));
+
+
+    if (memcmp(expected_rp_addrs_after_eviction, actual_rp_addrs_after_eviction, 64 * sizeof(haddr_t)) != 0) 
+        PB_TEST_FAULT("expected pages in rp don't match the actual pages in rp.\n");
+
+
+
+    /***** End Tests *****/   
+
+    if (H5Pclose(fapl_id) < 0) 
+        PB_TEST_FAULT("can't close FAPL ID\n");
+    
+    if (H5FDclose(file_ptr) < 0)
+        PB_TEST_FAULT("can't close file\n");
+
+
+done:
+
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Pclose(fapl_id);
+            H5FDclose(file_ptr);
+        }
+        H5E_END_TRY
+    }
+
+    if (setup_buf) 
+        free(setup_buf);
+
+    if (page) 
+        free(page);
+    
+    if (read_buf)
+        free(read_buf);
+
+    if (returned_array)
+        free(returned_array);
+
+    return ret_value;
+
+} /* end pb_test_rp_eviction_and_invalidation_fifo() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    pb_test_page_combinations
+ *
+ * Purpose:     Tests different combinations of head, middle, and tail
+ *              pages.
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ * Description: Opens the file from the previous test, and performs write 
+ *              and read tests of different combinations of head, middle,
+ *              and tail pages. 
+ *              
+ *              The tests are as follows:
+ *              - head and tail
+ *              - head and middle
+ *              - middle and tail 
+ *              - head, middle, and tail
+ *              - head, multiple middles, and tail
+ *              
+ *-------------------------------------------------------------------------
+ */
+static int
+pb_test_page_combinations(bool cl_config)
+{
+    char                  filename[1024];
+    hid_t                 fapl_id        = H5I_INVALID_HID;
+    H5FD_t               *file_ptr       = NULL;
+    int                   ret_value      = 0;
+    char                  config_str[] =
+        "( page_buffer "
+        "  ( ( page_size 4096 )" 
+        "    ( max_num_pages 64 )"
+        "    ( replacement_policy 0 )"
+        "  )"
+        ")";
+    H5FD_pb_vfd_config_t vfd_config =
+    {
+        /* magic            = */ H5FD_PB_CONFIG_MAGIC,
+        /* version          = */ H5FD_CURR_PB_VFD_CONFIG_VERSION,
+        /* page_size        = */ H5FD_PB_DEFAULT_PAGE_SIZE,
+        /* max_num_pages    = */ H5FD_PB_DEFAULT_MAX_NUM_PAGES,
+        /* rp               = */ H5FD_PB_DEFAULT_REPLACEMENT_POLICY,
+        /* fapl_id          = */ H5P_DEFAULT,
+        /* testing          = */ H5FD_PB_DEFAULT_TESTING_OFF
+    };
+    unsigned char        *write_buf    = NULL;
+    unsigned char        *read_buf     = NULL;
+    size_t                buf_size     = vfd_config.page_size * 6;
+    size_t                i            = 0;
+
+    /* setup the target file name, and delete any existing instance */
+
+    h5_fixname(FILENAME[16], vfd_config.fapl_id, filename, 1024);
+
+    /* Create a new fapl to use the page buffer file driver */
+
+    fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+
+    if (H5I_INVALID_HID == fapl_id) {
+        PB_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if ( cl_config ) {
+
+        if (H5CL_load_vfd_config_str_into_fapl(fapl_id, config_str) < 0) {
+            PB_TEST_FAULT("can't load config string into fapl\n");
+        }
+    } else {
+
+        if (H5Pset_fapl_pb(fapl_id, &vfd_config) < 0) {
+            PB_TEST_FAULT("can't set pb FAPL\n");
+        }
+    }
+
+    if (H5Pget_driver(fapl_id) != H5FD_PB) {
+        PB_TEST_FAULT("set FAPL not PB\n");
+    }
+
+    if (NULL == (file_ptr = H5FDopen(filename, H5F_ACC_RDWR | H5F_ACC_CREAT,
+                    fapl_id, HADDR_UNDEF))) 
+        PB_TEST_FAULT("couldn't get pointer to H5FD_t structure\n");
+
+    if ( H5FDset_eoa(file_ptr, H5FD_MEM_DEFAULT, (haddr_t)(vfd_config.page_size * 64)) < 0 )
+        PB_TEST_FAULT("couldn't set file eoa\n");
+
+    read_buf = (unsigned char *)malloc(buf_size);
+    if (NULL == read_buf) 
+        PB_TEST_FAULT("couldn't allocate memory for buffer (read_buf)\n");
+    
+    write_buf = (unsigned char *)malloc(buf_size);
+    if (NULL == write_buf) 
+        PB_TEST_FAULT("couldn't allocate memory for buffer (page)\n");
+
+    for (i = 0; i < buf_size; i++)
+        write_buf[i] = (unsigned char)rand() % 256;
+
+
+
+    /*************************/
+    /***** HEAD AND TAIL *****/
+    /*************************/
+
+    assert( vfd_config.page_size < buf_size );
+
+    /****** Read test *****/
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 10240, vfd_config.page_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    /****** Write test *****/
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 2000, vfd_config.page_size, write_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    /***** validate write *****/
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 2000, vfd_config.page_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    for ( i = 0; i < vfd_config.page_size; i++ ) {
+
+        if ( read_buf[i] != write_buf[i] )
+            PB_TEST_FAULT("write validation failed\n");
+    }
+
+
+    /***************************/
+    /***** HEAD AND MIDDLE *****/
+    /***************************/
+
+    assert( 6144 < buf_size );
+
+    /****** Read test *****/
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 22528, 6144, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    /****** Write test *****/
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 18432, 6144, write_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    /***** validate write *****/
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 18432, 6144, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    for ( i = 0; i < 6144; i++ ) {
+
+        if ( read_buf[i] != write_buf[i] )
+            PB_TEST_FAULT("write validation failed\n");
+    }
+
+
+    /***************************/
+    /***** MIDDLE AND TAIL *****/
+    /***************************/
+
+    assert( 6144 < buf_size );
+
+    /****** Read test *****/
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 32768, 6144, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    /****** Write test *****/
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 24500, 6144, write_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    /***** validate write *****/
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 24500, 6144, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    for ( i = 0; i < 6144; i++ ) {
+
+        if ( read_buf[i] != write_buf[i] )
+            PB_TEST_FAULT("write validation failed\n");
+    }
+
+
+    /**********************************/
+    /***** HEAD, MIDDLE, AND TAIL *****/
+    /**********************************/
+
+    assert( (vfd_config.page_size * 2) < buf_size );
+
+    /****** Read test *****/
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 61440, vfd_config.page_size * 2, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    /****** Write test *****/
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 47108, vfd_config.page_size * 2, write_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    /***** validate write *****/
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 47108, vfd_config.page_size * 2, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    for ( i = 0; i < vfd_config.page_size * 2; i++ ) {
+
+        if ( read_buf[i] != write_buf[i] )
+            PB_TEST_FAULT("write validation failed\n");
+    }
+
+
+    /********************************************/
+    /***** HEAD, MULTIPLE MIDDLES, AND TAIL *****/
+    /********************************************/
+
+    assert( (vfd_config.page_size * 5) < buf_size );
+
+    /****** Read test *****/
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 108544, vfd_config.page_size * 5, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    /****** Write test *****/
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 79872, vfd_config.page_size * 5, write_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    /***** validate write *****/
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 79872, vfd_config.page_size * 5, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    for ( i = 0; i < vfd_config.page_size * 5; i++ ) {
+
+        if ( read_buf[i] != write_buf[i] )
+            PB_TEST_FAULT("write validation failed\n");
+    }
+
+
+    /***** End Tests *****/   
+
+    if (H5Pclose(fapl_id) < 0) 
+        PB_TEST_FAULT("can't close FAPL ID\n");
+    
+    if (H5FDclose(file_ptr) < 0)
+        PB_TEST_FAULT("can't close file\n");
+
+
+done:
+
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Pclose(fapl_id);
+            H5FDclose(file_ptr);
+        }
+        H5E_END_TRY
+    }
+
+    if (write_buf) 
+        free(write_buf);
+    
+    if (read_buf)
+        free(read_buf);
+
+    return ret_value;
+
+} /* end pb_test_page_combinations */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    pb_test_specific_cases
+ *
+ * Purpose:     Tests multiple middle requests where only specific pages 
+ *              exist in the page buffer
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ * Description: Opens the file from the previous test, and performs write 
+ *              and read tests of multiple middles where specific ones
+ *              exist in the page buffer.
+ *              
+ *              The tests are as follows:
+ *              - multiple middles where the first page exists in the pb
+ *              - multiple middles where the last page exists in the pb
+ *              - multiple middles where two consecutive page exist in 
+ *                the pb, but the first and last middles do not
+ *              - multiple middles where alternating pages exist in the pb
+ *              
+ *-------------------------------------------------------------------------
+ */
+static int
+pb_test_specific_cases(bool cl_config)
+{
+    char                  filename[1024];
+    hid_t                 fapl_id        = H5I_INVALID_HID;
+    H5FD_t               *file_ptr       = NULL;
+    int                   ret_value      = 0;
+    char                  config_str[] =
+        "( page_buffer "
+        "  ( ( page_size 4096 )" 
+        "    ( max_num_pages 64 )"
+        "    ( replacement_policy 0 )"
+        "  )"
+        ")";
+    H5FD_pb_vfd_config_t vfd_config =
+    {
+        /* magic            = */ H5FD_PB_CONFIG_MAGIC,
+        /* version          = */ H5FD_CURR_PB_VFD_CONFIG_VERSION,
+        /* page_size        = */ H5FD_PB_DEFAULT_PAGE_SIZE,
+        /* max_num_pages    = */ H5FD_PB_DEFAULT_MAX_NUM_PAGES,
+        /* rp               = */ H5FD_PB_DEFAULT_REPLACEMENT_POLICY,
+        /* fapl_id          = */ H5P_DEFAULT,
+        /* testing          = */ H5FD_PB_DEFAULT_TESTING_OFF
+    };
+    unsigned char        *setup_buf    = NULL;
+    unsigned char        *write_buf    = NULL;
+    unsigned char        *read_buf     = NULL;
+    size_t                partial_size = vfd_config.page_size / 2;
+
+    /* setup the target file name, and delete any existing instance */
+
+    h5_fixname(FILENAME[16], vfd_config.fapl_id, filename, 1024);
+
+    /* Create a new fapl to use the page buffer file driver */
+
+    fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+
+    if (H5I_INVALID_HID == fapl_id) {
+        PB_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if ( cl_config ) {
+
+        if (H5CL_load_vfd_config_str_into_fapl(fapl_id, config_str) < 0) {
+            PB_TEST_FAULT("can't load config string into fapl\n");
+        }
+    } else {
+
+        if (H5Pset_fapl_pb(fapl_id, &vfd_config) < 0) {
+            PB_TEST_FAULT("can't set pb FAPL\n");
+        }
+    }
+
+    if (H5Pget_driver(fapl_id) != H5FD_PB) {
+        PB_TEST_FAULT("set FAPL not PB\n");
+    }
+
+    /* Opens a file that does exist*/
+    if (NULL == (file_ptr = H5FDopen(filename, H5F_ACC_RDWR | H5F_ACC_CREAT,
+                    fapl_id, HADDR_UNDEF))) 
+        PB_TEST_FAULT("couldn't get pointer to H5FD_t structure\n");
+
+    /* set the eoa so we can write the page of data */
+    if ( H5FDset_eoa(file_ptr, H5FD_MEM_DEFAULT, (haddr_t)(vfd_config.page_size * 64)) < 0 )
+        PB_TEST_FAULT("couldn't set file eoa\n");
+
+
+    setup_buf = (unsigned char *)malloc(vfd_config.page_size);
+    if (NULL == setup_buf) 
+        PB_TEST_FAULT("couldn't allocate memory for buffer (setup_buf)\n");
+
+    write_buf = (unsigned char *)malloc(vfd_config.page_size * 5);
+    if (NULL == write_buf) 
+        PB_TEST_FAULT("couldn't allocate memory for buffer (page)\n");
+
+    read_buf = (unsigned char *)malloc(vfd_config.page_size * 5);
+    if (NULL == read_buf) 
+        PB_TEST_FAULT("couldn't allocate memory for buffer (read_buf)\n");
+
+
+
+    /********************************************************/
+    /***** MIDDLES WITH FIRST PAGE EXISTING IN THE PB *****/
+    /********************************************************/
+
+    /* tail read to get the first page of the request in the page buffer */
+    if(H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, partial_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, vfd_config.page_size * 4, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+
+    /****** Write test *****/
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, vfd_config.page_size * 4, write_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+
+    /********************************************************/
+    /***** MIDDLES WITH LAST PAGE EXISTING IN THE PB *****/
+    /********************************************************/
+
+    /* tail read to get the last page of the request in the page buffer */
+    if(H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 16384, partial_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 4096, vfd_config.page_size * 4, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+
+    /****** Write test *****/
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 4096, vfd_config.page_size * 4, write_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+
+    /*********************************************************************************/
+    /***** MIDDLES WHERE FIRST AND LAST ARE NOT IN PB BUT TWO MIDDLE PAGES ARE *****/
+    /*********************************************************************************/
+
+    /* two tail reads to get the middle two pages of the request in the page buffer */
+    if(H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 12288, partial_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    if(H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 16384, partial_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 8192, vfd_config.page_size * 4, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+
+    /****** Write test *****/
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 8192, vfd_config.page_size * 4, write_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+
+    /**************************************************************/
+    /***** MIDDLES TEST WHERE ALTERNATING PAGES ARE IN THE PB *****/
+    /**************************************************************/
+
+    /* two tail reads to get the first and third page of the request in the page buffer */
+    if(H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 16384, partial_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+    if(H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 24576, partial_size, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 16384, vfd_config.page_size * 4, read_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+
+    /****** Write test *****/
+
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 16384, vfd_config.page_size * 4, write_buf) < 0) 
+        PB_TEST_FAULT("couldn't read data from file\n");
+
+
+
+    /***** End Tests *****/   
+
+    if (H5Pclose(fapl_id) < 0) 
+        PB_TEST_FAULT("can't close FAPL ID\n");
+    
+    if (H5FDclose(file_ptr) < 0)
+        PB_TEST_FAULT("can't close file\n");
+
+
+done:
+
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Pclose(fapl_id);
+            H5FDclose(file_ptr);
+        }
+        H5E_END_TRY
+    }
+
+    if (setup_buf) 
+        free(setup_buf);
+
+    if (write_buf) 
+        free(write_buf);
+    
+    if (read_buf)
+        free(read_buf);
+
+    return ret_value;
+
+} /* end pb_test_specific_cases */
+
+
+
+/*-------------------------------------------------------------------------
+ * Function:    test_pb
+ *
+ * Purpose:     Tests the page buffer VFD
+ *
+ *              THe current version is derived from the splitter test 
+ *              code, and is intended to show basic pass through 
+ *              functionality.  It will have to be revised heavily 
+ *              as the page buffer is implemented.
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ * Description:
+ *              This test function uses the page buffer VFD to produce a 
+ *              file and verify its contents.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+static herr_t
+test_pb(bool cl_config)
+{
+    int                         buf[PB_DS_SIZE][PB_DS_SIZE];
+    hsize_t                     dims[2]       = {PB_DS_SIZE, PB_DS_SIZE};
+    hid_t                       child_fapl_id = H5I_INVALID_HID;
+    int                         i             = 0;
+    int                         j             = 0;
+    struct pb_dataset_def data;
+
+    if ( cl_config ) {
+
+        TESTING("Page Buffer file driver with configuration language");
+
+    } else {
+
+        TESTING("Page Buffer file driver");
+    }
+
+    /* pre-fill data buffer to write */
+    for (i = 0; i < PB_DS_SIZE; i++) {
+        for (j = 0; j < PB_DS_SIZE; j++) {
+            buf[i][j] = i * 100 + j;
+        }
+    }
+
+    /* Dataset info */
+    data.buf         = (void *)buf;
+    data.mem_type_id = H5T_NATIVE_INT;
+    data.dims        = dims;
+    data.n_dims      = 2;
+    data.dset_name   = PB_DATASET_NAME;
+
+    /* Stand-in for manual FAPL creation
+     * Enables verification with arbitrary VFDs via `make check-vfd`
+     *
+     * Note: Due to cache coherency concerns, the page buffer VFD 
+     *       is incompatible with parallel HDF5 -- test code will 
+     *       have to be modified to reflect this at some point.
+     *
+     *                                       -- JRM 
+     */
+    child_fapl_id = h5_fileaccess();
+    if (child_fapl_id < 0) {
+        TEST_ERROR;
+    }
+
+
+    /* Test Read-Only access, including when the file does not exist. */
+    if (pb_RO_test(&data, child_fapl_id, cl_config) < 0) {
+        TEST_ERROR;
+    }
+
+    /* Test file creation, utilizing different child FAPLs (default vs.
+     * specified), logfile, and Write Channel error ignoring behavior.
+     */
+    for (i = 0; i < 2; i++) {
+
+        hid_t test_child_fapl_id;
+
+        test_child_fapl_id = (i > 0) ? child_fapl_id : H5P_DEFAULT;
+
+        if ( run_pb_test(&data, test_child_fapl_id, cl_config) < 0 ) {
+            TEST_ERROR;
+        }
+
+    } /* end for child fapl definition */
+
+    /* Simple test for testing the write and read functions as a base case */
+    if ( pb_test_create_write_read(cl_config) < 0 ) {
+        TEST_ERROR;
+    }
+
+    /* Tests write and read of head, middle, and tail pages */
+    if ( pb_test_head_middle_tail(cl_config) < 0 ) {
+        TEST_ERROR;
+    }
+
+    /* The eviction and invalidation */
+    if ( pb_test_rp_eviction_and_invalidation(cl_config) < 0 ) {
+        TEST_ERROR;
+    }
+
+    if ( pb_test_rp_eviction_and_invalidation_fifo(cl_config) < 0 ) {
+        TEST_ERROR;
+    }
+
+    /* Tests different combinations of head, middle, and tail pages */
+    if ( pb_test_page_combinations(cl_config) < 0 ) {
+        TEST_ERROR;
+    }
+
+    /* Tests multiple middle requests where only specific pages exist in the page buffer */
+    if ( pb_test_specific_cases(cl_config) < 0 ) {
+        TEST_ERROR;
+    }
+
+    if (H5Pclose(child_fapl_id) == FAIL) {
+        TEST_ERROR;
+    }
+
+    PASSED();
+
+    return 0;
+
+error:
+    if (child_fapl_id != H5I_INVALID_HID) {
+
+        H5Pclose(child_fapl_id);
+    }
+
+    return -1;
+
+} /* end test_pb() */
+
+#undef PB_TEST_FAULT
+
+#endif /* page buffer VFD test code */
+
+#if 1 /* encryption VFD test code */
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * Macro: CRYPT_TEST_FAULT()
+ *
+ * utility macro, helps create stack-like backtrace on error.
+ * requires defined in the calling function:
+ *    * variable `int ret_value` (return -1 on error)`
+ *    * label `done` for exit on fault
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ */
+#define CRYPT_TEST_FAULT(mesg)                                                                            \
+    do {                                                                                               \
+        H5_FAILED();                                                                                   \
+        AT();                                                                                          \
+        fprintf(stderr, mesg);                                                                         \
+        H5Eprint2(H5E_DEFAULT, stderr);                                                                \
+        fflush(stderr);                                                                                \
+        ret_value = -1;                                                                                \
+        goto done;                                                                                     \
+    } while (0)
+
+/*-------------------------------------------------------------------------
+ * Function:    compare_crypt_config_info
+ *
+ * Purpose:     Helper function to compare configuration info found in a
+ *              FAPL against a canonical structure.
+ *
+ * Return:      Success:  0, if config info in FAPL matches info structure.
+ *              Failure: -1, if difference detected.
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+compare_crypt_config_info(hid_t fapl_id, H5FD_crypt_vfd_config_t *info)
+{
+    int                      ret_value    = 0;
+    H5FD_crypt_vfd_config_t *fetched_info = NULL;
+
+    if (NULL == (fetched_info = calloc(1, sizeof(H5FD_crypt_vfd_config_t))))
+        CRYPT_TEST_FAULT("memory allocation for fetched_info struct failed");
+
+    fetched_info->magic      = H5FD_CRYPT_CONFIG_MAGIC;
+    fetched_info->version    = H5FD_CURR_CRYPT_VFD_CONFIG_VERSION;
+    fetched_info->fapl_id    = H5I_INVALID_HID;
+
+    if (H5Pget_fapl_crypt(fapl_id, fetched_info) < 0) {
+        CRYPT_TEST_FAULT("can't get page buffer info");
+    }
+
+
+
+    if (info->plaintext_page_size != fetched_info->plaintext_page_size) {
+        fprintf(stderr, "plaintext_page_size mismatch: expected %zu, got %zu\n",
+                info->plaintext_page_size, fetched_info->plaintext_page_size);
+        CRYPT_TEST_FAULT("plaintext_page_size mismatch\n");
+    }
+    if (info->ciphertext_page_size != fetched_info->ciphertext_page_size) {
+        fprintf(stderr, "ciphertext_page_size mismatch: expected %zu, got %zu\n",
+                info->ciphertext_page_size, fetched_info->ciphertext_page_size);
+        CRYPT_TEST_FAULT("ciphertext_page_size mismatch\n");
+    }
+
+    if (info->encryption_buffer_size != fetched_info->encryption_buffer_size) {
+        fprintf(stderr, "encryption_buffer_size mismatch: expected %zu, got %zu\n",
+                info->encryption_buffer_size, fetched_info->encryption_buffer_size);
+        CRYPT_TEST_FAULT("encryption_buffer_size mismatch\n");
+    }
+
+    if (info->cipher != fetched_info->cipher) {
+        fprintf(stderr, "cipher mismatch: expected %u, got %u\n",
+                info->cipher, fetched_info->cipher);
+        CRYPT_TEST_FAULT("cipher mismatch\n");
+    }
+
+    if (info->cipher_block_size != fetched_info->cipher_block_size) {
+        fprintf(stderr, "cipher_block_size mismatch: expected %zu, got %zu\n",
+                info->cipher_block_size, fetched_info->cipher_block_size);
+        CRYPT_TEST_FAULT("cipher_block_size mismatch\n");
+    }
+
+    if (info->key_size != fetched_info->key_size) {
+        fprintf(stderr, "key_size mismatch: expected %zu, got %zu\n",
+                info->key_size, fetched_info->key_size);
+        CRYPT_TEST_FAULT("key_size mismatch\n");
+    }
+
+    if (info->iv_size != fetched_info->iv_size) {
+        fprintf(stderr, "iv_size mismatch: expected %zu, got %zu\n",
+                info->iv_size, fetched_info->iv_size);
+        CRYPT_TEST_FAULT("iv_size mismatch\n");
+    }
+
+    if (info->mode != fetched_info->mode) {
+        fprintf(stderr, "mode mismatch: expected %u, got %u\n",
+                info->mode, fetched_info->mode);
+        CRYPT_TEST_FAULT("mode mismatch\n");
+    }
+
+
+
+    if ( info->key_size > 0 ) {
+
+        if ( memcmp(info->key, fetched_info->key, info->key_size) != 0 ) {
+
+            CRYPT_TEST_FAULT("key mismatch\n");
+        }
+    }
+
+    if (info->fapl_id == H5P_DEFAULT) {
+
+        if (H5Pget_driver(fetched_info->fapl_id) != H5Pget_driver(H5P_FILE_ACCESS_DEFAULT)) {
+
+            CRYPT_TEST_FAULT("underlying driver mismatch (default)\n");
+        }
+    }
+    else {
+
+        if (H5Pget_driver(fetched_info->fapl_id) != H5Pget_driver(info->fapl_id)) {
+
+            CRYPT_TEST_FAULT("underlying driver mismatch\n");
+        }
+    }
+
+
+done:
+    free(fetched_info);
+
+    return ret_value;
+
+} /* end compare_crypt_config_info() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    compare_crypt_config_str
+ *
+ * Purpose:     Helper function to compare configuration strings found in a
+ *              FAPL against a canonical string
+ *
+ * Return:      Success:  0, if config string in FAPL matches the 
+ *                           cannonical string
+ *              Failure: -1, if difference detected.
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+compare_crypt_config_str(hid_t fapl_id, char *cannonical_str)
+{
+    const char             * config_str = NULL;
+    H5P_genplist_t  * plist_ptr  = NULL;
+    const H5FD_pb_vfd_config_t * config_ptr = NULL;
+    int                      ret_value    = 0;
+
+    plist_ptr = (H5P_genplist_t *)H5I_object(fapl_id);
+
+    if ( NULL == plist_ptr )
+        CRYPT_TEST_FAULT("Supplied fapl doesn't exist?");
+
+    config_ptr = (const H5FD_pb_vfd_config_t *)H5P_peek_driver_info(plist_ptr);
+
+    config_str = H5P_peek_driver_config_str(plist_ptr);
+
+    if ( config_ptr && config_str )
+        CRYPT_TEST_FAULT("fapl driver info contains both config and string pointers.");
+
+    if ( ! config_str ) 
+        CRYPT_TEST_FAULT("fapl driver info doesn't have a configuration string.");
+
+    if ( 0 != strcmp(config_str, cannonical_str) )
+        CRYPT_TEST_FAULT("fapl and cannonical configuration strings differ.");
+
+done:
+
+    return ret_value;
+
+} /* end compare_crypt_config_str() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    test_crypt_fapl
+ *
+ * Purpose:     Test encryption VFD FAPL management
+ *
+ *              Quick check of encryption VFD FAPL management -- should 
+ *              be more complete.
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+test_crypt_fapl(bool cl_config)
+{
+    hid_t                 fapl_id         = H5I_INVALID_HID;
+    hid_t                 fapl_id_cpy     = H5I_INVALID_HID;
+    char vfd_cfg_str_0[] = 
+        "( encryption_VFD " 
+        "  ( ( plaintext_page_size  4096 )"
+        "    ( ciphertext_page_size 4112 )"
+        "    ( encryption_buffer_size 65792 )"
+        "    ( cipher  0 )"
+        "    ( cipher_block_size 16 )"
+        "    ( key_size  32 )"
+        "    ( key --5E73C3BFC3A22CC2AA54055DC3B56169C38E5F7DC395C2AC23C2BE4C14C3B33B )"
+        "    ( iv_size 16 )"
+        "    ( mode 0 )"
+        "    ( underlying_VFD ( sec2 () ) )"
+        "  )"
+        ")";
+    H5FD_crypt_vfd_config_t vfd_cfg_0 = 
+    {
+        /* magic                  = */ H5FD_CRYPT_CONFIG_MAGIC,
+        /* version                = */ H5FD_CURR_CRYPT_VFD_CONFIG_VERSION,
+        /* plaintext_page_size    = */ 4096,
+        /* ciphertext_page_size   = */ 4112,
+        /* encryption_buffer_size = */ H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE,
+        /* cipher                 = */ 0,
+        /* cipher_block_size      = */ 16,
+        /* key_size               = */ 32,
+        /* key                    = */ H5FD_CRYPT_TEST_KEY,
+        /* iv_size                = */ 16,
+        /* mode                   = */ 0,
+        /* fapl_id                = */ H5P_DEFAULT
+    };
+    int                      ret_value    = 0;
+
+#if 0 /* debug code -- keep for a while */
+    /* dump hex expression of the key */
+    {
+        size_t i;
+
+        fprintf(stdout, "\n\n--");
+
+        for ( i = 0; i < vfd_cfg_0.key_size; i++ ) {
+
+            fprintf(stdout, "%X ", (unsigned)(vfd_cfg_0.key[i]));
+        }
+
+        fprintf(stdout, "\n\n");
+    }
+#endif
+
+    /* Create a new fapl to use the page buffer file driver */
+
+    if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) == H5I_INVALID_HID) {
+        CRYPT_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if ( cl_config ) {
+
+        if (H5CL_load_vfd_config_str_into_fapl(fapl_id, vfd_cfg_str_0) < 0) {
+            CRYPT_TEST_FAULT("can't load config string into fapl\n");
+        }
+
+    } else {
+
+        if (H5Pset_fapl_crypt(fapl_id, &vfd_cfg_0) < 0) {
+            CRYPT_TEST_FAULT("can't set enryption VFD FAPL\n");
+        }
+    }
+
+    if (H5Pget_driver(fapl_id) != H5FD_CRYPT) {
+        CRYPT_TEST_FAULT("set FAPL not encryption VFD\n");
+    }
+
+    if ( cl_config ) {
+
+        if (compare_crypt_config_str(fapl_id, vfd_cfg_str_0) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+
+    } else {
+
+        if (compare_crypt_config_info(fapl_id, &vfd_cfg_0) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+    }
+
+
+    /*
+     * Copy property list, light compare, and close the copy.
+     * Helps test driver-implemented FAPL-copying and library ID management.
+     */
+
+    fapl_id_cpy = H5Pcopy(fapl_id);
+
+    if (H5I_INVALID_HID == fapl_id_cpy) {
+        CRYPT_TEST_FAULT("can't copy FAPL\n");
+    }
+
+    if ( cl_config ) {
+
+        if (compare_crypt_config_str(fapl_id_cpy, vfd_cfg_str_0) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+
+    } else {
+
+        if (compare_crypt_config_info(fapl_id_cpy, &vfd_cfg_0) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+    }
+
+    if (H5Pclose(fapl_id_cpy) < 0) {
+        CRYPT_TEST_FAULT("can't close fapl copy\n");
+    }
+
+    if (H5Pclose(fapl_id) < 0) {
+        CRYPT_TEST_FAULT("can't close fapl\n");
+    }
+
+done:
+
+    return ret_value;
+
+} /* test_crypt_fapl() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    crypt_test_create
+ *
+ * Purpose:     Tests the encryption VFD creating and opening a file that 
+ *              doesn't exist.
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+crypt_test_create(bool cl_config)
+{
+    hid_t                   fapl_id         = H5I_INVALID_HID;
+    char                    filename[1024];
+    char vfd_cfg_str[] =
+        "( encryption_VFD "
+        "  ( ( plaintext_page_size  4096 )"
+        "    ( ciphertext_page_size 4112 )"
+        "    ( encryption_buffer_size 65792 )"
+        "    ( cipher  0 )"
+        "    ( cipher_block_size 16 )"
+        "    ( key_size  32 )"
+        "    ( key --5E73C3BFC3A22CC2AA54055DC3B56169C38E5F7DC395C2AC23C2BE4C14C3B33B )"
+        "    ( iv_size 16 )"
+        "    ( mode 0 )"
+        "    ( underlying_VFD ( sec2 () ) )"
+        "  )"
+        ")";
+    H5FD_crypt_vfd_config_t vfd_config = 
+    {
+        /* magic                  = */ H5FD_CRYPT_CONFIG_MAGIC,
+        /* version                = */ H5FD_CURR_CRYPT_VFD_CONFIG_VERSION,
+        /* plaintext_page_size    = */ 4096,
+        /* ciphertext_page_size   = */ 4112,
+        /* encryption_buffer_size = */ H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE,
+        /* cipher                 = */ 0,  
+        /* cipher_block_size      = */ 16,
+        /* key_size               = */ 32,
+        /* key                    = */ H5FD_CRYPT_TEST_KEY,
+        /* iv_size                = */ 16,
+        /* mode                   = */ 0,
+        /* fapl_id                = */ H5P_DEFAULT
+    };
+    H5FD_t                * file_ptr          = NULL;
+    int                     ret_value    = 0;
+
+    /* setup the target file name, and delete any existing instance */
+    h5_fixname(FILENAME[17], vfd_config.fapl_id, filename, 1024);
+    HDremove(filename);
+
+    /* create and initialize FAPL for the encryption VFD */
+    
+    if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) == H5I_INVALID_HID) {
+        CRYPT_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if ( cl_config ) {
+
+        if (H5CL_load_vfd_config_str_into_fapl(fapl_id, vfd_cfg_str) < 0) {
+            CRYPT_TEST_FAULT("can't load config string into fapl\n");
+        }
+    } else {
+
+        if (H5Pset_fapl_crypt(fapl_id, &vfd_config) < 0) {
+            CRYPT_TEST_FAULT("can't set enryption VFD FAPL\n");
+        }
+    }
+
+    if (H5Pget_driver(fapl_id) != H5FD_CRYPT) {
+        CRYPT_TEST_FAULT("set FAPL not encryption VFD\n");
+    }
+
+
+    if ( cl_config ) {
+
+        if (compare_crypt_config_str(fapl_id, vfd_cfg_str) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+
+    } else {
+
+        if (compare_crypt_config_info(fapl_id, &vfd_config) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+    }
+
+    /** 
+     * Opens a file that doesn't exist with the create flag. Should create the
+     * file, open it, and write the first two pages with the config data.
+     */
+    if (NULL == (file_ptr = H5FDopen(filename, H5F_ACC_RDWR | H5F_ACC_CREAT, 
+                    fapl_id, HADDR_UNDEF)))
+        CRYPT_TEST_FAULT("couldn't get pointer to H5FD_t structure");
+
+    if (H5Pclose(fapl_id) < 0) {
+        CRYPT_TEST_FAULT("can't close fapl\n");
+    }
+
+    if (H5FDclose(file_ptr) < 0) {
+        CRYPT_TEST_FAULT("can't close file\n");
+    }
+
+done:
+    
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Pclose(fapl_id);
+            H5FDclose(file_ptr);
+        }
+        H5E_END_TRY
+    }
+
+    return ret_value;
+    
+} /* end crypt_test_create() */
+
+
+
+/*-------------------------------------------------------------------------
+ * Function:    crypt_test_create_and_write
+ *
+ * Purpose:     Tests the encryption VFD creating and opening a file that 
+ *              doesn't exist and writing to it. Only testing with one page
+ *              of data per write call. 
+ * 
+ *              Using the AES256 cipher
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+crypt_test_create_and_write(bool cl_config)
+{
+    hid_t                   fapl_id         = H5I_INVALID_HID;
+    char                    filename[1024];
+    char vfd_cfg_str[] =
+        "( encryption_VFD "
+        "  ( ( plaintext_page_size  4096 )"
+        "    ( ciphertext_page_size 4112 )"
+        "    ( encryption_buffer_size 65792 )"
+        "    ( cipher  0 )"
+        "    ( cipher_block_size 16 )"
+        "    ( key_size  32 )"
+        "    ( key --5E73C3BFC3A22CC2AA54055DC3B56169C38E5F7DC395C2AC23C2BE4C14C3B33B )"
+        "    ( iv_size 16 )"
+        "    ( mode 0 )"
+        "    ( underlying_VFD ( sec2 () ) )"
+        "  )"
+        ")";
+    H5FD_crypt_vfd_config_t vfd_config = 
+    {
+        /* magic                  = */ H5FD_CRYPT_CONFIG_MAGIC,
+        /* version                = */ H5FD_CURR_CRYPT_VFD_CONFIG_VERSION,
+        /* plaintext_page_size    = */ 4096,
+        /* ciphertext_page_size   = */ 4112,
+        /* encryption_buffer_size = */ H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE,
+        /* cipher                 = */ 0,  
+        /* cipher_block_size      = */ 16,
+        /* key_size               = */ 32,
+        /* key                    = */ H5FD_CRYPT_TEST_KEY,
+        /* iv_size                = */ 16,
+        /* mode                   = */ 0,
+        /* fapl_id                = */ H5P_DEFAULT
+    };
+    H5FD_t                * file_ptr           = NULL;
+    unsigned char         * one_page_write_buf = NULL;
+    unsigned char         * one_page_read_buf  = NULL;
+    int                     ret_value    = 0;
+
+    /* setup the target file name, and delete any existing instance */
+    h5_fixname(FILENAME[17], vfd_config.fapl_id, filename, 1024);
+    HDremove(filename);
+
+    /* create and initialize FAPL for the encryption VFD */
+    
+    if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) == H5I_INVALID_HID) {
+        CRYPT_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if ( cl_config ) {
+
+        if (H5CL_load_vfd_config_str_into_fapl(fapl_id, vfd_cfg_str) < 0) {
+            CRYPT_TEST_FAULT("can't load config string into fapl\n");
+        }
+    } else {
+
+        if (H5Pset_fapl_crypt(fapl_id, &vfd_config) < 0) {
+            CRYPT_TEST_FAULT("can't set enryption VFD FAPL\n");
+        }
+    }
+
+    if (H5Pget_driver(fapl_id) != H5FD_CRYPT) {
+        CRYPT_TEST_FAULT("set FAPL not encryption VFD\n");
+    }
+
+    if ( cl_config ) {
+        
+        if (compare_crypt_config_str(fapl_id, vfd_cfg_str) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+
+    } else {
+        
+        if (compare_crypt_config_info(fapl_id, &vfd_config) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+    }
+
+    /** 
+     * Opens a file that doesn't exist with the create flag. Should create the
+     * file, open it, and write the first two pages with the config data.
+     */
+    if (NULL == (file_ptr = H5FDopen(filename, H5F_ACC_RDWR | H5F_ACC_CREAT, 
+                    fapl_id, HADDR_UNDEF)))
+        CRYPT_TEST_FAULT("couldn't get pointer to H5FD_t structure");
+
+
+
+    /********** Buffer setup to test write data to the file  **********/
+
+    /* Buffer to hold the data that will be used to test the write function */
+    one_page_write_buf = malloc(vfd_config.plaintext_page_size);
+    if (NULL == one_page_write_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for one_page_write_buf\n");
+
+    /* Fill the buffer with random characters to simulate data */
+    for (size_t i = 0; i < vfd_config.plaintext_page_size; i++)
+        one_page_write_buf[i] = (unsigned char)rand() % 256;
+
+    /* set the eoa so we can write the page of data */
+    if ( H5FDset_eoa(file_ptr, H5FD_MEM_DEFAULT, (haddr_t)(vfd_config.plaintext_page_size)) < 0 )
+        CRYPT_TEST_FAULT("couldn't set file eoa\n");
+    
+    /* Write the data to the file */
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, 
+                    vfd_config.plaintext_page_size, one_page_write_buf) < 0)
+        CRYPT_TEST_FAULT("couldn't write data to file\n");
+
+
+    /* Buffer for the read test to store the page that was just written */
+    one_page_read_buf = malloc(vfd_config.plaintext_page_size);
+    if (NULL == one_page_read_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for one_page_write_buf\n");
+
+    /* Reads the data back that was just written */
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, 
+                    vfd_config.plaintext_page_size, one_page_read_buf) < 0)
+        CRYPT_TEST_FAULT("couldn't read data from file\n");
+
+    /* Compare the data that was written to the data that was read */
+    if (memcmp(one_page_write_buf, one_page_read_buf, 
+                vfd_config.plaintext_page_size) != 0)
+        CRYPT_TEST_FAULT("data read from file does not match data written\n");
+
+    if (H5Pclose(fapl_id) < 0) {
+        CRYPT_TEST_FAULT("can't close fapl\n");
+    }
+
+    if (H5FDclose(file_ptr) < 0) {
+        CRYPT_TEST_FAULT("can't close file\n");
+    }
+
+done:
+    
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Pclose(fapl_id);
+            H5FDclose(file_ptr);
+        }
+        H5E_END_TRY
+    }
+
+    if (one_page_write_buf)
+        free(one_page_write_buf);
+
+    if (one_page_read_buf)
+        free(one_page_read_buf);
+
+    return ret_value;
+    
+} /* end crypt_test_create_and_write() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    crypt_test_verify_create_and_encryption
+ *
+ * Purpose:     Tests the encryption VFD creating and opening a file that 
+ *              doesn't exist and writing one page to it. Then using POSIX
+ *              calls to open the file manually, reads the entire file 
+ *              (first two config pages and the third encrypted page) into
+ *              a buffer. Another buffer is allocated and three pages are 
+ *              manually created and stored in this new buffer. The 
+ *              manually created pages are exactly what the pages in the
+ *              file should be. These two buffers are then compared to 
+ *              ensure the data in the file is correct (first page 
+ *              configuration data, second page test encryption phrase, 
+ *              third page encrypted data).
+ * 
+ *              Using the AES256 cipher
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+crypt_test_verify_create_and_encryption(bool cl_config)
+{
+    hid_t                   fapl_id         = H5I_INVALID_HID;
+    char                    filename[1024];
+    char vfd_cfg_str[] =
+        "( encryption_VFD "
+        "  ( ( plaintext_page_size  4096 )"
+        "    ( ciphertext_page_size 4112 )"
+        "    ( encryption_buffer_size 65792 )"
+        "    ( cipher  0 )"
+        "    ( cipher_block_size 16 )"
+        "    ( key_size  32 )"
+        "    ( key --5E73C3BFC3A22CC2AA54055DC3B56169C38E5F7DC395C2AC23C2BE4C14C3B33B )"
+        "    ( iv_size 16 )"
+        "    ( mode 0 )"
+        "    ( underlying_VFD ( sec2 () ) )"
+        "  )"
+        ")";
+    H5FD_crypt_vfd_config_t vfd_config = 
+    {
+        /* magic                  = */ H5FD_CRYPT_CONFIG_MAGIC,
+        /* version                = */ H5FD_CURR_CRYPT_VFD_CONFIG_VERSION,
+        /* plaintext_page_size    = */ 4096,
+        /* ciphertext_page_size   = */ 4112,
+        /* encryption_buffer_size = */ H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE,
+        /* cipher                 = */ 0,  
+        /* cipher_block_size      = */ 16,
+        /* key_size               = */ 32,
+        /* key                    = */ H5FD_CRYPT_TEST_KEY,
+        /* iv_size                = */ 16,
+        /* mode                   = */ 0,
+        /* fapl_id                = */ H5P_DEFAULT
+    };
+    H5FD_t                * file_ptr            = NULL;
+    unsigned char         * write_buf           = NULL;
+    unsigned char         * read_buf            = NULL;
+    unsigned char         * compare_buf         = NULL;
+    int                     fd                  = -1;
+    size_t                  size_of_3_page_file;
+    gcry_cipher_hd_t        handle;
+    unsigned char         * iv_second_page      = NULL;
+    unsigned char         * iv_third_page       = NULL;
+    const char            * test_phrase         = "Decryption works";
+    unsigned char         * test_phrase_buf     = NULL;
+    int                     ret_value           = 0;
+
+    /* setup the target file name, and delete any existing instance */
+    h5_fixname(FILENAME[17], vfd_config.fapl_id, filename, 1024);
+    HDremove(filename);
+
+    /* create and initialize FAPL for the encryption VFD */
+    if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) == H5I_INVALID_HID) {
+        CRYPT_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if ( cl_config ) {
+
+        if (H5CL_load_vfd_config_str_into_fapl(fapl_id, vfd_cfg_str) < 0) {
+            CRYPT_TEST_FAULT("can't load config string into fapl\n");
+        }
+    } else {
+
+        if (H5Pset_fapl_crypt(fapl_id, &vfd_config) < 0) {
+            CRYPT_TEST_FAULT("can't set enryption VFD FAPL\n");
+        }
+    }
+
+    if (H5Pget_driver(fapl_id) != H5FD_CRYPT) {
+        CRYPT_TEST_FAULT("set FAPL not encryption VFD\n");
+    }
+
+    if ( cl_config ) {
+
+        if (compare_crypt_config_str(fapl_id, vfd_cfg_str) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+
+    } else {
+
+        if (compare_crypt_config_info(fapl_id, &vfd_config) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+    }
+
+
+    /** 
+     * Opens a file that doesn't exist with the create flag. Should create the
+     * file, open it, and write the first two pages with config data.
+     */
+    if (NULL == (file_ptr = H5FDopen(filename, H5F_ACC_RDWR | H5F_ACC_CREAT, 
+                    fapl_id, HADDR_UNDEF)))
+        CRYPT_TEST_FAULT("couldn't get pointer to H5FD_t structure");
+
+
+
+    /********** Buffer setup to test writing data to the file  **********/
+
+    /* Buffer to hold the data that will be used to test the write function */
+    write_buf = malloc(vfd_config.plaintext_page_size);
+    if (NULL == write_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for write_buf\n");
+
+    /* Fill the buffer with random characters to simulate data */
+    for (size_t i = 0; i < vfd_config.plaintext_page_size; i++)
+        write_buf[i] = (unsigned char)rand() % 256;
+
+    /* set the eoa so we can write the page of data */
+    if ( H5FDset_eoa(file_ptr, H5FD_MEM_DEFAULT, (haddr_t)(vfd_config.plaintext_page_size)) < 0 )
+        CRYPT_TEST_FAULT("couldn't set file eoa\n");
+
+    /* Write the data to the file */
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, 
+                    vfd_config.plaintext_page_size, write_buf) < 0)
+        CRYPT_TEST_FAULT("couldn't write data to file\n");
+
+    /* Close the file */
+    if (H5FDclose(file_ptr) < 0) {
+        CRYPT_TEST_FAULT("can't close file\n");
+    }
+
+
+    /*************************************************************************
+     * Opens the newly created file using normal POSIX calls to read the first
+     * two configuration pages and the third encrypted page into a buffer to 
+     * compare with manually created pages to ensure the data is correct.
+     *************************************************************************/
+
+    /* The size of all the pages file */
+    size_of_3_page_file = 3 * vfd_config.ciphertext_page_size;
+
+    /* Allocate buffer to read the entire file to */
+    read_buf = malloc(size_of_3_page_file);
+    if (NULL == read_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for read_buf\n");
+
+    /* Allocate buffer to store the IVs for the second and third pages */
+    iv_second_page = malloc(vfd_config.iv_size);
+    if (NULL == iv_second_page)
+        CRYPT_TEST_FAULT("couldn't allocate memory for iv_second_page\n");
+    
+    iv_third_page = malloc(vfd_config.iv_size);
+    if (NULL == iv_third_page)
+        CRYPT_TEST_FAULT("couldn't allocate memory for iv_third_page\n");
+    
+
+    /* Open the file using POSIX calls */
+    if ((fd = open(filename, O_RDONLY)) < 0)
+        CRYPT_TEST_FAULT("couldn't open file using POSIX calls\n");
+
+    /* Read the entire file into read_buf */
+    if (pread(fd, read_buf, size_of_3_page_file, 0) != (ssize_t)size_of_3_page_file)
+        CRYPT_TEST_FAULT("couldn't read file using POSIX calls\n");
+
+    /* Copies the IV for the second page to encrypt the manually made second page */
+    if (memcpy(iv_second_page, read_buf + vfd_config.ciphertext_page_size, vfd_config.iv_size) == NULL)
+        CRYPT_TEST_FAULT("couldn't copy second page's IV from read_buf\n");
+
+    /* Copies the IV for the third page to encrypt the manually made third page */
+    if (memcpy(iv_third_page, read_buf + 2 * vfd_config.ciphertext_page_size, vfd_config.iv_size) == NULL)
+        CRYPT_TEST_FAULT("couldn't copy third page's IV from read_buf\n");
+
+    /* Close the file */
+    if (close(fd) < 0)
+        CRYPT_TEST_FAULT("couldn't close file using POSIX calls\n");
+
+
+
+
+    /*************************************************************************
+     * Manually creating the data of the three pages into a buffer to compare
+     * the read_buf with to ensure the data in the file is correct.
+     *************************************************************************/
+
+    /* Allocate buffer to store the data for comparison */
+    compare_buf = malloc(size_of_3_page_file);
+    if (NULL == compare_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for compare_buf\n");
+
+
+    /* Manually create the first page and store it in the compare buf */
+    if (memset((void *)(compare_buf), '\0', vfd_config.ciphertext_page_size) == NULL)
+        CRYPT_TEST_FAULT("couldn't memset compare_buf\n");
+
+    snprintf((char *)compare_buf, vfd_config.ciphertext_page_size,
+             "plaintext_page_size: %zu\n"
+             "ciphertext_page_size: %zu\n"
+             "encryption_buffer_size: %zu\n"
+             "cipher: %d\n"
+             "cipher_block_size: %zu\n"
+             "key_size: %zu\n"
+             "iv_size: %zu\n"
+             "mode: %d\n",
+             vfd_config.plaintext_page_size,
+             vfd_config.ciphertext_page_size,
+             vfd_config.encryption_buffer_size,
+             vfd_config.cipher,
+             vfd_config.cipher_block_size,
+             vfd_config.key_size,
+             vfd_config.iv_size,
+             vfd_config.mode);
+
+
+
+    /* Manually create the second page and store it in the compare buf*/
+    if (memset((void *)(compare_buf + vfd_config.ciphertext_page_size), '\0', 
+                vfd_config.ciphertext_page_size) == NULL)
+        CRYPT_TEST_FAULT("couldn't memset compare_buf\n");
+
+
+    test_phrase_buf = (unsigned char *)calloc(vfd_config.ciphertext_page_size, 
+                                                sizeof(unsigned char));
+    if ( NULL == test_phrase_buf ) 
+        CRYPT_TEST_FAULT("couldn't allocate memory for test_phrase_buf\n");
+
+    memcpy(test_phrase_buf, test_phrase, strlen(test_phrase) + 1);
+
+
+
+    /* Manually encrypt and write the second page into the compare buf */
+    if ( gcry_cipher_open(&handle, GCRY_CIPHER_AES256, 
+                            GCRY_CIPHER_MODE_CBC, 0) != 0 )
+        CRYPT_TEST_FAULT("couldn't open cipher handle\n");
+    
+    if ( gcry_cipher_setkey(handle, vfd_config.key, 32) != 0 )
+        CRYPT_TEST_FAULT("couldn't set key\n");
+
+    /* Stores the second page's IV into the compare buf */
+    if (memcpy((void *)(compare_buf + vfd_config.ciphertext_page_size), 
+                            iv_second_page, vfd_config.iv_size) == NULL)
+        CRYPT_TEST_FAULT("couldn't memcpy second page's IV to compare buf\n");
+
+    if ( gcry_cipher_setiv(handle, iv_second_page, 16) != 0 )
+        CRYPT_TEST_FAULT("couldn't set IV to handle for page 2\n");
+
+    if ( gcry_cipher_encrypt(handle, 
+            compare_buf + vfd_config.ciphertext_page_size + vfd_config.iv_size,
+            vfd_config.plaintext_page_size, 
+            test_phrase_buf, 
+            vfd_config.plaintext_page_size) != 0 )
+        CRYPT_TEST_FAULT("couldn't encrypt second page\n");
+
+    gcry_cipher_close(handle);  
+
+
+
+    /* Manually encrypt and write the created page (write_buf) into the compare buf*/
+    if ( gcry_cipher_open(&handle, GCRY_CIPHER_AES256, 
+                            GCRY_CIPHER_MODE_CBC, 0) != 0 )
+        CRYPT_TEST_FAULT("couldn't open cipher handle for page 3\n");
+
+    if ( gcry_cipher_setkey(handle, vfd_config.key, 32) != 0 )
+        CRYPT_TEST_FAULT("couldn't set key the for page 3\n");
+
+    /* Stores the third page's IV into the compare buf */
+    if (memcpy((void *)(compare_buf + 2 * vfd_config.ciphertext_page_size), 
+                            iv_third_page, vfd_config.iv_size) == NULL)
+        CRYPT_TEST_FAULT("couldn't memcpy third page's IV to compare buf\n");
+
+    if ( gcry_cipher_setiv(handle, iv_third_page, 16) != 0 )
+        CRYPT_TEST_FAULT("couldn't set IV to handle for page 3\n");
+
+    if ( gcry_cipher_encrypt(handle, 
+            compare_buf + 2 * vfd_config.ciphertext_page_size + vfd_config.iv_size,
+            vfd_config.plaintext_page_size, 
+            write_buf, 
+            vfd_config.plaintext_page_size) != 0 )
+        CRYPT_TEST_FAULT("couldn't encrypt third page\n");
+
+    gcry_cipher_close(handle);
+
+
+
+    /**
+     * Compare the read_buf that holds the data read from the file and 
+     * compare_buf which holds the manually created data to ensure the data in
+     * the file matches what it should be.
+     */
+    if (memcmp(read_buf, compare_buf, size_of_3_page_file) != 0) {
+        CRYPT_TEST_FAULT("pages read from file does not match manually made pages\n");
+    }
+
+done:
+    
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Pclose(fapl_id);
+            H5FDclose(file_ptr);
+            if (fd >= 0)
+                close(fd);
+        }
+        H5E_END_TRY
+    }
+
+    if (write_buf)
+        free(write_buf);
+
+    if (compare_buf)
+        free(compare_buf);
+
+    if (read_buf)
+        free(read_buf);
+    
+    if (test_phrase_buf)
+        free(test_phrase_buf);
+    
+    if (iv_second_page)
+        free(iv_second_page);
+    
+    if (iv_third_page)
+        free(iv_third_page);
+
+    return ret_value;
+    
+} /* end crypt_test_verify_create_and_encryption() */
+
+
+
+/*-------------------------------------------------------------------------
+ * Function:    crypt_test_write_and_read_aes256
+ *
+ * Purpose:     Generalized test function for writing 'num_pages' to the 
+ *              file. This uses the AES256 cipher and tests the write and 
+ *              read operations with a variable number of pages.
+ * 
+ *              Using the AES256 cipher
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+crypt_test_write_and_read_aes256(size_t num_pages, bool cl_config)
+{
+    hid_t                   fapl_id         = H5I_INVALID_HID;
+    char                    filename[1024];
+    char vfd_cfg_str[] =
+        "( encryption_VFD "
+        "  ( ( plaintext_page_size  4096 )"
+        "    ( ciphertext_page_size 4112 )"
+        "    ( encryption_buffer_size 65792 )"
+        "    ( cipher  0 )"
+        "    ( cipher_block_size 16 )"
+        "    ( key_size  32 )"
+        "    ( key --5E73C3BFC3A22CC2AA54055DC3B56169C38E5F7DC395C2AC23C2BE4C14C3B33B )"
+        "    ( iv_size 16 )"
+        "    ( mode 0 )"
+        "    ( underlying_VFD ( sec2 () ) )"
+        "  )"
+        ")";
+    H5FD_crypt_vfd_config_t vfd_config = 
+    {
+        /* magic                  = */ H5FD_CRYPT_CONFIG_MAGIC,
+        /* version                = */ H5FD_CURR_CRYPT_VFD_CONFIG_VERSION,
+        /* plaintext_page_size    = */ 4096,
+        /* ciphertext_page_size   = */ 4112,
+        /* encryption_buffer_size = */ H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE,
+        /* cipher                 = */ 0,  
+        /* cipher_block_size      = */ 16,
+        /* key_size               = */ 32,
+        /* key                    = */ H5FD_CRYPT_TEST_KEY,
+        /* iv_size                = */ 16,
+        /* mode                   = */ 0,
+        /* fapl_id                = */ H5P_DEFAULT
+    };
+    H5FD_t                * file_ptr        = NULL;
+    unsigned char         * write_buf       = NULL;
+    unsigned char         * read_buf        = NULL;
+    size_t                  size_of_pages;
+    int                     ret_value       = 0;
+
+    /* setup the target file name */
+    h5_fixname(FILENAME[17], vfd_config.fapl_id, filename, 1024);
+
+    /* create and initialize FAPL for the encryption VFD */
+    
+    if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) == H5I_INVALID_HID) {
+        CRYPT_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if ( cl_config ) {
+
+        if (H5CL_load_vfd_config_str_into_fapl(fapl_id, vfd_cfg_str) < 0) {
+            CRYPT_TEST_FAULT("can't load config string into fapl\n");
+        }
+    } else {
+
+        if (H5Pset_fapl_crypt(fapl_id, &vfd_config) < 0) {
+            CRYPT_TEST_FAULT("can't set enryption VFD FAPL\n");
+        }
+    }
+
+    if (H5Pget_driver(fapl_id) != H5FD_CRYPT) {
+        CRYPT_TEST_FAULT("set FAPL not encryption VFD\n");
+    }
+
+    if ( cl_config ) {
+
+        if (compare_crypt_config_str(fapl_id, vfd_cfg_str) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+
+    } else {
+
+        if (compare_crypt_config_info(fapl_id, &vfd_config) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+    }
+
+
+    /* Opens an existing file with the read/write flag. */
+    if (NULL == (file_ptr = H5FDopen(filename, H5F_ACC_RDWR, fapl_id, HADDR_UNDEF)))
+        CRYPT_TEST_FAULT("couldn't get pointer to H5FD_t structure");
+
+
+
+    /********** Buffer setup to test write data to the file  **********/
+
+    size_of_pages = num_pages * vfd_config.plaintext_page_size;
+
+    /* Buffer to hold the data that will be used to test the write function */
+    write_buf = malloc(size_of_pages);
+    if (NULL == write_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for six_page_write_buf\n");
+
+    /* Fill the buffer with random characters to simulate data */
+    for (size_t i = 0; i < (size_of_pages); i++)
+        write_buf[i] = (unsigned char)rand() % 256;
+
+    /* set the eoa so we can write the page of data */
+    if ( H5FDset_eoa(file_ptr, H5FD_MEM_DEFAULT, (haddr_t)(num_pages * vfd_config.plaintext_page_size)) < 0 )
+        CRYPT_TEST_FAULT("couldn't set file eoa\n");
+    
+    /* Write the data to the file */
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, size_of_pages, 
+                    write_buf) < 0)
+        CRYPT_TEST_FAULT("couldn't write data to file\n");
+
+    /* Buffer for the read test to try to store the page that was just written */
+    read_buf = malloc(size_of_pages);
+    if (NULL == read_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for one_page_write_buf\n");
+
+    /* Reads the data back that was just written */
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, size_of_pages, 
+                    read_buf) < 0)
+        CRYPT_TEST_FAULT("couldn't read data from file\n");
+
+    if (memcmp(write_buf, read_buf, size_of_pages) != 0)
+        CRYPT_TEST_FAULT("data read from file does not match data written\n");
+
+    if (H5Pclose(fapl_id) < 0) {
+        CRYPT_TEST_FAULT("can't close fapl\n");
+    }
+
+    if (H5FDclose(file_ptr) < 0) {
+        CRYPT_TEST_FAULT("can't close file\n");
+    }
+
+done:
+    
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Pclose(fapl_id);
+            H5FDclose(file_ptr);
+        }
+        H5E_END_TRY
+    }
+
+    if (write_buf)
+        free(write_buf);
+
+    if (read_buf)
+        free(read_buf);
+
+    return ret_value;
+    
+} /* end crypt_test_write_and_read_aes256() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    crypt_test_create_and_write_twofish
+ *
+ * Purpose:     Tests the encryption VFD creating and opening a file that 
+ *              doesn't exist and writing to it. Only testing with one page
+ *              of data per write call. 
+ * 
+ *              Using the TWOFISH cipher
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+crypt_test_create_and_write_twofish(bool cl_config)
+{
+    hid_t                   fapl_id         = H5I_INVALID_HID;
+    char                    filename[1024];
+    char vfd_cfg_str[] =
+        "( encryption_VFD "
+        "  ( ( plaintext_page_size  4096 )"
+        "    ( ciphertext_page_size 4112 )"
+        "    ( encryption_buffer_size 65792 )"
+        "    ( cipher  0 )"
+        "    ( cipher_block_size 16 )"
+        "    ( key_size  32 )"
+        "    ( key --5E73C3BFC3A22CC2AA54055DC3B56169C38E5F7DC395C2AC23C2BE4C14C3B33B )"
+        "    ( iv_size 16 )"
+        "    ( mode 0 )"
+        "    ( underlying_VFD ( sec2 () ) )"
+        "  )"
+        ")";
+    H5FD_crypt_vfd_config_t vfd_config = 
+    {
+        /* magic                  = */ H5FD_CRYPT_CONFIG_MAGIC,
+        /* version                = */ H5FD_CURR_CRYPT_VFD_CONFIG_VERSION,
+        /* plaintext_page_size    = */ 4096,
+        /* ciphertext_page_size   = */ 4112,
+        /* encryption_buffer_size = */ H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE,
+        /* cipher                 = */ 0,  
+        /* cipher_block_size      = */ 16,
+        /* key_size               = */ 32,
+        /* key                    = */ H5FD_CRYPT_TEST_KEY,
+        /* iv_size                = */ 16,
+        /* mode                   = */ 0,
+        /* fapl_id                = */ H5P_DEFAULT
+    };
+    H5FD_t                * file_ptr           = NULL;
+    unsigned char         * one_page_write_buf = NULL;
+    unsigned char         * one_page_read_buf  = NULL;
+    int                     ret_value    = 0;
+
+    /* setup the target file name, and delete any existing instance */
+    h5_fixname(FILENAME[17], vfd_config.fapl_id, filename, 1024);
+    HDremove(filename);
+
+    /* create and initialize FAPL for the encryption VFD */
+    
+    if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) == H5I_INVALID_HID) {
+        CRYPT_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if ( cl_config ) {
+
+        if (H5CL_load_vfd_config_str_into_fapl(fapl_id, vfd_cfg_str) < 0) {
+            CRYPT_TEST_FAULT("can't load config string into fapl\n");
+        }
+    } else {
+
+        if (H5Pset_fapl_crypt(fapl_id, &vfd_config) < 0) {
+            CRYPT_TEST_FAULT("can't set enryption VFD FAPL\n");
+        }
+    }
+
+    if (H5Pget_driver(fapl_id) != H5FD_CRYPT) {
+        CRYPT_TEST_FAULT("set FAPL not encryption VFD\n");
+    }
+
+    if ( cl_config ) {
+
+        if (compare_crypt_config_str(fapl_id, vfd_cfg_str) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+
+    } else {
+
+        if (compare_crypt_config_info(fapl_id, &vfd_config) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+    }
+
+    /** 
+     * Opens a file that doesn't exist with the create flag. Should create the
+     * file, open it, and write the first two pages with the config data.
+     */
+    if (NULL == (file_ptr = H5FDopen(filename, H5F_ACC_RDWR | H5F_ACC_CREAT, 
+                    fapl_id, HADDR_UNDEF)))
+        CRYPT_TEST_FAULT("couldn't get pointer to H5FD_t structure");
+
+
+
+    /********** Buffer setup to test write data to the file  **********/
+
+    /* Buffer to hold the data that will be used to test the write function */
+    one_page_write_buf = malloc(vfd_config.plaintext_page_size);
+    if (NULL == one_page_write_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for one_page_write_buf\n");
+
+    /* Fill the buffer with random characters to simulate data */
+    for (size_t i = 0; i < vfd_config.plaintext_page_size; i++)
+        one_page_write_buf[i] = (unsigned char)rand() % 256;
+
+    /* set the eoa so we can write the page of data */
+    if ( H5FDset_eoa(file_ptr, H5FD_MEM_DEFAULT, (haddr_t)(1 * vfd_config.plaintext_page_size)) < 0 )
+        CRYPT_TEST_FAULT("couldn't set file eoa\n");
+    
+    /* Write the data to the file */
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, 
+                    vfd_config.plaintext_page_size, one_page_write_buf) < 0)
+        CRYPT_TEST_FAULT("couldn't write data to file\n");
+
+
+    /* Buffer for the read test to store the page that was just written */
+    one_page_read_buf = malloc(vfd_config.plaintext_page_size);
+    if (NULL == one_page_read_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for one_page_write_buf\n");
+
+    /* Reads the data back that was just written */
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, 
+                    vfd_config.plaintext_page_size, one_page_read_buf) < 0)
+        CRYPT_TEST_FAULT("couldn't read data from file\n");
+
+    /* Compare the data that was written to the data that was read */
+    if (memcmp(one_page_write_buf, one_page_read_buf, 
+                vfd_config.plaintext_page_size) != 0)
+        CRYPT_TEST_FAULT("data read from file does not match data written\n");
+
+    if (H5Pclose(fapl_id) < 0) {
+        CRYPT_TEST_FAULT("can't close fapl\n");
+    }
+
+    if (H5FDclose(file_ptr) < 0) {
+        CRYPT_TEST_FAULT("can't close file\n");
+    }
+
+done:
+    
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Pclose(fapl_id);
+            H5FDclose(file_ptr);
+        }
+        H5E_END_TRY
+    }
+
+    if (one_page_write_buf)
+        free(one_page_write_buf);
+
+    if (one_page_read_buf)
+        free(one_page_read_buf);
+
+    return ret_value;
+    
+} /* end crypt_test_create_and_write_twofish() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    crypt_test_verify_create_and_encryption_twofish
+ *
+ * Purpose:     Tests the encryption VFD creating and opening a file that 
+ *              doesn't exist and writing one page to it. Then using POSIX
+ *              calls to open the file manually, reads the entire file 
+ *              (first two config pages and the third encrypted page) into
+ *              a buffer. Another buffer is allocated and three pages are 
+ *              manually created and stored in this new buffer. The 
+ *              manually created pages are exactly what the pages in the
+ *              file should be. These two buffers are then compared to 
+ *              ensure the data in the file is correct (first page 
+ *              configuration data, second page test encryption phrase, 
+ *              third page encrypted data).
+ * 
+ *              Using the TWOFISH cipher
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+crypt_test_verify_create_and_encryption_twofish(bool cl_config)
+{
+    hid_t                   fapl_id         = H5I_INVALID_HID;
+    char                    filename[1024];
+    char vfd_cfg_str[] =
+        "( encryption_VFD "
+        "  ( ( plaintext_page_size  4096 )"
+        "    ( ciphertext_page_size 4112 )"
+        "    ( encryption_buffer_size 65792 )"
+        "    ( cipher  1 )"
+        "    ( cipher_block_size 16 )"
+        "    ( key_size  32 )"
+        "    ( key --5E73C3BFC3A22CC2AA54055DC3B56169C38E5F7DC395C2AC23C2BE4C14C3B33B )"
+        "    ( iv_size 16 )"
+        "    ( mode 0 )"
+        "    ( underlying_VFD ( sec2 () ) )"
+        "  )"
+        ")";
+    H5FD_crypt_vfd_config_t vfd_config = 
+    {
+        /* magic                  = */ H5FD_CRYPT_CONFIG_MAGIC,
+        /* version                = */ H5FD_CURR_CRYPT_VFD_CONFIG_VERSION,
+        /* plaintext_page_size    = */ 4096,
+        /* ciphertext_page_size   = */ 4112,
+        /* encryption_buffer_size = */ H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE,
+        /* cipher                 = */ 1,  
+        /* cipher_block_size      = */ 16,
+        /* key_size               = */ 32,
+        /* key                    = */ H5FD_CRYPT_TEST_KEY,
+        /* iv_size                = */ 16,
+        /* mode                   = */ 0,
+        /* fapl_id                = */ H5P_DEFAULT
+    };
+    H5FD_t                * file_ptr            = NULL;
+    unsigned char         * write_buf           = NULL;
+    unsigned char         * read_buf            = NULL;
+    unsigned char         * compare_buf         = NULL;
+    int                     fd                  = -1;
+    size_t                  size_of_3_page_file;
+    gcry_cipher_hd_t        handle;
+    unsigned char         * iv_second_page      = NULL;
+    unsigned char         * iv_third_page       = NULL;
+    const char            * test_phrase         = "Decryption works";
+    unsigned char         * test_phrase_buf     = NULL;
+    int                     ret_value           = 0;
+
+    /* setup the target file name, and delete any existing instance */
+    h5_fixname(FILENAME[17], vfd_config.fapl_id, filename, 1024);
+    HDremove(filename);
+
+    /* create and initialize FAPL for the encryption VFD */
+    if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) == H5I_INVALID_HID) {
+        CRYPT_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if ( cl_config ) {
+
+        if (H5CL_load_vfd_config_str_into_fapl(fapl_id, vfd_cfg_str) < 0) {
+            CRYPT_TEST_FAULT("can't load config string into fapl\n");
+        }
+    } else {
+
+        if (H5Pset_fapl_crypt(fapl_id, &vfd_config) < 0) {
+            CRYPT_TEST_FAULT("can't set enryption VFD FAPL\n");
+        }
+    }
+
+    if (H5Pget_driver(fapl_id) != H5FD_CRYPT) {
+        CRYPT_TEST_FAULT("set FAPL not encryption VFD\n");
+    }
+
+    if ( cl_config ) {
+
+        if (compare_crypt_config_str(fapl_id, vfd_cfg_str) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+
+    } else {
+
+        if (compare_crypt_config_info(fapl_id, &vfd_config) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+    }
+
+
+    /** 
+     * Opens a file that doesn't exist with the create flag. Should create the
+     * file, open it, and write the first two pages with config data.
+     */
+    if (NULL == (file_ptr = H5FDopen(filename, H5F_ACC_RDWR | H5F_ACC_CREAT, 
+                    fapl_id, HADDR_UNDEF)))
+        CRYPT_TEST_FAULT("couldn't get pointer to H5FD_t structure");
+
+
+
+    /********** Buffer setup to test writing data to the file  **********/
+
+    /* Buffer to hold the data that will be used to test the write function */
+    write_buf = malloc(vfd_config.plaintext_page_size);
+    if (NULL == write_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for write_buf\n");
+
+    /* Fill the buffer with random characters to simulate data */
+    for (size_t i = 0; i < vfd_config.plaintext_page_size; i++)
+        write_buf[i] = (unsigned char)rand() % 256;
+
+    /* set the eoa so we can write the page of data */
+    if ( H5FDset_eoa(file_ptr, H5FD_MEM_DEFAULT, (haddr_t)(1 * vfd_config.plaintext_page_size)) < 0 )
+        CRYPT_TEST_FAULT("couldn't set file eoa\n");
+
+    /* Write the data to the file */
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, 
+                    vfd_config.plaintext_page_size, write_buf) < 0)
+        CRYPT_TEST_FAULT("couldn't write data to file\n");
+
+    /* Close the file */
+    if (H5FDclose(file_ptr) < 0) {
+        CRYPT_TEST_FAULT("can't close file\n");
+    }
+
+
+    /*************************************************************************
+     * Opens the newly created file using normal POSIX calls to read the first
+     * two configuration pages and the third encrypted page into a buffer to 
+     * compare with manually created pages to ensure the data is correct.
+     *************************************************************************/
+
+    /* The size of all the pages file */
+    size_of_3_page_file = 3 * vfd_config.ciphertext_page_size;
+
+    /* Allocate buffer to read the entire file to */
+    read_buf = malloc(size_of_3_page_file);
+    if (NULL == read_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for read_buf\n");
+
+    /* Allocate buffer to store the IVs for the second and third pages */
+    iv_second_page = malloc(vfd_config.iv_size);
+    if (NULL == iv_second_page)
+        CRYPT_TEST_FAULT("couldn't allocate memory for iv_second_page\n");
+    
+    iv_third_page = malloc(vfd_config.iv_size);
+    if (NULL == iv_third_page)
+        CRYPT_TEST_FAULT("couldn't allocate memory for iv_third_page\n");
+    
+
+    /* Open the file using POSIX calls */
+    if ((fd = open(filename, O_RDONLY)) < 0)
+        CRYPT_TEST_FAULT("couldn't open file using POSIX calls\n");
+
+    /* Read the entire file into read_buf */
+    if (pread(fd, read_buf, size_of_3_page_file, 0) != (ssize_t)size_of_3_page_file)
+        CRYPT_TEST_FAULT("couldn't read file using POSIX calls\n");
+
+    /* Copies the IV for the second page to encrypt the manually made second page */
+    if (memcpy(iv_second_page, read_buf + vfd_config.ciphertext_page_size, vfd_config.iv_size) == NULL)
+        CRYPT_TEST_FAULT("couldn't copy second page's IV from read_buf\n");
+
+    /* Copies the IV for the third page to encrypt the manually made third page */
+    if (memcpy(iv_third_page, read_buf + 2 * vfd_config.ciphertext_page_size, vfd_config.iv_size) == NULL)
+        CRYPT_TEST_FAULT("couldn't copy third page's IV from read_buf\n");
+
+    /* Close the file */
+    if (close(fd) < 0)
+        CRYPT_TEST_FAULT("couldn't close file using POSIX calls\n");
+
+
+
+
+    /*************************************************************************
+     * Manually creating the data of the three pages into a buffer to compare
+     * the read_buf with to ensure the data in the file is correct.
+     *************************************************************************/
+
+    /* Allocate buffer to store the data for comparison */
+    compare_buf = malloc(size_of_3_page_file);
+    if (NULL == compare_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for compare_buf\n");
+
+
+    /* Manually create the first page and store it in the compare buf */
+    if (memset((void *)(compare_buf), '\0', vfd_config.ciphertext_page_size) == NULL)
+        CRYPT_TEST_FAULT("couldn't memset compare_buf\n");
+
+    snprintf((char *)compare_buf, vfd_config.ciphertext_page_size,
+             "plaintext_page_size: %zu\n"
+             "ciphertext_page_size: %zu\n"
+             "encryption_buffer_size: %zu\n"
+             "cipher: %d\n"
+             "cipher_block_size: %zu\n"
+             "key_size: %zu\n"
+             "iv_size: %zu\n"
+             "mode: %d\n",
+             vfd_config.plaintext_page_size,
+             vfd_config.ciphertext_page_size,
+             vfd_config.encryption_buffer_size,
+             vfd_config.cipher,
+             vfd_config.cipher_block_size,
+             vfd_config.key_size,
+             vfd_config.iv_size,
+             vfd_config.mode);
+
+
+
+    /* Manually create the second page and store it in the compare buf*/
+    if (memset((void *)(compare_buf + vfd_config.ciphertext_page_size), '\0', 
+                vfd_config.ciphertext_page_size) == NULL)
+        CRYPT_TEST_FAULT("couldn't memset compare_buf\n");
+
+
+    test_phrase_buf = (unsigned char *)calloc(vfd_config.ciphertext_page_size, 
+                                                sizeof(unsigned char));
+    if ( NULL == test_phrase_buf ) 
+        CRYPT_TEST_FAULT("couldn't allocate memory for test_phrase_buf\n");
+
+    memcpy(test_phrase_buf, test_phrase, strlen(test_phrase) + 1);
+
+
+
+    /* Manually encrypt and write the second page into the compare buf */
+    if ( gcry_cipher_open(&handle, GCRY_CIPHER_TWOFISH, 
+                            GCRY_CIPHER_MODE_CBC, 0) != 0 )
+        CRYPT_TEST_FAULT("couldn't open cipher handle\n");
+    
+    if ( gcry_cipher_setkey(handle, vfd_config.key, 32) != 0 )
+        CRYPT_TEST_FAULT("couldn't set key\n");
+
+    /* Stores the second page's IV into the compare buf */
+    if (memcpy((void *)(compare_buf + vfd_config.ciphertext_page_size), 
+                            iv_second_page, vfd_config.iv_size) == NULL)
+        CRYPT_TEST_FAULT("couldn't memcpy second page's IV to compare buf\n");
+
+    if ( gcry_cipher_setiv(handle, iv_second_page, 16) != 0 )
+        CRYPT_TEST_FAULT("couldn't set IV to handle for page 2\n");
+
+    if ( gcry_cipher_encrypt(handle, 
+            compare_buf + vfd_config.ciphertext_page_size + vfd_config.iv_size,
+            vfd_config.plaintext_page_size, 
+            test_phrase_buf, 
+            vfd_config.plaintext_page_size) != 0 )
+        CRYPT_TEST_FAULT("couldn't encrypt second page\n");
+
+    gcry_cipher_close(handle);  
+
+
+
+    /* Manually encrypt and write the created page (write_buf) into the compare buf*/
+    if ( gcry_cipher_open(&handle, GCRY_CIPHER_TWOFISH, 
+                            GCRY_CIPHER_MODE_CBC, 0) != 0 )
+        CRYPT_TEST_FAULT("couldn't open cipher handle for page 3\n");
+
+    if ( gcry_cipher_setkey(handle, vfd_config.key, 32) != 0 )
+        CRYPT_TEST_FAULT("couldn't set key the for page 3\n");
+
+    /* Stores the third page's IV into the compare buf */
+    if (memcpy((void *)(compare_buf + 2 * vfd_config.ciphertext_page_size), 
+                            iv_third_page, vfd_config.iv_size) == NULL)
+        CRYPT_TEST_FAULT("couldn't memcpy third page's IV to compare buf\n");
+
+    if ( gcry_cipher_setiv(handle, iv_third_page, 16) != 0 )
+        CRYPT_TEST_FAULT("couldn't set IV to handle for page 3\n");
+
+    if ( gcry_cipher_encrypt(handle, 
+            compare_buf + 2 * vfd_config.ciphertext_page_size + vfd_config.iv_size,
+            vfd_config.plaintext_page_size, 
+            write_buf, 
+            vfd_config.plaintext_page_size) != 0 )
+        CRYPT_TEST_FAULT("couldn't encrypt third page\n");
+
+    gcry_cipher_close(handle);
+
+
+
+    /**
+     * Compare the read_buf that holds the data read from the file and 
+     * compare_buf which holds the manually created data to ensure the data in
+     * the file matches what it should be.
+     */
+    if (memcmp(read_buf, compare_buf, size_of_3_page_file) != 0) {
+        CRYPT_TEST_FAULT("pages read from file does not match manually made pages\n");
+    }
+
+done:
+    
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Pclose(fapl_id);
+            H5FDclose(file_ptr);
+            if (fd >= 0)
+                close(fd);
+        }
+        H5E_END_TRY
+    }
+
+    if (write_buf)
+        free(write_buf);
+
+    if (compare_buf)
+        free(compare_buf);
+
+    if (read_buf)
+        free(read_buf);
+    
+    if (test_phrase_buf)
+        free(test_phrase_buf);
+    
+    if (iv_second_page)
+        free(iv_second_page);
+    
+    if (iv_third_page)
+        free(iv_third_page);
+
+    return ret_value;
+    
+} /* end crypt_test_verify_create_and_encryption_twofish() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    crypt_test_write_and_read_twofish
+ *
+ * Purpose:     Generalized test function for writing 'num_pages' to the 
+ *              file. This uses the TWOFISH cipher and tests the write and 
+ *              read operations with a variable number of pages.
+ * 
+ *              Using the TWOFISH cipher
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+crypt_test_write_and_read_twofish(size_t num_pages, H5FD_crypt_vfd_config_t *vfd_config, 
+                                  char * config_str, bool cl_config)
+{
+    hid_t                   fapl_id         = H5I_INVALID_HID;
+    char                    filename[1024];
+    H5FD_t                * file_ptr        = NULL;
+    unsigned char         * write_buf       = NULL;
+    unsigned char         * read_buf        = NULL;
+    size_t                  size_of_pages;
+    int                     ret_value       = 0;
+
+    /* setup the target file name */
+    h5_fixname(FILENAME[17], vfd_config->fapl_id, filename, 1024);
+
+    /* create and initialize FAPL for the encryption VFD */
+    
+    if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) == H5I_INVALID_HID) {
+        CRYPT_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if ( cl_config ) {
+
+        if (H5CL_load_vfd_config_str_into_fapl(fapl_id, config_str) < 0) {
+            CRYPT_TEST_FAULT("can't load config string into fapl\n");
+        }
+    } else {
+
+        if (H5Pset_fapl_crypt(fapl_id, vfd_config) < 0) {
+            CRYPT_TEST_FAULT("can't set enryption VFD FAPL\n");
+        }
+    }
+
+    if (H5Pget_driver(fapl_id) != H5FD_CRYPT) {
+        CRYPT_TEST_FAULT("set FAPL not encryption VFD\n");
+    }
+
+    if ( cl_config ) {
+
+        if (compare_crypt_config_str(fapl_id, config_str) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+
+    } else {
+
+        if (compare_crypt_config_info(fapl_id, vfd_config) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+    }
+
+
+    /* Opens an existing file with the read/write flag. */
+    if (NULL == (file_ptr = H5FDopen(filename, H5F_ACC_RDWR, fapl_id, HADDR_UNDEF)))
+        CRYPT_TEST_FAULT("couldn't get pointer to H5FD_t structure");
+
+
+
+    /********** Buffer setup to test write data to the file  **********/
+
+    size_of_pages = num_pages * vfd_config->plaintext_page_size;
+
+    /* Buffer to hold the data that will be used to test the write function */
+    write_buf = malloc(size_of_pages);
+    if (NULL == write_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for six_page_write_buf\n");
+
+    /* Fill the buffer with random characters to simulate data */
+    for (size_t i = 0; i < (size_of_pages); i++)
+        write_buf[i] = (unsigned char)rand() % 256;
+
+    /* set the eoa so we can write the page of data */
+    if ( H5FDset_eoa(file_ptr, H5FD_MEM_DEFAULT, (haddr_t)(num_pages * vfd_config->plaintext_page_size)) < 0 )
+        CRYPT_TEST_FAULT("couldn't set file eoa\n");
+    
+    /* Write the data to the file */
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, size_of_pages, 
+                    write_buf) < 0)
+        CRYPT_TEST_FAULT("couldn't write data to file\n");
+
+    /* Buffer for the read test to try to store the page that was just written */
+    read_buf = malloc(size_of_pages);
+    if (NULL == read_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for one_page_write_buf\n");
+
+    /* Reads the data back that was just written */
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, size_of_pages, 
+                    read_buf) < 0)
+        CRYPT_TEST_FAULT("couldn't read data from file\n");
+
+    if (memcmp(write_buf, read_buf, size_of_pages) != 0)
+        CRYPT_TEST_FAULT("data read from file does not match data written\n");
+
+    if (H5Pclose(fapl_id) < 0) {
+        CRYPT_TEST_FAULT("can't close fapl\n");
+    }
+
+    if (H5FDclose(file_ptr) < 0) {
+        CRYPT_TEST_FAULT("can't close file\n");
+    }
+
+done:
+    
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Pclose(fapl_id);
+            H5FDclose(file_ptr);
+        }
+        H5E_END_TRY
+    }
+
+    if (write_buf)
+        free(write_buf);
+
+    if (read_buf)
+        free(read_buf);
+
+    return ret_value;
+    
+} /* end crypt_test_write_and_read_twofish() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    run_crypt_test
+ *
+ * Purpose:     Auxiliary function for test_pb().
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ * Description:
+ *              Perform basic open-write-close with the page buffer / 
+ *              encryption VFD stack.
+ *
+ *              Prior to operations, removes files from a previous run,
+ *              if they exist.
+ *
+ *              After writing, verify the contents.
+ *              Includes FAPL sanity testing.
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+run_crypt_test(const struct crypt_dataset_def *data, const hid_t child_fapl_id, bool cl_config)
+{
+    hid_t                    file_id           = H5I_INVALID_HID;
+    hid_t                    dset_id           = H5I_INVALID_HID;
+    hid_t                    space_id          = H5I_INVALID_HID;
+    hid_t                    fapl_id_out       = H5I_INVALID_HID;
+    hid_t                    pb_fapl_id_cpy    = H5I_INVALID_HID;
+    hid_t                    crypt_fapl_id_cpy = H5I_INVALID_HID;
+    hid_t                    pb_fapl_id        = H5I_INVALID_HID;
+    hid_t                    crypt_fapl_id     = H5I_INVALID_HID;
+    char                     filename[1024];
+    char                  config_str_sub_sec2[] =
+        "( page_buffer "
+        "  ( ( page_size 4096 )"
+        "    ( max_num_pages 64 )"
+        "    ( replacement_policy 0 )"
+        "    ( underlying_VFD "
+        "      ( encryption_VFD "
+        "        ( ( plaintext_page_size  4096 )"
+        "          ( ciphertext_page_size 4112 )"
+        "          ( encryption_buffer_size 65792 )"
+        "          ( cipher  0 )"
+        "          ( cipher_block_size 16 )"
+        "          ( key_size  32 )"
+        "          ( key --0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF )"
+        "          ( iv_size 16 )"
+        "          ( mode 0 )"
+        "          ( underlying_VFD ( sec2 () ) )"
+        "        )"
+        "      )"
+        "    )"
+        "  )"
+        ")";
+    char                  config_str_sub_default[] =
+        "( page_buffer "
+        "  ( ( page_size 4096 )"
+        "    ( max_num_pages 64 )"
+        "    ( replacement_policy 0 )"
+        "    ( underlying_VFD "
+        "      ( encryption_VFD "
+        "        ( ( plaintext_page_size  4096 )"
+        "          ( ciphertext_page_size 4112 )"
+        "          ( encryption_buffer_size 65792 )"
+        "          ( cipher  0 )"
+        "          ( cipher_block_size 16 )"
+        "          ( key_size  32 )"
+        "          ( key --0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF )"
+        "          ( iv_size 16 )"
+        "          ( mode 0 )"
+        "        )"
+        "      )"
+        "    )"
+        "  )"
+        ")";
+    H5FD_pb_vfd_config_t     pb_vfd_config =
+    {
+        /* magic          = */ H5FD_PB_CONFIG_MAGIC,
+        /* version        = */ H5FD_CURR_PB_VFD_CONFIG_VERSION,
+        /* page_size      = */ H5FD_PB_DEFAULT_PAGE_SIZE,
+        /* max_num_pages  = */ H5FD_PB_DEFAULT_MAX_NUM_PAGES,
+        /* rp             = */ H5FD_PB_DEFAULT_REPLACEMENT_POLICY,
+        /* fapl_id        = */ H5P_DEFAULT,  /* will overwrite */
+        /* testing        = */ H5FD_PB_DEFAULT_TESTING_OFF
+    };
+    H5FD_crypt_vfd_config_t  crypt_vfd_config =
+    {
+        /* magic                  = */ H5FD_CRYPT_CONFIG_MAGIC,
+        /* version                = */ H5FD_CURR_CRYPT_VFD_CONFIG_VERSION,
+        /* plaintext_page_size    = */ 4096,
+        /* ciphertext_page_size   = */ 4112,
+        /* encryption_buffer_size = */ H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE,
+        /* cipher                 = */ 0,  
+        /* cipher_block_size      = */ 16,
+        /* key_size               = */ 32,
+        /* key                    = */ H5FD_CRYPT_TEST_KEY,
+        /* iv_size                = */ 16,
+        /* mode                   = */ 0,
+        /* fapl_id                = */ H5P_DEFAULT
+    };
+    int                   ret_value        = 0;
+
+
+    /* setup the target file name, and delete any existing instance */
+
+    h5_fixname(FILENAME[17], child_fapl_id, filename, 1024);
+    HDremove(filename);
+
+    if ( cl_config ) {
+
+        pb_fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+
+        if (H5I_INVALID_HID == pb_fapl_id) {
+            CRYPT_TEST_FAULT("can't create page buffer FAPL ID\n");
+        }
+
+        if ( H5P_DEFAULT == child_fapl_id ) {
+
+            if (H5CL_load_vfd_config_str_into_fapl(pb_fapl_id, config_str_sub_default) < 0)
+                CRYPT_TEST_FAULT("can't load config string into fapl\n");
+
+        } else if ( H5FD_SEC2 == H5Pget_driver(child_fapl_id) ) {
+
+            if (H5CL_load_vfd_config_str_into_fapl(pb_fapl_id, config_str_sub_sec2) < 0)
+                CRYPT_TEST_FAULT("can't load config string into fapl\n");
+
+        } else {
+
+            CRYPT_TEST_FAULT("unknown sub_fapl_id\n");
+        }
+
+    } else {
+
+        /* Create a new fapl to use the cryptography file driver */
+
+        crypt_fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+
+        if (H5I_INVALID_HID == crypt_fapl_id) {
+            CRYPT_TEST_FAULT("can't create cryptography FAPL ID\n");
+        }
+
+        crypt_vfd_config.fapl_id = child_fapl_id;
+
+        if (H5Pset_fapl_crypt(crypt_fapl_id, &crypt_vfd_config) < 0) {
+            CRYPT_TEST_FAULT("can't set crypt FAPL\n");
+        }
+
+        if (H5Pget_driver(crypt_fapl_id) != H5FD_CRYPT) {
+            CRYPT_TEST_FAULT("set FAPL not crypt\n");
+        }
+
+        /* Create a new fapl to use the page buffer file driver */
+
+        pb_fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+
+        if (H5I_INVALID_HID == pb_fapl_id) {
+            CRYPT_TEST_FAULT("can't create page buffer FAPL ID\n");
+        }
+
+        pb_vfd_config.fapl_id = crypt_fapl_id;
+
+        if (H5Pset_fapl_pb(pb_fapl_id, &pb_vfd_config) < 0) {
+            CRYPT_TEST_FAULT("can't set pb FAPL\n");
+        }
+
+        if (H5Pget_driver(pb_fapl_id) != H5FD_PB) {
+            CRYPT_TEST_FAULT("set FAPL not PB\n");
+        }
+
+        if (compare_pb_config_info(pb_fapl_id, &pb_vfd_config, false) < 0) {
+            CRYPT_TEST_FAULT("pb information mismatch\n");
+        }
+
+        if (compare_crypt_config_info(crypt_fapl_id, &crypt_vfd_config) < 0) {
+            CRYPT_TEST_FAULT("crypt information mismatch\n");
+        }
+    }
+
+
+    /*
+     * Copy property list, light compare, and close the copy.
+     * Helps test driver-implemented FAPL-copying and library ID management.
+     */
+
+    if ( cl_config ) {
+
+        pb_fapl_id_cpy = H5Pcopy(pb_fapl_id);
+
+        if (H5I_INVALID_HID == pb_fapl_id_cpy) {
+            CRYPT_TEST_FAULT("can't copy pb FAPL\n");
+        }
+
+        if ( H5P_DEFAULT == child_fapl_id ) {
+
+            if ( compare_pb_config_str(pb_fapl_id_cpy, config_str_sub_default) != 0 ) {
+
+                CRYPT_TEST_FAULT("pb copy information mismatch\n");
+
+            }
+        } else if ( H5FD_SEC2 == H5Pget_driver(child_fapl_id) ) {
+
+            if ( compare_pb_config_str(pb_fapl_id_cpy, config_str_sub_sec2) != 0 ) {
+
+                CRYPT_TEST_FAULT("pb copy information mismatch\n");
+
+            }
+        } else {
+
+            CRYPT_TEST_FAULT("unknown child_fapl_id\n");
+        }
+
+        if (H5Pclose(pb_fapl_id_cpy) < 0) {
+            CRYPT_TEST_FAULT("can't close pb fapl copy\n");
+        }
+    } else {
+
+        pb_fapl_id_cpy = H5Pcopy(pb_fapl_id);
+        if (H5I_INVALID_HID == pb_fapl_id_cpy) {
+            CRYPT_TEST_FAULT("can't copy pb FAPL\n");
+        }
+
+        if (compare_pb_config_info(pb_fapl_id_cpy, &pb_vfd_config, false) < 0) {
+            CRYPT_TEST_FAULT("pb copy information mismatch\n");
+        }
+
+        if (H5Pclose(pb_fapl_id_cpy) < 0) {
+            CRYPT_TEST_FAULT("can't close pb fapl copy\n");
+        }
+
+
+        crypt_fapl_id_cpy = H5Pcopy(crypt_fapl_id);
+        if (H5I_INVALID_HID == crypt_fapl_id_cpy) {
+            CRYPT_TEST_FAULT("can't copy crypt FAPL\n");
+        }
+        if (compare_crypt_config_info(crypt_fapl_id_cpy, &crypt_vfd_config) < 0) {
+            CRYPT_TEST_FAULT("crypt copy information mismatch\n");
+        }
+        if (H5Pclose(crypt_fapl_id_cpy) < 0) {
+            CRYPT_TEST_FAULT("can't close crypt fapl copy\n");
+        }
+    }
+
+
+    /*
+     * Proceed with test. Create file.
+     */
+    file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, pb_fapl_id);
+    if (file_id < 0) {
+        CRYPT_TEST_FAULT("can't create file\n");
+    }
+
+
+    /*
+     * Check driver from file
+     */
+
+    fapl_id_out = H5Fget_access_plist(file_id);
+
+    if (H5I_INVALID_HID == fapl_id_out) {
+        CRYPT_TEST_FAULT("can't get file's FAPL\n");
+    }
+
+    if (H5Pget_driver(fapl_id_out) != H5FD_PB) {
+        CRYPT_TEST_FAULT("wrong file FAPL driver\n");
+    }
+
+    /* BUG: to reproduce segfault on shutdown replace cl_config with true in 
+     *      following call to compare_pb_config_info().
+     */
+#if 0 
+    if (compare_pb_config_info(fapl_id_out, &pb_vfd_config, true) < 0) {
+#else
+    if (compare_pb_config_info(fapl_id_out, &pb_vfd_config, cl_config) < 0) {
+#endif 
+        CRYPT_TEST_FAULT("information mismatch\n");
+    }
+
+    if (H5Pclose(fapl_id_out) < 0) {
+        CRYPT_TEST_FAULT("can't close file's FAPL\n");
+    }
+
+
+    /*
+     * Create and write the dataset
+     */
+
+    space_id = H5Screate_simple(data->n_dims, data->dims, NULL);
+
+    if (space_id < 0) {
+        CRYPT_TEST_FAULT("can't create dataspace\n");
+    }
+
+    dset_id = H5Dcreate2(file_id, data->dset_name, data->mem_type_id, space_id,
+                         H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+
+    if (dset_id < 0) {
+        CRYPT_TEST_FAULT("can't create dataset\n");
+    }
+
+    if (H5Dwrite(dset_id, data->mem_type_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, data->buf) < 0) {
+        CRYPT_TEST_FAULT("can't write data to dataset\n");
+    }
+
+    if (crypt_compare_expected_data(file_id, data) < 0) {
+        CRYPT_TEST_FAULT("data mismatch in file - 1\n");
+    }
+
+    /* close the file */
+
+    if (H5Dclose(dset_id) < 0) {
+        CRYPT_TEST_FAULT("can't close dset\n");
+    }
+
+    if (H5Sclose(space_id) < 0) {
+        CRYPT_TEST_FAULT("can't close space\n");
+    }
+
+    if (H5Fclose(file_id) < 0) {
+        CRYPT_TEST_FAULT("can't close file\n");
+    }
+
+
+    /* re-open the file and verify its contents */
+    file_id = H5Fopen(filename, H5F_ACC_RDWR, pb_fapl_id);
+
+    if (file_id < 0) {
+        CRYPT_TEST_FAULT("R/W open on extant file failed\n");
+    }
+
+    if (crypt_compare_expected_data(file_id, data) < 0) {
+        CRYPT_TEST_FAULT("data mismatch in file - 2\n");
+    }
+
+    if (H5Fclose(file_id) < 0) {
+        CRYPT_TEST_FAULT("can't close file\n");
+    }
+
+
+    /* Close FAPLs */
+
+    if (H5Pclose(pb_fapl_id) < 0) {
+        CRYPT_TEST_FAULT("can't close fapl\n");
+    }
+
+    if ( ! cl_config ) {
+
+        if (H5Pclose(crypt_fapl_id) < 0) {
+            CRYPT_TEST_FAULT("can't close fapl\n");
+        }
+    }
+
+
+done:
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Dclose(dset_id);
+            H5Sclose(space_id);
+            H5Pclose(fapl_id_out);
+            H5Pclose(pb_fapl_id_cpy);
+            H5Pclose(crypt_fapl_id_cpy);
+            H5Pclose(pb_fapl_id);
+            H5Pclose(crypt_fapl_id);
+            H5Fclose(file_id);
+        }
+        H5E_END_TRY
+    }
+
+    return ret_value;
+
+} /* end run_crypt_test() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    crypt_RO_test
+ *
+ * Purpose:     Verify page buffer / crypt VFDs with the Read-Only access 
+ *              flag.
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ * Description: Attempt read-only opening of file that eithr does or
+ *              does not exist.
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+crypt_RO_test(const struct crypt_dataset_def *data, hid_t child_fapl_id, bool cl_config)
+{
+    char                     filename[1024];
+    char                  config_str_sub_sec2[] =
+        "( page_buffer "
+        "  ( ( page_size 4096 )"
+        "    ( max_num_pages 16 )"
+        "    ( replacement_policy 0 )"
+        "    ( underlying_VFD "
+        "      ( encryption_VFD "
+        "        ( ( plaintext_page_size  4096 )"
+        "          ( ciphertext_page_size 4112 )"
+        "          ( encryption_buffer_size 65792 )"
+        "          ( cipher  0 )"
+        "          ( cipher_block_size 16 )"
+        "          ( key_size  32 )"
+        "          ( key --0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF )"
+        "          ( iv_size 16 )"
+        "          ( mode 0 )"
+        "          ( underlying_VFD ( sec2 () ) )"
+        "        )"
+        "      )"
+        "    )"
+        "  )"
+        ")";
+    char                  config_str_sub_default[] =
+        "( page_buffer "
+        "  ( ( page_size 4096 )"
+        "    ( max_num_pages 16 )"
+        "    ( replacement_policy 0 )"
+        "    ( underlying_VFD "
+        "      ( encryption_VFD "
+        "        ( ( plaintext_page_size  4096 )"
+        "          ( ciphertext_page_size 4112 )"
+        "          ( encryption_buffer_size 65792 )"
+        "          ( cipher  0 )"
+        "          ( cipher_block_size 16 )"
+        "          ( key_size  32 )"
+        "          ( key --0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF )"
+        "          ( iv_size 16 )"
+        "          ( mode 0 )"
+        "        )"
+        "      )"
+        "    )"
+        "  )"
+        ")";
+    H5FD_pb_vfd_config_t     pb_vfd_config = 
+    {
+        /* magic          = */ H5FD_PB_CONFIG_MAGIC,
+        /* version        = */ H5FD_CURR_PB_VFD_CONFIG_VERSION,
+        /* page_size      = */ H5FD_PB_DEFAULT_PAGE_SIZE,
+        /* max_num_pages  = */ H5FD_PB_DEFAULT_MAX_NUM_PAGES,
+        /* rp             = */ H5FD_PB_DEFAULT_REPLACEMENT_POLICY, 
+        /* fapl_id        = */ H5P_DEFAULT,  /* will overwrite */
+        /* testing        = */ H5FD_PB_DEFAULT_TESTING_OFF
+    };
+    H5FD_crypt_vfd_config_t  crypt_vfd_config =
+    {
+        /* magic                  = */ H5FD_CRYPT_CONFIG_MAGIC,
+        /* version                = */ H5FD_CURR_CRYPT_VFD_CONFIG_VERSION,
+        /* plaintext_page_size    = */ 4096,
+        /* ciphertext_page_size   = */ 4112,
+        /* encryption_buffer_size = */ H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE,
+        /* cipher                 = */ 0,  
+        /* cipher_block_size      = */ 16,
+        /* key_size               = */ 32,
+        /* key                    = */ H5FD_CRYPT_TEST_KEY,
+        /* iv_size                = */ 16,
+        /* mode                   = */ 0,
+        /* fapl_id                = */ H5P_DEFAULT
+    };
+    hid_t                    pb_fapl_id       = H5I_INVALID_HID;
+    hid_t                    crypt_fapl_id    = H5I_INVALID_HID;
+    hid_t                    file_id          = H5I_INVALID_HID;
+    int                      ret_value        = 0;
+
+    /* setup the target file name, and delete any existing instance */
+
+    h5_fixname(FILENAME[17], child_fapl_id, filename, 1024);
+    HDremove(filename);
+
+    if ( cl_config ) {
+
+        pb_fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+
+        if (H5I_INVALID_HID == pb_fapl_id) {
+            CRYPT_TEST_FAULT("can't create page buffer FAPL ID\n");
+        }
+
+        if ( H5P_DEFAULT == child_fapl_id ) {
+ 
+            if (H5CL_load_vfd_config_str_into_fapl(pb_fapl_id, config_str_sub_default) < 0)
+                CRYPT_TEST_FAULT("can't load config string into fapl\n");
+
+        } else if ( H5FD_SEC2 == H5Pget_driver(child_fapl_id) ) {
+
+            if (H5CL_load_vfd_config_str_into_fapl(pb_fapl_id, config_str_sub_sec2) < 0)
+                CRYPT_TEST_FAULT("can't load config string into fapl\n");
+        
+        } else { 
+        
+            CRYPT_TEST_FAULT("unknown sub_fapl_id\n");
+        }   
+
+    } else {
+
+        /* Create a new fapl to use the cryptography file driver */
+
+        crypt_fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+
+        if (H5I_INVALID_HID == crypt_fapl_id) {
+            CRYPT_TEST_FAULT("can't create cryptography FAPL ID\n");
+        }
+
+        crypt_vfd_config.fapl_id = child_fapl_id;
+
+        if (H5Pset_fapl_crypt(crypt_fapl_id, &crypt_vfd_config) < 0) {
+            CRYPT_TEST_FAULT("can't set crypt FAPL\n");
+        }
+
+        if (H5Pget_driver(crypt_fapl_id) != H5FD_CRYPT) {
+            CRYPT_TEST_FAULT("set FAPL not crypt\n");
+        }
+
+
+        /* Create a new fapl to use the page buffer file driver */
+
+        pb_fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+
+        if (H5I_INVALID_HID == pb_fapl_id) {
+            CRYPT_TEST_FAULT("can't create page buffer FAPL ID\n");
+        }
+
+        pb_vfd_config.fapl_id = crypt_fapl_id;
+
+        if (H5Pset_fapl_pb(pb_fapl_id, &pb_vfd_config) < 0) {
+            CRYPT_TEST_FAULT("can't set pb FAPL\n");
+        }
+
+        if (H5Pget_driver(pb_fapl_id) != H5FD_PB) {
+            CRYPT_TEST_FAULT("set FAPL not PB\n");
+        }
+    }
+
+    /* Attempt R/O open when target file doesn't exist.
+     * Should fail.
+     */
+
+    H5E_BEGIN_TRY
+    {
+        file_id = H5Fopen(filename, H5F_ACC_RDONLY, pb_fapl_id);
+    }
+    H5E_END_TRY
+
+    if (file_id >= 0) {
+        CRYPT_TEST_FAULT("R/O open on nonexistent file unexpectedly successful\n");
+    }
+
+
+    /* Attempt R/O open when file exists
+     */
+
+    /* For now, attempt to create the test file with pb_vfd_config.  May
+     * have to revisit this.
+     */
+    if (crypt_create_single_file_at(filename, pb_fapl_id, data) < 0) {
+        CRYPT_TEST_FAULT("can't create file\n");
+    }
+
+    // file_id = H5Fopen(filename, H5F_ACC_RDWR, pb_fapl_id);
+    file_id = H5Fopen(filename, H5F_ACC_RDONLY, pb_fapl_id);
+
+    if (file_id < 0) {
+        CRYPT_TEST_FAULT("R/O open on extant file failed\n");
+    }
+
+    if (crypt_compare_expected_data(file_id, data) < 0) {
+        CRYPT_TEST_FAULT("data mismatch in file\n");
+    }
+
+    if (H5Fclose(file_id) < 0) {
+        CRYPT_TEST_FAULT("can't close file(s)\n");
+    }
+
+    file_id = H5I_INVALID_HID;
+
+    /* Cleanup
+     */
+
+    if ( ( H5I_INVALID_HID != crypt_fapl_id ) && ( H5Pclose(crypt_fapl_id) < 0 ) ) {
+        CRYPT_TEST_FAULT("can't close crypt FAPL ID\n");
+    }
+
+    crypt_fapl_id = H5I_INVALID_HID;
+
+    if ( ( H5I_INVALID_HID != pb_fapl_id ) && ( H5Pclose(pb_fapl_id) < 0 ) ) {
+        CRYPT_TEST_FAULT("can't close pb FAPL ID\n");
+    }
+
+    pb_fapl_id = H5I_INVALID_HID;
+
+done:
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Pclose(crypt_fapl_id);
+            H5Pclose(pb_fapl_id);
+            H5Fclose(file_id);
+        }
+        H5E_END_TRY
+    }
+
+    return ret_value;
+
+} /* end crypt_RO_test() */
+
+/*-------------------------------------------------------------------------
+ * Function:    crypt_create_single_file_at
+ *
+ * Purpose:     Create a file, optionally w/ dataset.
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ * Description:
+ *              Create a an encrypted file at the given location with 
+ *              the given FAPL, and write data as defined in `data` in 
+ *              a pre-determined location in the file.
+ *
+ *              If the dataset definition pointer is NULL, no data is 
+ *              written to the file.
+ *
+ *              Will always overwrite an existing file with the given
+ *              name/path.
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+crypt_create_single_file_at(const char *filename, hid_t fapl_id, const struct crypt_dataset_def *data)
+{
+    hid_t file_id   = H5I_INVALID_HID;
+    hid_t space_id  = H5I_INVALID_HID;
+    hid_t dset_id   = H5I_INVALID_HID;
+    int   ret_value = 0;
+
+
+    if (filename == NULL || *filename == '\0') {
+        CRYPT_TEST_FAULT("filename is invalid\n");
+    }
+    /* TODO: sanity-check fapl id? */
+
+    file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
+
+    if (file_id < 0) {
+        CRYPT_TEST_FAULT("can't create file\n");
+    }
+
+    if (data) {
+
+        /* TODO: sanity-check data, if it exists? */
+
+        space_id = H5Screate_simple(data->n_dims, data->dims, NULL);
+
+        if (space_id < 0) {
+            CRYPT_TEST_FAULT("can't create dataspace\n");
+        }
+
+        dset_id = H5Dcreate2(file_id, data->dset_name, data->mem_type_id, space_id,
+                             H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+
+        if (dset_id < 0) {
+            CRYPT_TEST_FAULT("can't create dataset\n");
+        }
+
+        if (H5Dwrite(dset_id, data->mem_type_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, data->buf) < 0) {
+            CRYPT_TEST_FAULT("can't write data to dataset\n");
+        }
+
+        if (H5Dclose(dset_id) < 0) {
+            CRYPT_TEST_FAULT("can't close dset\n");
+        }
+
+        if (H5Sclose(space_id) < 0) {
+            CRYPT_TEST_FAULT("can't close space\n");
+        }
+
+        if (crypt_compare_expected_data(file_id, data) < 0) {
+            CRYPT_TEST_FAULT("data mismatch in file\n");
+        }
+
+        if (H5Fclose(file_id) < 0) {
+            CRYPT_TEST_FAULT("can't close file\n");
+        }
+
+        /* re-open the file and verify its contents */
+        file_id = H5Fopen(filename, H5F_ACC_RDWR, fapl_id);
+
+        if (file_id < 0) {
+            CRYPT_TEST_FAULT("R/W open on extant file failed\n");
+        }
+
+        if (crypt_compare_expected_data(file_id, data) < 0) {
+            CRYPT_TEST_FAULT("data mismatch in file\n");
+        }
+    } /* end if data definition is provided */
+
+    if (H5Fclose(file_id) < 0) {
+        CRYPT_TEST_FAULT("can't close file\n");
+    }
+
+done:
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            // H5Pclose(dcpl_id);
+            H5Dclose(dset_id);
+            H5Sclose(space_id);
+            H5Fclose(file_id);
+        }
+        H5E_END_TRY
+    } /* end if error */
+
+    return ret_value;
+
+} /* end crypt_create_single_file_at() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    crypt_compare_expected_data
+ *
+ * Purpose:     Compare data within a predermined dataset.
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ * Description: Read data from the file at a predetermined location, and
+ *              compare its contents byte-for-byte with that expected in
+ *              the `data` definition structure.
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+crypt_compare_expected_data(hid_t file_id, const struct crypt_dataset_def *data)
+{
+    hid_t  dset_id = H5I_INVALID_HID;
+    int    buf[PB_DS_SIZE][PB_DS_SIZE];
+    int    expected[PB_DS_SIZE][PB_DS_SIZE];
+    size_t i         = 0;
+    size_t j         = 0;
+    int    ret_value = 0;
+
+    if (sizeof((void *)buf) != sizeof(data->buf)) {
+        CRYPT_TEST_FAULT("invariant size of expected data does not match that received!\n");
+    }
+
+    memcpy(expected, data->buf, sizeof(expected));
+
+    dset_id = H5Dopen2(file_id, data->dset_name, H5P_DEFAULT);
+
+    if (dset_id < 0) {
+        CRYPT_TEST_FAULT("can't open dataset\n");
+    }
+
+    if (H5Dread(dset_id, data->mem_type_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, (void *)buf) < 0) {
+        CRYPT_TEST_FAULT("can't read dataset\n");
+    }
+
+    for (i = 0; i < CRYPT_DS_SIZE; i++) {
+        for (j = 0; j < CRYPT_DS_SIZE; j++) {
+            if (buf[i][j] != expected[i][j]) {
+                CRYPT_TEST_FAULT("mismatch in expected data\n");
+            }
+        }
+    }
+
+    if (H5Dclose(dset_id) < 0) {
+        CRYPT_TEST_FAULT("can't close dataset\n");
+    }
+
+done:
+    if (ret_value < 0) {
+        H5E_BEGIN_TRY
+        {
+            H5Dclose(dset_id);
+        }
+        H5E_END_TRY
+    }
+
+    return ret_value;
+
+} /* end crypt_compare_expected_data() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    test_crypt
+ *
+ * Purpose:     Tests the encryption VFD
+ *
+ *              This is the main function for all encryption VFD specific
+ *              tests.
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+test_crypt(bool cl_config)
+{
+    int                         buf[PB_DS_SIZE][PB_DS_SIZE];
+    hsize_t                     dims[2]       = {CRYPT_DS_SIZE, CRYPT_DS_SIZE};
+    hid_t                       child_fapl_id = H5I_INVALID_HID;
+    int                         i             = 0;
+    int                         j             = 0;
+    struct crypt_dataset_def    data;
+
+    /* pre-fill data buffer to write */
+    for (i = 0; i < CRYPT_DS_SIZE; i++) {
+        for (j = 0; j < CRYPT_DS_SIZE; j++) {
+            buf[i][j] = i * 100 + j;
+        }
+    }
+
+    /* Dataset info */
+    data.buf         = (void *)buf;
+    data.mem_type_id = H5T_NATIVE_INT;
+    data.dims        = dims;
+    data.n_dims      = 2;
+    data.dset_name   = CRYPT_DATASET_NAME;
+
+    if ( cl_config ) {
+
+        TESTING("Encrypting VFD with text based config -- Stand Alone");
+
+    } else {
+
+        TESTING("Encrypting VFD -- Stand Alone");
+
+    }
+
+    if ( test_crypt_fapl(cl_config) != 0 )
+        TEST_ERROR;
+
+    /* AES256 */
+
+    if ( crypt_test_create(cl_config) != 0 )
+        TEST_ERROR;
+
+    if ( crypt_test_create_and_write(cl_config) != 0 )
+        TEST_ERROR;
+
+    if ( crypt_test_verify_create_and_encryption(cl_config) != 0 )
+        TEST_ERROR;
+
+    if ( crypt_test_write_and_read_aes256(2, cl_config) != 0 )
+        TEST_ERROR;
+    
+    if ( crypt_test_write_and_read_aes256(15, cl_config) != 0 )
+        TEST_ERROR;
+    
+    if ( crypt_test_write_and_read_aes256(16, cl_config) != 0 )
+        TEST_ERROR;
+    
+    if ( crypt_test_write_and_read_aes256(17, cl_config) != 0 )
+        TEST_ERROR;
+
+    if ( crypt_test_write_and_read_aes256(18, cl_config) != 0 )
+        TEST_ERROR;
+
+    if ( crypt_test_write_and_read_aes256(32, cl_config) != 0 )
+        TEST_ERROR;
+
+    if ( crypt_test_write_and_read_aes256(33, cl_config) != 0 )
+        TEST_ERROR;
+
+    /* TWOFISH */
+
+    if ( crypt_test_create_and_write_twofish(cl_config) != 0 )
+        TEST_ERROR;
+
+    if ( crypt_test_verify_create_and_encryption_twofish(cl_config) != 0 )
+        TEST_ERROR;
+
+    char vfd_cfg_str[] =
+        "( encryption_VFD "
+        "  ( ( plaintext_page_size  4096 )"
+        "    ( ciphertext_page_size 4112 )"
+        "    ( encryption_buffer_size 65792 )"
+        "    ( cipher  1 )"
+        "    ( cipher_block_size 16 )"
+        "    ( key_size  32 )"
+        "    ( key --5E73C3BFC3A22CC2AA54055DC3B56169C38E5F7DC395C2AC23C2BE4C14C3B33B )"
+        "    ( iv_size 16 )"
+        "    ( mode 0 )"
+        "    ( underlying_VFD ( sec2 () ) )"
+        "  )"
+        ")";
+    H5FD_crypt_vfd_config_t vfd_config = 
+    {
+        /* magic                  = */ H5FD_CRYPT_CONFIG_MAGIC,
+        /* version                = */ H5FD_CURR_CRYPT_VFD_CONFIG_VERSION,
+        /* plaintext_page_size    = */ 4096,
+        /* ciphertext_page_size   = */ 4112,
+        /* encryption_buffer_size = */ H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE,
+        /* cipher                 = */ 1,  
+        /* cipher_block_size      = */ 16,
+        /* key_size               = */ 32,
+        /* key                    = */ H5FD_CRYPT_TEST_KEY,
+        /* iv_size                = */ 16,
+        /* mode                   = */ 0,
+        /* fapl_id                = */ H5P_DEFAULT
+    };
+
+    if ( crypt_test_write_and_read_twofish(17, &vfd_config, vfd_cfg_str, cl_config) != 0 )
+        TEST_ERROR;
+
+
+    PASSED();
+
+
+    if ( cl_config ) {
+
+        TESTING("Encrypting VFD with text based config -- with Page Buffer VFD");
+
+    } else {
+
+        TESTING("Encrypting VFD -- with Page Buffer VFD");
+
+    }
+
+    /* Stand-in for manual FAPL creation
+     * Enables verification with arbitrary VFDs via `make check-vfd`
+     *
+     * Note: Due to cache coherency concerns, the page buffer VFD
+     *       is incompatible with parallel HDF5 -- test code will
+     *       have to be modified to reflect this at some point.
+     *
+     *                                       -- JRM
+     */
+    child_fapl_id = h5_fileaccess();
+    if (child_fapl_id < 0) {
+        TEST_ERROR;
+    }
+
+    /* Test Read-Only access, including when the file does not exist.
+     */
+
+    if (crypt_RO_test(&data, child_fapl_id, cl_config) < 0) {
+
+        TEST_ERROR;
+    }
+
+
+    /* Test file creation, utilizing different child FAPLs (default vs.
+     * specified), logfile, and Write Channel error ignoring behavior.
+     */
+    for (i = 0; i < 2; i++) {
+
+        hid_t test_child_fapl_id;
+
+        test_child_fapl_id = (i > 0) ? child_fapl_id : H5P_DEFAULT;
+
+        if ( run_crypt_test(&data, test_child_fapl_id, cl_config) < 0 ) {
+
+            TEST_ERROR;
+        }
+
+    } /* end for child fapl definition */
+
+
+    PASSED();
+
+    return 0;
+
+error:
+
+    return -1;
+
+} /* end test_crypt() */
+
+#undef CRYPT_TEST_FAULT
+
+#endif /* encrypting VFD test code */
+
+
 /*****************************************************************************
  *
  * Function    setup_rand()
@@ -5881,11 +11141,13 @@ main(void)
      * being set can interfere with that.
      */
     driver_name = h5_get_test_driver_name();
+    fprintf(stderr, "\ndriver_name = \"%s\"\n", driver_name);
+#if 0 
     if (driver_name) {
         printf(" -- SKIPPED VFD tests because driver environment variable is set -- \n");
         exit(EXIT_SUCCESS);
     }
-
+#endif
     h5_test_init();
 
     printf("Testing basic Virtual File Driver functionality.\n");
@@ -5905,6 +11167,10 @@ main(void)
     nerrors += test_windows() < 0 ? 1 : 0;
     nerrors += test_ros3() < 0 ? 1 : 0;
     nerrors += test_splitter() < 0 ? 1 : 0;
+    nerrors += test_pb(false) < 0 ? 1 : 0;
+    nerrors += test_pb(true) < 0 ? 1 : 0;
+    nerrors += test_crypt(false) < 0 ? 1 : 0;
+    nerrors += test_crypt(true) < 0 ? 1 : 0;
     nerrors += test_vector_io("sec2") < 0 ? 1 : 0;
     nerrors += test_vector_io("stdio") < 0 ? 1 : 0;
     nerrors += test_selection_io("sec2") < 0 ? 1 : 0;

--- a/hdf5/hdf5-1.14.6/test/vfd_cl.c
+++ b/hdf5/hdf5-1.14.6/test/vfd_cl.c
@@ -13,11 +13,12 @@
 /*
  * Purpose:     Tests the basic features of Virtual File Drivers
  */
-
+#define H5E_FRIEND
 #define H5CL_FRIEND
 
 #include "h5test.h"
 #include "H5CLpkg.h"
+#include "H5Epkg.h"
 
 /* utility functions */
 static bool cl_lexer_test_verify_token(H5CL_token_t * token_ptr, int token_num, int32_t expected_code, 
@@ -28,11 +29,27 @@ static int cl_test_verify_nv_pair(H5CL_nv_pair_t * nv_pair_ptr, int nv_pair_num,
                                   const void * expected_vlen_val_ptr, size_t expected_len, bool verbose);
 static int cl_test_verify_nv_pairs(H5CL_nv_pair_t * actual_nv_pairs, H5CL_nv_pair_t * expected_nv_pairs,
                                    int num_nv_pairs, bool verbose);
+static int cl_test_verify_error_stack(hid_t maj_num, hid_t min_num, const char *desc, bool verbose);
 
 /* test functions */
 static herr_t cl_lexer_smoke_check(void);
+static herr_t cl_lexer_detail_check(void);
+static herr_t cl_lexer_error_check_1(void);
+static herr_t cl_lexer_error_check_2(void);
+static herr_t cl_lexer_error_check_3(void);
+static herr_t cl_lexer_error_check_4(void);
 static herr_t cl_parse_name_val_pair_smoke_check(void);
+static herr_t cl_parse_nv_pair_error_check_1(void);
+static herr_t cl_parse_nv_pair_error_check_2(void);
+static herr_t cl_parse_nv_pair_error_check_3(void);
+static herr_t cl_parse_nv_pair_error_check_4(void);
+static herr_t cl_parse_nv_pair_error_check_5(void);
+static herr_t cl_parse_nv_pair_error_check_6(void);
+static herr_t cl_parse_nv_pair_error_check_7(void);
 static herr_t cl_parse_name_val_pair_list_smoke_check(void);
+static herr_t cl_parse_name_val_pair_list_err_check_1(void);
+static herr_t cl_parse_name_val_pair_list_err_check_2(void);
+static herr_t cl_parse_name_val_pair_list_err_check_3(void);
 herr_t cl_parser_smoke_check(void);
 
 
@@ -107,14 +124,14 @@ cl_lexer_test_verify_token(H5CL_token_t * token_ptr, int token_num,
 
             for ( i = 0; i < (int)expected_bb_len; i++ ) {
 
-                fprintf(stdout, "%2x ", (unsigned)(token_ptr->bb_ptr[i]));
+                fprintf(stdout, "0x%02x ", (unsigned)(token_ptr->bb_ptr[i]));
             }
 
             fprintf(stdout, "\nexpected bb = ");
 
             for ( i = 0; i < (int)expected_bb_len; i++ ) {
 
-                fprintf(stdout, "%2x ", (unsigned)(expected_bb_ptr[i]));
+                fprintf(stdout, "0x%02x ", (unsigned)(expected_bb_ptr[i]));
             }
 
             fprintf(stdout, "\n");
@@ -301,6 +318,75 @@ cl_test_verify_nv_pairs(H5CL_nv_pair_t * actual_nv_pairs,
 
 /*******************************************************************************
  *
+ * cl_test_verify_error_stack()
+ *
+ * Verify that the bottom entry on the current error stack has major and 
+ * minor error IDs and error message matching the supplied values.
+ *
+ *                                              JRM -- 1/10/26
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+static int
+cl_test_verify_error_stack(hid_t maj_num, hid_t min_num, const char *desc, bool verbose)
+{
+    int failures = 0;
+    H5E_stack_t * estack_ptr;
+    H5E_entry_t * entry_ptr;
+    H5E_error2_t * err_ptr;
+
+    if ( NULL == (estack_ptr = H5E__get_my_stack()) ) {
+
+        failures++;
+
+        if ( verbose ) {
+
+            fprintf(stderr, "\ncl_test_verify_error_stack(): can't get error stack\n");
+        }
+    } else if ( estack_ptr->nused < 1 ) {
+
+        failures++;
+
+        if ( verbose ) {
+
+            fprintf(stderr, "\ncl_test_verify_error_stack(): error stack is empty\n");
+        }
+    } else {
+
+        entry_ptr = &(estack_ptr->entries[0]);
+        err_ptr = &(entry_ptr->err);
+
+        if ( ( maj_num != err_ptr->maj_num ) ||
+             ( min_num != err_ptr->min_num ) ||
+             ( 0 != strcmp(desc, err_ptr->desc) ) ) {
+
+            failures++;
+
+            if ( verbose ) {
+
+                fprintf(stderr, "\n\nActual / Expected major error number = 0x%llx / 0x%llx.\n",
+                        (long long)(err_ptr->maj_num), (long long)(maj_num));
+                fprintf(stderr, "Actual / Expected minor error number = 0x%llx / 0x%llx.\n",
+                        (long long)(err_ptr->min_num), (long long)(min_num));
+                fprintf(stderr, "Actual error desc = \"%s\".\n", err_ptr->desc);
+                fprintf(stderr, "Expected error desc = \"%s\".\n\n", desc);
+            }
+        }
+
+        H5E__clear_stack(estack_ptr);
+    }
+
+    return(failures);
+
+} /* cl_test_verify_error_stack() */
+
+
+/*******************************************************************************
+ *
  * cl_lexer_smoke_check()
  *
  * Initial set of lexer tests designed to verify basic functionality.  Note that
@@ -327,8 +413,7 @@ cl_lexer_smoke_check(void)
         /* input_str_ptr     = */ NULL,
         /* next_char_ptr     = */ NULL,
         /* end_of_input      = */ false, 
-        /* line_num          = */ 0,
-        /* char_num          = */ 0, 
+        /* err_ctx           = */ "",
         /* token             = */ {
         /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
         /* token.code        = */    H5CL_ERROR_TOK,
@@ -368,21 +453,21 @@ cl_lexer_smoke_check(void)
         TEST_ERROR;
     }
 
-    if ( H5CL__lex_read_token(false, &token_ptr, &lex_vars) < 0 ) /* 0 */
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 0 */
         TEST_ERROR;
 
     if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_L_PAREN_TOK, "(", 0, 0.0, NULL, 0, true) )
         TEST_ERROR;
 
 
-    if ( H5CL__lex_read_token(false, &token_ptr, &lex_vars) < 0 ) /* 1 */
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 1 */
         TEST_ERROR;
 
     if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_R_PAREN_TOK, ")", 0, 0.0, NULL, 0, true) )
         TEST_ERROR;
 
 
-    if ( H5CL__lex_read_token(false, &token_ptr, &lex_vars) < 0 ) /* 2 */
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 2 */
         TEST_ERROR;
 
     if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_SYMBOL_TOK, "symbol", 0, 0.0, 
@@ -390,14 +475,14 @@ cl_lexer_smoke_check(void)
         TEST_ERROR;
 
 
-    if ( H5CL__lex_read_token(false, &token_ptr, &lex_vars) < 0 ) /* 3 */
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 3 */
         TEST_ERROR;
 
     if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_INT_TOK, "1", 1, 0.0, NULL, 0, true) )
         TEST_ERROR;
 
 
-    if ( H5CL__lex_read_token(false, &token_ptr, &lex_vars) < 0 ) /* 4 */
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 4 */
         TEST_ERROR;
     
     if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_FLOAT_TOK, "3.14159", 0, 3.14159, 
@@ -405,7 +490,7 @@ cl_lexer_smoke_check(void)
         TEST_ERROR;
     
 
-    if ( H5CL__lex_read_token(false, &token_ptr, &lex_vars) < 0 ) /* 5 */
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 5 */
         TEST_ERROR;
     
     if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_QSTRING_TOK, "Hello World", 0, 0.0, 
@@ -413,7 +498,7 @@ cl_lexer_smoke_check(void)
         TEST_ERROR;
     
 
-    if ( H5CL__lex_read_token(false, &token_ptr, &lex_vars) < 0 ) /* 6 */
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 6 */
         TEST_ERROR;
     
     if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_BIN_BLOB_TOK, "--00010203", 0, 0.0, 
@@ -421,7 +506,7 @@ cl_lexer_smoke_check(void)
         TEST_ERROR;
     
 
-    if ( H5CL__lex_read_token(true, &token_ptr, &lex_vars) < 0 ) /* 7 */
+    if ( H5CL__lex_read_token(true, false, &token_ptr, &lex_vars) < 0 ) /* 7 */
         TEST_ERROR;
     
     if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_LIST_TOK, "( sec2 () )", 0, 0.0, 
@@ -429,7 +514,7 @@ cl_lexer_smoke_check(void)
         TEST_ERROR;
     
 
-    if ( H5CL__lex_read_token(false, &token_ptr, &lex_vars) < 0 ) /* 8 */
+    if ( H5CL__lex_read_token(false, true, &token_ptr, &lex_vars) < 0 ) /* 8 */
         TEST_ERROR;
     
     if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_EOS_TOK, "", 0, 0.0, NULL, 0, true) )
@@ -462,6 +547,870 @@ error:
 
 /*******************************************************************************
  *
+ * cl_lexer_detail_check()
+ *
+ * Initial set of lexer tests designed to verify basic functionality.  Note that
+ * these tests do not trigger any error conditinos in the lexer.
+ *
+ *                                              JRM -- 12/16/25
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+static herr_t
+cl_lexer_detail_check(void)
+{
+    int token_num = 0;
+    const char * input_string = "(()())/* comment */)A1 1+1-1 2A2 1.1.1 +.2-.3\"i\"A/**/B\"\\\"\")"
+                                "--0--123 --aAb --AaB --0ff)(/* commenta can appear in lists)"
+                                "(ilegal characters, i.e.!@#$%^;:&*, can appear in lists)"
+                                "( and ()(((arbitrary))nesting of((parens))))";
+    uint8_t bb_0[] = { 0 };
+    uint8_t bb_1[] = { 18, 48 };
+    uint8_t bb_2[] = { 170, 176 };
+    uint8_t bb_3[] = { 15, 240 };
+    size_t bb_0_len = 1;
+    size_t bb_1_len = 2;
+    size_t bb_2_len = 2;
+    size_t bb_3_len = 2;
+    H5CL_token_t * token_ptr;
+    H5CL_lex_vars_t lex_vars = {
+        /* struct_tag        = */ H5CL_LEX_VARS_STRUCT_TAG,
+        /* input_str_ptr     = */ NULL,
+        /* next_char_ptr     = */ NULL,
+        /* end_of_input      = */ false, 
+        /* err_ctx           = */ "",
+        /* token             = */ {
+        /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
+        /* token.code        = */    H5CL_ERROR_TOK,
+        /* token.str_ptr     = */    NULL,
+        /* token.str_len     = */    0,
+        /* token.max_str_len = */    0,
+        /* token.int_val     = */    1,    /* should be overwritten on init */
+        /* token.f_val       = */    1.0,  /* should be overwritten on init */
+        /* token.bb_ptr      = */    NULL,
+        /* token.bb_len      = */    0
+        /* end of token        */ }
+    };
+
+    TESTING("VFD Configuration Language Lexer detail Check");
+
+    if ( H5CL__init_lex_vars(input_string, &lex_vars) < 0 ) {
+
+        TEST_ERROR;
+    }
+
+    if ( ( H5CL_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL == lex_vars.input_str_ptr ) ||
+         ( input_string == lex_vars.input_str_ptr ) ||
+         ( 0 != strcmp(input_string, lex_vars.input_str_ptr) ) ||
+         ( lex_vars.input_str_ptr != lex_vars.next_char_ptr ) || 
+         ( H5CL_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( H5CL_ERROR_TOK != lex_vars.token.code ) ||
+         ( NULL == lex_vars.token.str_ptr ) ||
+         ( 0 != lex_vars.token.str_len ) ||
+         ( strlen(input_string) != lex_vars.token.max_str_len ) ||
+         ( 0 != lex_vars.token.int_val ) ||
+         ( 0.0 < lex_vars.token.f_val ) ||    /* circumlocution to keep */
+         ( 0.0 > lex_vars.token.f_val ) ||    /* the compier happy      */
+         ( NULL == lex_vars.token.bb_ptr ) ||
+         ( 0 != lex_vars.token.bb_len ) ) {
+
+        TEST_ERROR;
+    }
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 0 */
+        TEST_ERROR;
+
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_L_PAREN_TOK, "(", 0, 0.0, NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 1 */
+        TEST_ERROR;
+
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_L_PAREN_TOK, "(", 0, 0.0, NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 2 */
+        TEST_ERROR;
+
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_R_PAREN_TOK, ")", 0, 0.0, NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 3 */
+        TEST_ERROR;
+
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_L_PAREN_TOK, "(", 0, 0.0, NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 4 */
+        TEST_ERROR;
+
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_R_PAREN_TOK, ")", 0, 0.0, NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 5 */
+        TEST_ERROR;
+
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_R_PAREN_TOK, ")", 0, 0.0, NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 6 */
+        TEST_ERROR;
+
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_R_PAREN_TOK, ")", 0, 0.0, NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 7 */
+        TEST_ERROR;
+
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_SYMBOL_TOK, "A1", 0, 0.0, 
+                                         NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 8 */
+        TEST_ERROR;
+
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_INT_TOK, "1", 1, 0.0, NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 9 */
+        TEST_ERROR;
+
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_INT_TOK, "+1", 1, 0.0, NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 10 */
+        TEST_ERROR;
+
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_INT_TOK, "-1", -1, 0.0, NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 11 */
+        TEST_ERROR;
+
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_INT_TOK, "2", 2, 0.0, NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 12 */
+        TEST_ERROR;
+
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_SYMBOL_TOK, "A2", 0, 0.0, 
+                                         NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 13 */
+        TEST_ERROR;
+    
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_FLOAT_TOK, "1.1", 0, 1.1, 
+                                         NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 14 */
+        TEST_ERROR;
+    
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_FLOAT_TOK, ".1", 0, .1, 
+                                         NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 15 */
+        TEST_ERROR;
+    
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_FLOAT_TOK, "+.2", 0, .2, 
+                                         NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 16 */
+        TEST_ERROR;
+    
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_FLOAT_TOK, "-.3", 0, -.3, 
+                                         NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 17 */
+        TEST_ERROR;
+    
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_QSTRING_TOK, "i", 0, 0.0, 
+                                         NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 18 */
+        TEST_ERROR;
+
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_SYMBOL_TOK, "A", 0, 0.0, 
+                                         NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 19 */
+        TEST_ERROR;
+
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_SYMBOL_TOK, "B", 0, 0.0, 
+                                         NULL, 0, true) )
+        TEST_ERROR;
+    
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 20 */
+        TEST_ERROR;
+    
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_QSTRING_TOK, "\\\"", 0, 0.0, 
+                                         NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 21 */
+        TEST_ERROR;
+
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_R_PAREN_TOK, ")", 0, 0.0, NULL, 0, true) )
+        TEST_ERROR;
+    
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 22 */
+        TEST_ERROR;
+    
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_BIN_BLOB_TOK, "--0", 0, 0.0, 
+                                          bb_0, bb_0_len, true) )
+        TEST_ERROR;
+    
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 23 */
+        TEST_ERROR;
+    
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_BIN_BLOB_TOK, "--123", 0, 0.0, 
+                                          bb_1, bb_1_len, true) )
+        TEST_ERROR;
+    
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 24 */
+        TEST_ERROR;
+    
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_BIN_BLOB_TOK, "--aAb", 0, 0.0, 
+                                          bb_2, bb_2_len, true) )
+        TEST_ERROR;
+    
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 25 */
+        TEST_ERROR;
+    
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_BIN_BLOB_TOK, "--AaB", 0, 0.0, 
+                                          bb_2, bb_2_len, true) )
+        TEST_ERROR;
+    
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 26 */
+        TEST_ERROR;
+    
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_BIN_BLOB_TOK, "--0ff", 0, 0.0, 
+                                          bb_3, bb_3_len, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) < 0 ) /* 27 */
+        TEST_ERROR;
+
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_R_PAREN_TOK, ")", 0, 0.0, NULL, 0, true) )
+        TEST_ERROR;
+    
+
+    if ( H5CL__lex_read_token(true, false, &token_ptr, &lex_vars) < 0 ) /* 28 */
+        TEST_ERROR;
+    
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_LIST_TOK, 
+                                         "(/* commenta can appear in lists)", 0, 0.0, NULL, 0, true) )
+        TEST_ERROR;
+    
+
+    if ( H5CL__lex_read_token(true, false, &token_ptr, &lex_vars) < 0 ) /* 29 */
+        TEST_ERROR;
+    
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_LIST_TOK, 
+                                         "(ilegal characters, i.e.!@#$%^;:&*, can appear in lists)", 0, 0.0, 
+                                         NULL, 0, true) )
+        TEST_ERROR;
+    
+
+    if ( H5CL__lex_read_token(true, false, &token_ptr, &lex_vars) < 0 ) /* 30 */
+        TEST_ERROR;
+    
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_LIST_TOK, 
+                                         "( and ()(((arbitrary))nesting of((parens))))", 0, 0.0, 
+                                         NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__lex_read_token(false, true, &token_ptr, &lex_vars) < 0 ) /* 31 */
+        TEST_ERROR;
+    
+    if ( 0 != cl_lexer_test_verify_token(token_ptr, token_num++, H5CL_EOS_TOK, "", 0, 0.0, NULL, 0, true) )
+        TEST_ERROR;
+
+
+    if ( H5CL__take_down_lex_vars(&lex_vars) < 0 )
+        TEST_ERROR;
+
+    if ( ( H5CL_INVALID_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL != lex_vars.input_str_ptr ) ||
+         ( H5CL_INVALID_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( NULL != lex_vars.token.str_ptr ) ||
+         ( NULL != lex_vars.token.bb_ptr ) ) {
+
+        TEST_ERROR;
+    }
+
+    PASSED();
+
+    return 0;
+
+error:
+
+    return -1;
+
+} /* cl_lexer_detail_check() */
+
+
+/*******************************************************************************
+ *
+ * cl_lexer_error_check_1()
+ *
+ * Verify that the lexer detects and reports errors as expected.
+ *
+ *                                              JRM -- 1/8/26
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+static herr_t
+cl_lexer_error_check_1(void)
+{
+    const char * input_string = "* /* a comment */&/*another comment */    _=% {}[]\"unterminated string";
+    bool verbose = true;
+    H5CL_token_t * token_ptr;
+    H5CL_lex_vars_t lex_vars = {
+        /* struct_tag        = */ H5CL_LEX_VARS_STRUCT_TAG,
+        /* input_str_ptr     = */ NULL,
+        /* next_char_ptr     = */ NULL,
+        /* end_of_input      = */ false, 
+        /* err_ctx           = */ "",
+        /* token             = */ {
+        /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
+        /* token.code        = */    H5CL_ERROR_TOK,
+        /* token.str_ptr     = */    NULL,
+        /* token.str_len     = */    0,
+        /* token.max_str_len = */    0,
+        /* token.int_val     = */    1,    /* should be overwritten on init */
+        /* token.f_val       = */    1.0,  /* should be overwritten on init */
+        /* token.bb_ptr      = */    NULL,
+        /* token.bb_len      = */    0
+        /* end of token        */ }
+    };
+
+    TESTING("VFD Configuration Language Lexer error detection & reporting 1");
+
+    if ( H5CL__init_lex_vars(input_string, &lex_vars) < 0 ) {
+
+        TEST_ERROR;
+    }
+
+    if ( ( H5CL_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL == lex_vars.input_str_ptr ) ||
+         ( input_string == lex_vars.input_str_ptr ) ||
+         ( 0 != strcmp(input_string, lex_vars.input_str_ptr) ) ||
+         ( lex_vars.input_str_ptr != lex_vars.next_char_ptr ) || 
+         ( H5CL_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( H5CL_ERROR_TOK != lex_vars.token.code ) ||
+         ( NULL == lex_vars.token.str_ptr ) ||
+         ( 0 != lex_vars.token.str_len ) ||
+         ( strlen(input_string) != lex_vars.token.max_str_len ) ||
+         ( 0 != lex_vars.token.int_val ) ||
+         ( 0.0 < lex_vars.token.f_val ) ||    /* circumlocution to keep */
+         ( 0.0 > lex_vars.token.f_val ) ||    /* the compier happy      */
+         ( NULL == lex_vars.token.bb_ptr ) ||
+         ( 0 != lex_vars.token.bb_len ) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on illegal char '*' */
+    if  ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                               "Illagal char '*' in input string.  Context: * /* a comment */&/*another co...", 
+                               verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on illegal char '&' */
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                               "Illagal char '&' in input string.  Context: ...* a comment */&/*another comme...",
+                                verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on illegal char '_' */
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                                "Illagal char '_' in input string.  Context: ...comment */    _=% {}[]\"untermi...",
+                                verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on illegal char '=' */
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                                "Illagal char '=' in input string.  Context: ...omment */    _=% {}[]\"untermin...",
+                                verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on illegal char '%' */
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                                "Percent sign in input string.  Context: ...mment */    _=% {}[]\"untermina...",
+                                verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on illegal char '{' */
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                                "Illagal char '{' in input string.  Context: ...ent */    _=% {}[]\"unterminate...",
+                                verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on illegal char '}' */
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                                "Illagal char '}' in input string.  Context: ...nt */    _=% {}[]\"unterminated...",
+                                verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on illegal char '[' */
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                                "Illagal char '[' in input string.  Context: ...t */    _=% {}[]\"unterminated ...",
+                                verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on illegal char ']' */
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                                "Illagal char ']' in input string.  Context: ... */    _=% {}[]\"unterminated s...",
+                                verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on an unterminated string' */
+    if ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                                "Un-terminate quote string in input string.  Context: ...rminated string",
+                                verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    PASSED();
+
+    return 0;
+
+error:
+
+    return -1;
+
+} /* cl_lexer_error_check_1() */
+
+
+/*******************************************************************************
+ *
+ * cl_lexer_error_check_2()
+ *
+ * Verify that the lexer detects and reports errors as expected.
+ *
+ *                                              JRM -- 1/8/26
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+static herr_t
+cl_lexer_error_check_2(void)
+{
+    const char * input_string = "/* malformed numeric values */ + - . +. -. (an unterminated list";
+    bool verbose = true;
+    H5CL_token_t * token_ptr;
+    H5CL_lex_vars_t lex_vars = {
+        /* struct_tag        = */ H5CL_LEX_VARS_STRUCT_TAG,
+        /* input_str_ptr     = */ NULL,
+        /* next_char_ptr     = */ NULL,
+        /* end_of_input      = */ false, 
+        /* err_ctx           = */ "",
+        /* token             = */ {
+        /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
+        /* token.code        = */    H5CL_ERROR_TOK,
+        /* token.str_ptr     = */    NULL,
+        /* token.str_len     = */    0,
+        /* token.max_str_len = */    0,
+        /* token.int_val     = */    1,    /* should be overwritten on init */
+        /* token.f_val       = */    1.0,  /* should be overwritten on init */
+        /* token.bb_ptr      = */    NULL,
+        /* token.bb_len      = */    0
+        /* end of token        */ }
+    };
+
+    TESTING("VFD Configuration Language Lexer error detection & reporting 2");
+
+    if ( H5CL__init_lex_vars(input_string, &lex_vars) < 0 ) {
+
+        TEST_ERROR;
+    }
+
+    if ( ( H5CL_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL == lex_vars.input_str_ptr ) ||
+         ( input_string == lex_vars.input_str_ptr ) ||
+         ( 0 != strcmp(input_string, lex_vars.input_str_ptr) ) ||
+         ( lex_vars.input_str_ptr != lex_vars.next_char_ptr ) || 
+         ( H5CL_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( H5CL_ERROR_TOK != lex_vars.token.code ) ||
+         ( NULL == lex_vars.token.str_ptr ) ||
+         ( 0 != lex_vars.token.str_len ) ||
+         ( strlen(input_string) != lex_vars.token.max_str_len ) ||
+         ( 0 != lex_vars.token.int_val ) ||
+         ( 0.0 < lex_vars.token.f_val ) ||    /* circumlocution to keep */
+         ( 0.0 > lex_vars.token.f_val ) ||    /* the compier happy      */
+         ( NULL == lex_vars.token.bb_ptr ) ||
+         ( 0 != lex_vars.token.bb_len ) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on an ill formed numeric constantt */
+    if  ( H5CL__lex_read_token(true, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                               "Ill-formed numerical constant.  Context: ...eric values */ + - . +. -. (an...",
+                               verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on an ill formed numeric constantt */
+    if  ( H5CL__lex_read_token(true, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                               "Ill-formed numerical constant.  Context: ...ic values */ + - . +. -. (an u...",
+                               verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on an ill formed numeric constantt */
+    if  ( H5CL__lex_read_token(true, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                               "Ill-formed numerical constant.  Context: ... values */ + - . +. -. (an unt...",
+                               verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on an ill formed numeric constantt */
+    if  ( H5CL__lex_read_token(true, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                               "Ill-formed numerical constant.  Context: ...alues */ + - . +. -. (an unter...",
+                               verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on an ill formed numeric constantt */
+    if  ( H5CL__lex_read_token(true, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                               "Ill-formed numerical constant.  Context: ...es */ + - . +. -. (an untermin...",
+                               verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on na unterminate list */
+    if  ( H5CL__lex_read_token(true, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                               "Un-terminated list in input string.  Context: ...terminated list",
+                               verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    PASSED();
+
+    return 0;
+
+error:
+
+    return -1;
+
+} /* cl_lexer_error_check_2() */
+
+
+/*******************************************************************************
+ *
+ * cl_lexer_error_check_3()
+ *
+ * Verify that the lexer detects and reports errors as expected.
+ *
+ *                                              JRM -- 1/8/26
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+static herr_t
+cl_lexer_error_check_3(void)
+{
+    const char * input_string = " /* an empty input string to generate an unexpected EOI error */";
+    bool verbose = true;
+    H5CL_token_t * token_ptr;
+    H5CL_lex_vars_t lex_vars = {
+        /* struct_tag        = */ H5CL_LEX_VARS_STRUCT_TAG,
+        /* input_str_ptr     = */ NULL,
+        /* next_char_ptr     = */ NULL,
+        /* end_of_input      = */ false, 
+        /* err_ctx           = */ "",
+        /* token             = */ {
+        /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
+        /* token.code        = */    H5CL_ERROR_TOK,
+        /* token.str_ptr     = */    NULL,
+        /* token.str_len     = */    0,
+        /* token.max_str_len = */    0,
+        /* token.int_val     = */    1,    /* should be overwritten on init */
+        /* token.f_val       = */    1.0,  /* should be overwritten on init */
+        /* token.bb_ptr      = */    NULL,
+        /* token.bb_len      = */    0
+        /* end of token        */ }
+    };
+
+    TESTING("VFD Configuration Language Lexer error detection & reporting 3");
+
+    if ( H5CL__init_lex_vars(input_string, &lex_vars) < 0 ) {
+
+        TEST_ERROR;
+    }
+
+    if ( ( H5CL_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL == lex_vars.input_str_ptr ) ||
+         ( input_string == lex_vars.input_str_ptr ) ||
+         ( 0 != strcmp(input_string, lex_vars.input_str_ptr) ) ||
+         ( lex_vars.input_str_ptr != lex_vars.next_char_ptr ) || 
+         ( H5CL_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( H5CL_ERROR_TOK != lex_vars.token.code ) ||
+         ( NULL == lex_vars.token.str_ptr ) ||
+         ( 0 != lex_vars.token.str_len ) ||
+         ( strlen(input_string) != lex_vars.token.max_str_len ) ||
+         ( 0 != lex_vars.token.int_val ) ||
+         ( 0.0 < lex_vars.token.f_val ) ||    /* circumlocution to keep */
+         ( 0.0 > lex_vars.token.f_val ) ||    /* the compier happy      */
+         ( NULL == lex_vars.token.bb_ptr ) ||
+         ( 0 != lex_vars.token.bb_len ) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on an un enxpected end of input string error */
+    if  ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                               "Un-expected end of input string.  Context: ...ed EOI error */",
+                               verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    PASSED();
+
+    return 0;
+
+error:
+
+    return -1;
+
+} /* cl_lexer_error_check_3() */
+
+
+/*******************************************************************************
+ *
+ * cl_lexer_error_check_4()
+ *
+ * Verify that the lexer detects and reports errors as expected.
+ *
+ *                                              JRM -- 1/8/26
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+static herr_t
+cl_lexer_error_check_4(void)
+{
+    const char * input_string = " /* end of input in a comment ";
+    bool verbose = true;
+    H5CL_token_t * token_ptr;
+    H5CL_lex_vars_t lex_vars = {
+        /* struct_tag        = */ H5CL_LEX_VARS_STRUCT_TAG,
+        /* input_str_ptr     = */ NULL,
+        /* next_char_ptr     = */ NULL,
+        /* end_of_input      = */ false, 
+        /* err_ctx           = */ "",
+        /* token             = */ {
+        /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
+        /* token.code        = */    H5CL_ERROR_TOK,
+        /* token.str_ptr     = */    NULL,
+        /* token.str_len     = */    0,
+        /* token.max_str_len = */    0,
+        /* token.int_val     = */    1,    /* should be overwritten on init */
+        /* token.f_val       = */    1.0,  /* should be overwritten on init */
+        /* token.bb_ptr      = */    NULL,
+        /* token.bb_len      = */    0
+        /* end of token        */ }
+    };
+
+    TESTING("VFD Configuration Language Lexer error detection & reporting 4");
+
+    if ( H5CL__init_lex_vars(input_string, &lex_vars) < 0 ) {
+
+        TEST_ERROR;
+    }
+
+    if ( ( H5CL_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL == lex_vars.input_str_ptr ) ||
+         ( input_string == lex_vars.input_str_ptr ) ||
+         ( 0 != strcmp(input_string, lex_vars.input_str_ptr) ) ||
+         ( lex_vars.input_str_ptr != lex_vars.next_char_ptr ) || 
+         ( H5CL_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( H5CL_ERROR_TOK != lex_vars.token.code ) ||
+         ( NULL == lex_vars.token.str_ptr ) ||
+         ( 0 != lex_vars.token.str_len ) ||
+         ( strlen(input_string) != lex_vars.token.max_str_len ) ||
+         ( 0 != lex_vars.token.int_val ) ||
+         ( 0.0 < lex_vars.token.f_val ) ||    /* circumlocution to keep */
+         ( 0.0 > lex_vars.token.f_val ) ||    /* the compier happy      */
+         ( NULL == lex_vars.token.bb_ptr ) ||
+         ( 0 != lex_vars.token.bb_len ) ) {
+
+        TEST_ERROR;
+    }
+
+    /* should fail on an un enxpected end of input string error */
+    if  ( H5CL__lex_read_token(false, false, &token_ptr, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                               "Un-expected end of input string.  Context: ...t in a comment ",
+                               verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    PASSED();
+
+    return 0;
+
+error:
+
+    return -1;
+
+} /* cl_lexer_error_check_4() */
+
+
+/*******************************************************************************
+ *
  * cl_parse_name_val_pair_smoke_check()
  *
  * Initial set of parse tests designed to verify basic functionality of the 
@@ -490,8 +1439,7 @@ cl_parse_name_val_pair_smoke_check(void)
         /* input_str_ptr     = */ NULL,
         /* next_char_ptr     = */ NULL,
         /* end_of_input      = */ false, 
-        /* line_num          = */ 0,
-        /* char_num          = */ 0, 
+        /* err_ctx           = */ "",
         /* token             = */ {
         /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
         /* token.code        = */    H5CL_ERROR_TOK,
@@ -535,7 +1483,7 @@ cl_parse_name_val_pair_smoke_check(void)
 
         nv_pairs[nv_pair_num].struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
 
-        if ( H5CL__init_nv_pair(&(nv_pairs[nv_pair_num])) < 0 )
+        if ( H5CL_init_nv_pair(&(nv_pairs[nv_pair_num])) < 0 )
             TEST_ERROR;
     }
 
@@ -578,7 +1526,7 @@ cl_parse_name_val_pair_smoke_check(void)
     /* take down the array of instance of cl_nv_pair_t */
     for ( nv_pair_num = 0; nv_pair_num < 5; nv_pair_num++ ) {
 
-        if ( H5CL__take_down_nv_pair(&(nv_pairs[nv_pair_num])) < 0 ) 
+        if ( H5CL_take_down_nv_pair(&(nv_pairs[nv_pair_num])) < 0 ) 
             TEST_ERROR;
     }
 
@@ -605,6 +1553,662 @@ error:
     return -1;
 
 } /* cl_parse_name_val_pair_smoke_check() */
+
+/*******************************************************************************
+ *
+ * cl_parse_nv_pair_error_check_1()
+ *
+ * Verify that the name value pair parser function detects and reports errors 
+ * as expected.
+ *
+ *                                              JRM -- 1/8/26
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+static herr_t
+cl_parse_nv_pair_error_check_1(void)
+{
+    const char * input_string = "name 1 ) /* NV pair missing the opening paren */";
+    bool verbose = true;
+    H5CL_lex_vars_t lex_vars = {
+        /* struct_tag        = */ H5CL_LEX_VARS_STRUCT_TAG,
+        /* input_str_ptr     = */ NULL,
+        /* next_char_ptr     = */ NULL,
+        /* end_of_input      = */ false, 
+        /* err_ctx           = */ "",
+        /* token             = */ {
+        /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
+        /* token.code        = */    H5CL_ERROR_TOK,
+        /* token.str_ptr     = */    NULL,
+        /* token.str_len     = */    0,
+        /* token.max_str_len = */    0,
+        /* token.int_val     = */    1,    /* should be overwritten on init */
+        /* token.f_val       = */    1.0,  /* should be overwritten on init */
+        /* token.bb_ptr      = */    NULL,
+        /* token.bb_len      = */    0
+        /* end of token        */ }
+    };
+    H5CL_nv_pair_t nv_pair;
+
+    TESTING("VFD Configuration Language NV pair err detection & reporting 1");
+
+    if ( H5CL__init_lex_vars(input_string, &lex_vars) < 0 ) {
+
+        TEST_ERROR;
+    }
+
+    if ( ( H5CL_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL == lex_vars.input_str_ptr ) ||
+         ( input_string == lex_vars.input_str_ptr ) ||
+         ( 0 != strcmp(input_string, lex_vars.input_str_ptr) ) ||
+         ( lex_vars.input_str_ptr != lex_vars.next_char_ptr ) || 
+         ( H5CL_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( H5CL_ERROR_TOK != lex_vars.token.code ) ||
+         ( NULL == lex_vars.token.str_ptr ) ||
+         ( 0 != lex_vars.token.str_len ) ||
+         ( strlen(input_string) != lex_vars.token.max_str_len ) ||
+         ( 0 != lex_vars.token.int_val ) ||
+         ( 0.0 < lex_vars.token.f_val ) ||    /* circumlocution to keep */
+         ( 0.0 > lex_vars.token.f_val ) ||    /* the compier happy      */
+         ( NULL == lex_vars.token.bb_ptr ) ||
+         ( 0 != lex_vars.token.bb_len ) ) {
+
+        TEST_ERROR;
+    }
+
+    nv_pair.struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
+
+    if ( H5CL_init_nv_pair(&nv_pair) < 0 )
+        TEST_ERROR;
+
+    /* should fail on a missing initial paren */
+    if ( H5CL__parse_name_value_pair(&nv_pair, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+            "Syntax error -- Initial '(' of name value pair expected.  Context: name 1 ) /* NV pair missing th...",
+            verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    PASSED();
+
+    return 0;
+
+error:
+
+    return -1;
+
+} /* cl_parse_nv_pair_error_check_1() */
+
+/*******************************************************************************
+ *
+ * cl_parse_nv_pair_error_check_2()
+ *
+ * Verify that the name value pair parser function detects and reports errors 
+ * as expected.
+ *
+ *                                              JRM -- 1/8/26
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+static herr_t
+cl_parse_nv_pair_error_check_2(void)
+{
+    const char * input_string = "( /* NV pair missing the name */ 1 --01020304 )";
+    bool verbose = true;
+    H5CL_lex_vars_t lex_vars = {
+        /* struct_tag        = */ H5CL_LEX_VARS_STRUCT_TAG,
+        /* input_str_ptr     = */ NULL,
+        /* next_char_ptr     = */ NULL,
+        /* end_of_input      = */ false, 
+        /* err_ctx           = */ "",
+        /* token             = */ {
+        /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
+        /* token.code        = */    H5CL_ERROR_TOK,
+        /* token.str_ptr     = */    NULL,
+        /* token.str_len     = */    0,
+        /* token.max_str_len = */    0,
+        /* token.int_val     = */    1,    /* should be overwritten on init */
+        /* token.f_val       = */    1.0,  /* should be overwritten on init */
+        /* token.bb_ptr      = */    NULL,
+        /* token.bb_len      = */    0
+        /* end of token        */ }
+    };
+    H5CL_nv_pair_t nv_pair;
+
+    TESTING("VFD Configuration Language NV pair err detection & reporting 2");
+
+    if ( H5CL__init_lex_vars(input_string, &lex_vars) < 0 ) {
+
+        TEST_ERROR;
+    }
+
+    if ( ( H5CL_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL == lex_vars.input_str_ptr ) ||
+         ( input_string == lex_vars.input_str_ptr ) ||
+         ( 0 != strcmp(input_string, lex_vars.input_str_ptr) ) ||
+         ( lex_vars.input_str_ptr != lex_vars.next_char_ptr ) || 
+         ( H5CL_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( H5CL_ERROR_TOK != lex_vars.token.code ) ||
+         ( NULL == lex_vars.token.str_ptr ) ||
+         ( 0 != lex_vars.token.str_len ) ||
+         ( strlen(input_string) != lex_vars.token.max_str_len ) ||
+         ( 0 != lex_vars.token.int_val ) ||
+         ( 0.0 < lex_vars.token.f_val ) ||    /* circumlocution to keep */
+         ( 0.0 > lex_vars.token.f_val ) ||    /* the compier happy      */
+         ( NULL == lex_vars.token.bb_ptr ) ||
+         ( 0 != lex_vars.token.bb_len ) ) {
+
+        TEST_ERROR;
+    }
+
+    nv_pair.struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
+
+    if ( H5CL_init_nv_pair(&nv_pair) < 0 )
+        TEST_ERROR;
+
+    /* should fail on a missing name in the name value pair */
+    if ( H5CL__parse_name_value_pair(&nv_pair, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                    "Syntax error -- name of name value pair expected.  Context: ...g the name */ 1 --01020304 )",
+                    verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    PASSED();
+
+    return 0;
+
+error:
+
+    return -1;
+
+} /* cl_parse_nv_pair_error_check_2() */
+
+
+/*******************************************************************************
+ *
+ * cl_parse_nv_pair_error_check_3()
+ *
+ * Verify that the name value pair parser function detects and reports errors 
+ * as expected.
+ *
+ *                                              JRM -- 1/8/26
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+static herr_t
+cl_parse_nv_pair_error_check_3(void)
+{
+    const char * input_string = "( name /* NV pair missing the value */ )";
+    bool verbose = true;
+    H5CL_lex_vars_t lex_vars = {
+        /* struct_tag        = */ H5CL_LEX_VARS_STRUCT_TAG,
+        /* input_str_ptr     = */ NULL,
+        /* next_char_ptr     = */ NULL,
+        /* end_of_input      = */ false, 
+        /* err_ctx           = */ "",
+        /* token             = */ {
+        /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
+        /* token.code        = */    H5CL_ERROR_TOK,
+        /* token.str_ptr     = */    NULL,
+        /* token.str_len     = */    0,
+        /* token.max_str_len = */    0,
+        /* token.int_val     = */    1,    /* should be overwritten on init */
+        /* token.f_val       = */    1.0,  /* should be overwritten on init */
+        /* token.bb_ptr      = */    NULL,
+        /* token.bb_len      = */    0
+        /* end of token        */ }
+    };
+    H5CL_nv_pair_t nv_pair;
+
+    TESTING("VFD Configuration Language NV pair err detection & reporting 3");
+
+    if ( H5CL__init_lex_vars(input_string, &lex_vars) < 0 ) {
+
+        TEST_ERROR;
+    }
+
+    if ( ( H5CL_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL == lex_vars.input_str_ptr ) ||
+         ( input_string == lex_vars.input_str_ptr ) ||
+         ( 0 != strcmp(input_string, lex_vars.input_str_ptr) ) ||
+         ( lex_vars.input_str_ptr != lex_vars.next_char_ptr ) || 
+         ( H5CL_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( H5CL_ERROR_TOK != lex_vars.token.code ) ||
+         ( NULL == lex_vars.token.str_ptr ) ||
+         ( 0 != lex_vars.token.str_len ) ||
+         ( strlen(input_string) != lex_vars.token.max_str_len ) ||
+         ( 0 != lex_vars.token.int_val ) ||
+         ( 0.0 < lex_vars.token.f_val ) ||    /* circumlocution to keep */
+         ( 0.0 > lex_vars.token.f_val ) ||    /* the compier happy      */
+         ( NULL == lex_vars.token.bb_ptr ) ||
+         ( 0 != lex_vars.token.bb_len ) ) {
+
+        TEST_ERROR;
+    }
+
+    nv_pair.struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
+
+    if ( H5CL_init_nv_pair(&nv_pair) < 0 )
+        TEST_ERROR;
+
+    /* should fail on a missing value in the name value pair */
+    if ( H5CL__parse_name_value_pair(&nv_pair, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                                "Syntax error -- value of name value pair expected.  Context: ... the value */ )",
+                                verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    PASSED();
+
+    return 0;
+
+error:
+
+    return -1;
+
+} /* cl_parse_nv_pair_error_check_3() */
+
+
+/*******************************************************************************
+ *
+ * cl_parse_nv_pair_error_check_4()
+ *
+ * Verify that the name value pair parser function detects and reports errors 
+ * as expected.
+ *
+ *                                              JRM -- 1/8/26
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+static herr_t
+cl_parse_nv_pair_error_check_4(void)
+{
+    const char * input_string = "( name 1.1 /* NV pair with extra value */ --01020304 )";
+    bool verbose = true;
+    H5CL_lex_vars_t lex_vars = {
+        /* struct_tag        = */ H5CL_LEX_VARS_STRUCT_TAG,
+        /* input_str_ptr     = */ NULL,
+        /* next_char_ptr     = */ NULL,
+        /* end_of_input      = */ false, 
+        /* err_ctx           = */ "",
+        /* token             = */ {
+        /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
+        /* token.code        = */    H5CL_ERROR_TOK,
+        /* token.str_ptr     = */    NULL,
+        /* token.str_len     = */    0,
+        /* token.max_str_len = */    0,
+        /* token.int_val     = */    1,    /* should be overwritten on init */
+        /* token.f_val       = */    1.0,  /* should be overwritten on init */
+        /* token.bb_ptr      = */    NULL,
+        /* token.bb_len      = */    0
+        /* end of token        */ }
+    };
+    H5CL_nv_pair_t nv_pair;
+
+    TESTING("VFD Configuration Language NV pair err detection & reporting 4");
+
+    if ( H5CL__init_lex_vars(input_string, &lex_vars) < 0 ) {
+
+        TEST_ERROR;
+    }
+
+    if ( ( H5CL_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL == lex_vars.input_str_ptr ) ||
+         ( input_string == lex_vars.input_str_ptr ) ||
+         ( 0 != strcmp(input_string, lex_vars.input_str_ptr) ) ||
+         ( lex_vars.input_str_ptr != lex_vars.next_char_ptr ) || 
+         ( H5CL_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( H5CL_ERROR_TOK != lex_vars.token.code ) ||
+         ( NULL == lex_vars.token.str_ptr ) ||
+         ( 0 != lex_vars.token.str_len ) ||
+         ( strlen(input_string) != lex_vars.token.max_str_len ) ||
+         ( 0 != lex_vars.token.int_val ) ||
+         ( 0.0 < lex_vars.token.f_val ) ||    /* circumlocution to keep */
+         ( 0.0 > lex_vars.token.f_val ) ||    /* the compier happy      */
+         ( NULL == lex_vars.token.bb_ptr ) ||
+         ( 0 != lex_vars.token.bb_len ) ) {
+
+        TEST_ERROR;
+    }
+
+    nv_pair.struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
+
+    if ( H5CL_init_nv_pair(&nv_pair) < 0 )
+        TEST_ERROR;
+
+    /* should fail on an extra value / missting closing paren in the name value pair */
+    if ( H5CL__parse_name_value_pair(&nv_pair, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                    "Syntax error -- Terminal ')' of name value pair expected.  Context: ...e */ --01020304 )",
+                    verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    PASSED();
+
+    return 0;
+
+error:
+
+    return -1;
+
+} /* cl_parse_nv_pair_error_check_4() */
+
+
+/*******************************************************************************
+ *
+ * cl_parse_nv_pair_error_check_5()
+ *
+ * Verify that the name value pair parser function detects and reports errors 
+ * as expected.
+ *
+ *                                              JRM -- 1/8/26
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+static herr_t
+cl_parse_nv_pair_error_check_5(void)
+{
+    const char * input_string = "( name \" unterminated quote string ";
+    bool verbose = true;
+    H5CL_lex_vars_t lex_vars = {
+        /* struct_tag        = */ H5CL_LEX_VARS_STRUCT_TAG,
+        /* input_str_ptr     = */ NULL,
+        /* next_char_ptr     = */ NULL,
+        /* end_of_input      = */ false, 
+        /* err_ctx           = */ "",
+        /* token             = */ {
+        /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
+        /* token.code        = */    H5CL_ERROR_TOK,
+        /* token.str_ptr     = */    NULL,
+        /* token.str_len     = */    0,
+        /* token.max_str_len = */    0,
+        /* token.int_val     = */    1,    /* should be overwritten on init */
+        /* token.f_val       = */    1.0,  /* should be overwritten on init */
+        /* token.bb_ptr      = */    NULL,
+        /* token.bb_len      = */    0
+        /* end of token        */ }
+    };
+    H5CL_nv_pair_t nv_pair;
+
+    TESTING("VFD Configuration Language NV pair err detection & reporting 5");
+
+    if ( H5CL__init_lex_vars(input_string, &lex_vars) < 0 ) {
+
+        TEST_ERROR;
+    }
+
+    if ( ( H5CL_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL == lex_vars.input_str_ptr ) ||
+         ( input_string == lex_vars.input_str_ptr ) ||
+         ( 0 != strcmp(input_string, lex_vars.input_str_ptr) ) ||
+         ( lex_vars.input_str_ptr != lex_vars.next_char_ptr ) || 
+         ( H5CL_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( H5CL_ERROR_TOK != lex_vars.token.code ) ||
+         ( NULL == lex_vars.token.str_ptr ) ||
+         ( 0 != lex_vars.token.str_len ) ||
+         ( strlen(input_string) != lex_vars.token.max_str_len ) ||
+         ( 0 != lex_vars.token.int_val ) ||
+         ( 0.0 < lex_vars.token.f_val ) ||    /* circumlocution to keep */
+         ( 0.0 > lex_vars.token.f_val ) ||    /* the compier happy      */
+         ( NULL == lex_vars.token.bb_ptr ) ||
+         ( 0 != lex_vars.token.bb_len ) ) {
+
+        TEST_ERROR;
+    }
+
+    nv_pair.struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
+
+    if ( H5CL_init_nv_pair(&nv_pair) < 0 )
+        TEST_ERROR;
+
+    /* should fail on an unterminated quote string */
+    if ( H5CL__parse_name_value_pair(&nv_pair, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                                        "Un-terminate quote string in input string.  Context: ...d quote string ",
+                                        verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    PASSED();
+
+    return 0;
+
+error:
+
+    return -1;
+
+} /* cl_parse_nv_pair_error_check_5() */
+
+
+/*******************************************************************************
+ *
+ * cl_parse_nv_pair_error_check_6()
+ *
+ * Verify that the name value pair parser function detects and reports errors 
+ * as expected.
+ *
+ *                                              JRM -- 1/8/26
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+static herr_t
+cl_parse_nv_pair_error_check_6(void)
+{
+    const char * input_string = "( name ( unterminated list ";
+    bool verbose = true;
+    H5CL_lex_vars_t lex_vars = {
+        /* struct_tag        = */ H5CL_LEX_VARS_STRUCT_TAG,
+        /* input_str_ptr     = */ NULL,
+        /* next_char_ptr     = */ NULL,
+        /* end_of_input      = */ false, 
+        /* err_ctx           = */ "",
+        /* token             = */ {
+        /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
+        /* token.code        = */    H5CL_ERROR_TOK,
+        /* token.str_ptr     = */    NULL,
+        /* token.str_len     = */    0,
+        /* token.max_str_len = */    0,
+        /* token.int_val     = */    1,    /* should be overwritten on init */
+        /* token.f_val       = */    1.0,  /* should be overwritten on init */
+        /* token.bb_ptr      = */    NULL,
+        /* token.bb_len      = */    0
+        /* end of token        */ }
+    };
+    H5CL_nv_pair_t nv_pair;
+
+    TESTING("VFD Configuration Language NV pair err detection & reporting 6");
+
+    if ( H5CL__init_lex_vars(input_string, &lex_vars) < 0 ) {
+
+        TEST_ERROR;
+    }
+
+    if ( ( H5CL_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL == lex_vars.input_str_ptr ) ||
+         ( input_string == lex_vars.input_str_ptr ) ||
+         ( 0 != strcmp(input_string, lex_vars.input_str_ptr) ) ||
+         ( lex_vars.input_str_ptr != lex_vars.next_char_ptr ) || 
+         ( H5CL_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( H5CL_ERROR_TOK != lex_vars.token.code ) ||
+         ( NULL == lex_vars.token.str_ptr ) ||
+         ( 0 != lex_vars.token.str_len ) ||
+         ( strlen(input_string) != lex_vars.token.max_str_len ) ||
+         ( 0 != lex_vars.token.int_val ) ||
+         ( 0.0 < lex_vars.token.f_val ) ||    /* circumlocution to keep */
+         ( 0.0 > lex_vars.token.f_val ) ||    /* the compier happy      */
+         ( NULL == lex_vars.token.bb_ptr ) ||
+         ( 0 != lex_vars.token.bb_len ) ) {
+
+        TEST_ERROR;
+    }
+
+    nv_pair.struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
+
+    if ( H5CL_init_nv_pair(&nv_pair) < 0 )
+        TEST_ERROR;
+
+    /* should fail on an unterminated list */
+    if ( H5CL__parse_name_value_pair(&nv_pair, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                                        "Un-terminated list in input string.  Context: ...erminated list ",
+                                        verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    PASSED();
+
+    return 0;
+
+error:
+
+    return -1;
+
+} /* cl_parse_nv_pair_error_check_6() */
+
+
+/*******************************************************************************
+ *
+ * cl_parse_nv_pair_error_check_7()
+ *
+ * Verify that the name value pair parser function detects and reports errors 
+ * as expected.
+ *
+ *                                              JRM -- 1/8/26
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+static herr_t
+cl_parse_nv_pair_error_check_7(void)
+{
+    const char * input_string = "( name 3.14159 /* unexpected EOI */ ";
+    bool verbose = true;
+    H5CL_lex_vars_t lex_vars = {
+        /* struct_tag        = */ H5CL_LEX_VARS_STRUCT_TAG,
+        /* input_str_ptr     = */ NULL,
+        /* next_char_ptr     = */ NULL,
+        /* end_of_input      = */ false, 
+        /* err_ctx           = */ "",
+        /* token             = */ {
+        /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
+        /* token.code        = */    H5CL_ERROR_TOK,
+        /* token.str_ptr     = */    NULL,
+        /* token.str_len     = */    0,
+        /* token.max_str_len = */    0,
+        /* token.int_val     = */    1,    /* should be overwritten on init */
+        /* token.f_val       = */    1.0,  /* should be overwritten on init */
+        /* token.bb_ptr      = */    NULL,
+        /* token.bb_len      = */    0
+        /* end of token        */ }
+    };
+    H5CL_nv_pair_t nv_pair;
+
+    TESTING("VFD Configuration Language NV pair err detection & reporting 7");
+
+    if ( H5CL__init_lex_vars(input_string, &lex_vars) < 0 ) {
+
+        TEST_ERROR;
+    }
+
+    if ( ( H5CL_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL == lex_vars.input_str_ptr ) ||
+         ( input_string == lex_vars.input_str_ptr ) ||
+         ( 0 != strcmp(input_string, lex_vars.input_str_ptr) ) ||
+         ( lex_vars.input_str_ptr != lex_vars.next_char_ptr ) || 
+         ( H5CL_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( H5CL_ERROR_TOK != lex_vars.token.code ) ||
+         ( NULL == lex_vars.token.str_ptr ) ||
+         ( 0 != lex_vars.token.str_len ) ||
+         ( strlen(input_string) != lex_vars.token.max_str_len ) ||
+         ( 0 != lex_vars.token.int_val ) ||
+         ( 0.0 < lex_vars.token.f_val ) ||    /* circumlocution to keep */
+         ( 0.0 > lex_vars.token.f_val ) ||    /* the compier happy      */
+         ( NULL == lex_vars.token.bb_ptr ) ||
+         ( 0 != lex_vars.token.bb_len ) ) {
+
+        TEST_ERROR;
+    }
+
+    nv_pair.struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
+
+    if ( H5CL_init_nv_pair(&nv_pair) < 0 )
+        TEST_ERROR;
+
+    /* should fail on an unterminated list */
+    if ( H5CL__parse_name_value_pair(&nv_pair, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                                        "Un-expected end of input string.  Context: ...xpected EOI */ ",
+                                        verbose) ) {
+
+        TEST_ERROR;
+    }
+
+    PASSED();
+
+    return 0;
+
+error:
+
+    return -1;
+
+} /* cl_parse_nv_pair_error_check_7() */
 
 
 /*******************************************************************************
@@ -692,8 +2296,7 @@ cl_parse_name_val_pair_list_smoke_check(void)
         /* input_str_ptr     = */ NULL,
         /* next_char_ptr     = */ NULL,
         /* end_of_input      = */ false, 
-        /* line_num          = */ 0,
-        /* char_num          = */ 0, 
+        /* err_ctx           = */ "",
         /* token             = */ {
         /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
         /* token.code        = */    H5CL_ERROR_TOK,
@@ -737,7 +2340,7 @@ cl_parse_name_val_pair_list_smoke_check(void)
 
         actual_nv_pairs[nv_pair_num].struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
 
-        if ( H5CL__init_nv_pair(&(actual_nv_pairs[nv_pair_num])) < 0 )
+        if ( H5CL_init_nv_pair(&(actual_nv_pairs[nv_pair_num])) < 0 )
             TEST_ERROR;
     }
 
@@ -755,7 +2358,7 @@ cl_parse_name_val_pair_list_smoke_check(void)
 
     for ( nv_pair_num = 0; nv_pair_num < 5; nv_pair_num++ ) {
 
-        if ( H5CL__take_down_nv_pair(&(actual_nv_pairs[nv_pair_num])) < 0 )
+        if ( H5CL_take_down_nv_pair(&(actual_nv_pairs[nv_pair_num])) < 0 )
             TEST_ERROR;
     }
 
@@ -781,6 +2384,344 @@ error:
     return -1;
 
 } /* cl_parse_name_val_pair_list_smoke_check() */
+
+
+/*******************************************************************************
+ *
+ * cl_parse_name_val_pair_list_err_check_1()
+ *
+ * Name value pair errer detection and reporting test.
+ *
+ *                                              JRM -- 12/20/25
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+static herr_t
+cl_parse_name_val_pair_list_err_check_1(void)
+{
+    bool verbose = true;
+    int nv_pair_num = 0;
+    const char * input_string = " ( name_0 1 ) ( name_1 3.14159 ) ( name_2 \"Hello World\" ) "
+                                "( name_3 --10111213 ) ( name_4 ( sec2 () ) ) )";
+    H5CL_nv_pair_t actual_nv_pairs[5];
+    H5CL_lex_vars_t lex_vars = {
+        /* struct_tag        = */ H5CL_LEX_VARS_STRUCT_TAG,
+        /* input_str_ptr     = */ NULL,
+        /* next_char_ptr     = */ NULL,
+        /* end_of_input      = */ false, 
+        /* err_ctx           = */ "",
+        /* token             = */ {
+        /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
+        /* token.code        = */    H5CL_ERROR_TOK,
+        /* token.str_ptr     = */    NULL,
+        /* token.str_len     = */    0,
+        /* token.max_str_len = */    0,
+        /* token.int_val     = */    1,    /* should be overwritten on init */
+        /* token.f_val       = */    1.0,  /* should be overwritten on init */
+        /* token.bb_ptr      = */    NULL,
+        /* token.bb_len      = */    0
+        /* end of token        */ }
+    };
+
+    TESTING("VFD Configuration Language NV Pair List err detect & report 1");
+
+    if ( H5CL__init_lex_vars(input_string, &lex_vars) < 0 ) 
+        TEST_ERROR;
+
+
+    if ( ( H5CL_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL == lex_vars.input_str_ptr ) ||
+         ( input_string == lex_vars.input_str_ptr ) ||
+         ( 0 != strcmp(input_string, lex_vars.input_str_ptr) ) ||
+         ( lex_vars.input_str_ptr != lex_vars.next_char_ptr ) || 
+         ( H5CL_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( H5CL_ERROR_TOK != lex_vars.token.code ) ||
+         ( NULL == lex_vars.token.str_ptr ) ||
+         ( 0 != lex_vars.token.str_len ) ||
+         ( strlen(input_string) != lex_vars.token.max_str_len ) ||
+         ( 0 != lex_vars.token.int_val ) ||
+         ( 0.0 < lex_vars.token.f_val ) ||    /* circumlocution to keep */
+         ( 0.0 > lex_vars.token.f_val ) ||    /* the compier happy      */
+         ( NULL == lex_vars.token.bb_ptr ) ||
+         ( 0 != lex_vars.token.bb_len ) ) {
+
+        TEST_ERROR;
+    }
+
+    /* initialize the array of instance of cl_nv_pair_t */
+    for ( nv_pair_num = 0; nv_pair_num < 5; nv_pair_num++ ) {
+
+        actual_nv_pairs[nv_pair_num].struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
+
+        if ( H5CL_init_nv_pair(&(actual_nv_pairs[nv_pair_num])) < 0 )
+            TEST_ERROR;
+    }
+
+    /* missing initial left paren -- should fail with either left or right parent expected */
+    if ( H5CL__parse_name_value_pair_list(actual_nv_pairs, 5, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                                        "Syntax error -- Terminal \')\' of name value pair list or leading \'(\' "
+                                        "of name value pair expected.  Context:  ( name_0 1 ) ( name_1 3.14159...",
+                                        verbose) ) {
+
+        TEST_ERROR;
+    }
+
+
+    if ( H5CL__take_down_lex_vars(&lex_vars) < 0 )
+        TEST_ERROR;
+
+    if ( ( H5CL_INVALID_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL != lex_vars.input_str_ptr ) ||
+         ( H5CL_INVALID_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( NULL != lex_vars.token.str_ptr ) ||
+         ( NULL != lex_vars.token.bb_ptr ) ) {
+
+        TEST_ERROR;
+    }
+
+
+    PASSED();
+
+    return 0;
+
+error:
+
+    return -1;
+
+} /* cl_parse_name_val_pair_list_err_check_1() */
+
+
+/*******************************************************************************
+ *
+ * cl_parse_name_val_pair_list_err_check_2()
+ *
+ * Name value pair errer detection and reporting test.
+ *
+ *                                              JRM -- 12/20/25
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+static herr_t
+cl_parse_name_val_pair_list_err_check_2(void)
+{
+    bool verbose = true;
+    int nv_pair_num = 0;
+    const char * input_string = "  name_0 1 ) ( name_1 3.14159 ) ( name_2 \"Hello World\" ) "
+                                "( name_3 --10111213 ) ( name_4 ( sec2 () ) ) )";
+    H5CL_nv_pair_t actual_nv_pairs[5];
+    H5CL_lex_vars_t lex_vars = {
+        /* struct_tag        = */ H5CL_LEX_VARS_STRUCT_TAG,
+        /* input_str_ptr     = */ NULL,
+        /* next_char_ptr     = */ NULL,
+        /* end_of_input      = */ false, 
+        /* err_ctx           = */ "",
+        /* token             = */ {
+        /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
+        /* token.code        = */    H5CL_ERROR_TOK,
+        /* token.str_ptr     = */    NULL,
+        /* token.str_len     = */    0,
+        /* token.max_str_len = */    0,
+        /* token.int_val     = */    1,    /* should be overwritten on init */
+        /* token.f_val       = */    1.0,  /* should be overwritten on init */
+        /* token.bb_ptr      = */    NULL,
+        /* token.bb_len      = */    0
+        /* end of token        */ }
+    };
+
+    TESTING("VFD Configuration Language NV Pair List err detect & report 2");
+
+    if ( H5CL__init_lex_vars(input_string, &lex_vars) < 0 ) 
+        TEST_ERROR;
+
+
+    if ( ( H5CL_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL == lex_vars.input_str_ptr ) ||
+         ( input_string == lex_vars.input_str_ptr ) ||
+         ( 0 != strcmp(input_string, lex_vars.input_str_ptr) ) ||
+         ( lex_vars.input_str_ptr != lex_vars.next_char_ptr ) || 
+         ( H5CL_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( H5CL_ERROR_TOK != lex_vars.token.code ) ||
+         ( NULL == lex_vars.token.str_ptr ) ||
+         ( 0 != lex_vars.token.str_len ) ||
+         ( strlen(input_string) != lex_vars.token.max_str_len ) ||
+         ( 0 != lex_vars.token.int_val ) ||
+         ( 0.0 < lex_vars.token.f_val ) ||    /* circumlocution to keep */
+         ( 0.0 > lex_vars.token.f_val ) ||    /* the compier happy      */
+         ( NULL == lex_vars.token.bb_ptr ) ||
+         ( 0 != lex_vars.token.bb_len ) ) {
+
+        TEST_ERROR;
+    }
+
+    /* initialize the array of instance of cl_nv_pair_t */
+    for ( nv_pair_num = 0; nv_pair_num < 5; nv_pair_num++ ) {
+
+        actual_nv_pairs[nv_pair_num].struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
+
+        if ( H5CL_init_nv_pair(&(actual_nv_pairs[nv_pair_num])) < 0 )
+            TEST_ERROR;
+    }
+
+    /* missing initial left paren -- should fail with either left or right parent expected */
+    if ( H5CL__parse_name_value_pair_list(actual_nv_pairs, 5, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                                        "Syntax error -- Initial \'(\' of name value pair list expected.  "
+                                        "Context:   name_0 1 ) ( name_1 3.14159 ...",
+                                        verbose) ) {
+
+        TEST_ERROR;
+    }
+
+
+    if ( H5CL__take_down_lex_vars(&lex_vars) < 0 )
+        TEST_ERROR;
+
+    if ( ( H5CL_INVALID_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL != lex_vars.input_str_ptr ) ||
+         ( H5CL_INVALID_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( NULL != lex_vars.token.str_ptr ) ||
+         ( NULL != lex_vars.token.bb_ptr ) ) {
+
+        TEST_ERROR;
+    }
+
+
+    PASSED();
+
+    return 0;
+
+error:
+
+    return -1;
+
+} /* cl_parse_name_val_pair_list_err_check_2() */
+
+
+/*******************************************************************************
+ *
+ * cl_parse_name_val_pair_list_err_check_3()
+ *
+ * Name value pair errer detection and reporting test.
+ *
+ *                                              JRM -- 12/20/25
+ *
+ * Changes:
+ *
+ *    None.
+ *
+ *******************************************************************************/
+
+static herr_t
+cl_parse_name_val_pair_list_err_check_3(void)
+{
+    bool verbose = true;
+    int nv_pair_num = 0;
+    const char * input_string = "( ( name_3 --10111213- ) ( name_4 ( sec2 () ) ) )";
+    H5CL_nv_pair_t actual_nv_pairs[5];
+    H5CL_lex_vars_t lex_vars = {
+        /* struct_tag        = */ H5CL_LEX_VARS_STRUCT_TAG,
+        /* input_str_ptr     = */ NULL,
+        /* next_char_ptr     = */ NULL,
+        /* end_of_input      = */ false, 
+        /* err_ctx           = */ "",
+        /* token             = */ {
+        /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
+        /* token.code        = */    H5CL_ERROR_TOK,
+        /* token.str_ptr     = */    NULL,
+        /* token.str_len     = */    0,
+        /* token.max_str_len = */    0,
+        /* token.int_val     = */    1,    /* should be overwritten on init */
+        /* token.f_val       = */    1.0,  /* should be overwritten on init */
+        /* token.bb_ptr      = */    NULL,
+        /* token.bb_len      = */    0
+        /* end of token        */ }
+    };
+
+    TESTING("VFD Configuration Language NV Pair List err detect & report 3");
+
+    if ( H5CL__init_lex_vars(input_string, &lex_vars) < 0 ) 
+        TEST_ERROR;
+
+
+    if ( ( H5CL_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL == lex_vars.input_str_ptr ) ||
+         ( input_string == lex_vars.input_str_ptr ) ||
+         ( 0 != strcmp(input_string, lex_vars.input_str_ptr) ) ||
+         ( lex_vars.input_str_ptr != lex_vars.next_char_ptr ) || 
+         ( H5CL_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( H5CL_ERROR_TOK != lex_vars.token.code ) ||
+         ( NULL == lex_vars.token.str_ptr ) ||
+         ( 0 != lex_vars.token.str_len ) ||
+         ( strlen(input_string) != lex_vars.token.max_str_len ) ||
+         ( 0 != lex_vars.token.int_val ) ||
+         ( 0.0 < lex_vars.token.f_val ) ||    /* circumlocution to keep */
+         ( 0.0 > lex_vars.token.f_val ) ||    /* the compier happy      */
+         ( NULL == lex_vars.token.bb_ptr ) ||
+         ( 0 != lex_vars.token.bb_len ) ) {
+
+        TEST_ERROR;
+    }
+
+    /* initialize the array of instance of cl_nv_pair_t */
+    for ( nv_pair_num = 0; nv_pair_num < 5; nv_pair_num++ ) {
+
+        actual_nv_pairs[nv_pair_num].struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
+
+        if ( H5CL_init_nv_pair(&(actual_nv_pairs[nv_pair_num])) < 0 )
+            TEST_ERROR;
+    }
+
+    /* missing initial left paren -- should fail with either left or right parent expected */
+    if ( H5CL__parse_name_value_pair_list(actual_nv_pairs, 5, &lex_vars) >= 0 ) {
+
+        TEST_ERROR;
+
+    } else if ( 0 != cl_test_verify_error_stack(H5E_ARGS, H5E_BADVALUE, 
+                                        "Ill-formed numerical constant.  "
+                                        "Context: ...me_3 --10111213- ) ( name_4 ( ...",
+                                        verbose) ) {
+
+        TEST_ERROR;
+    }
+
+
+    if ( H5CL__take_down_lex_vars(&lex_vars) < 0 )
+        TEST_ERROR;
+
+    if ( ( H5CL_INVALID_LEX_VARS_STRUCT_TAG != lex_vars.struct_tag ) ||
+         ( NULL != lex_vars.input_str_ptr ) ||
+         ( H5CL_INVALID_TOKEN_STRUCT_TAG != lex_vars.token.struct_tag ) ||
+         ( NULL != lex_vars.token.str_ptr ) ||
+         ( NULL != lex_vars.token.bb_ptr ) ) {
+
+        TEST_ERROR;
+    }
+
+
+    PASSED();
+
+    return 0;
+
+error:
+
+    return -1;
+
+} /* cl_parse_name_val_pair_list_err_check_3() */
 
 
 /*******************************************************************************
@@ -1081,8 +3022,7 @@ cl_parser_smoke_check(void)
         /* input_str_ptr     = */ NULL,
         /* next_char_ptr     = */ NULL,
         /* end_of_input      = */ false, 
-        /* line_num          = */ 0,
-        /* char_num          = */ 0, 
+        /* err_ctx           = */ "",
         /* token             = */ {
         /* token.struct_tag  = */    H5CL_TOKEN_STRUCT_TAG,
         /* token.code        = */    H5CL_ERROR_TOK,
@@ -1109,7 +3049,7 @@ cl_parser_smoke_check(void)
 
         actual_nv_pairs_0[i].struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
 
-        if ( H5CL__init_nv_pair(&(actual_nv_pairs_0[i])) < 0 )
+        if ( H5CL_init_nv_pair(&(actual_nv_pairs_0[i])) < 0 )
             TEST_ERROR;
 
     }
@@ -1127,7 +3067,7 @@ cl_parser_smoke_check(void)
 
     for ( i = 0; i < num_nv_pairs_0; i++ ) {
 
-        if ( H5CL__take_down_nv_pair(&(actual_nv_pairs_0[0])) < 0 )
+        if ( H5CL_take_down_nv_pair(&(actual_nv_pairs_0[0])) < 0 )
             TEST_ERROR;
     }
 
@@ -1146,7 +3086,7 @@ cl_parser_smoke_check(void)
 
         actual_nv_pairs_1[i].struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
 
-        if ( H5CL__init_nv_pair(&(actual_nv_pairs_1[i])) < 0 )
+        if ( H5CL_init_nv_pair(&(actual_nv_pairs_1[i])) < 0 )
             TEST_ERROR;
     }
 
@@ -1163,7 +3103,7 @@ cl_parser_smoke_check(void)
 
     for ( i = 0; i < num_nv_pairs_1; i++ ) {
 
-        if ( H5CL__take_down_nv_pair(&(actual_nv_pairs_1[i])) < 0 )
+        if ( H5CL_take_down_nv_pair(&(actual_nv_pairs_1[i])) < 0 )
             TEST_ERROR;
     }
 
@@ -1182,7 +3122,7 @@ cl_parser_smoke_check(void)
 
         actual_nv_pairs_2[i].struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
 
-        if ( H5CL__init_nv_pair(&(actual_nv_pairs_2[i])) < 0 )
+        if ( H5CL_init_nv_pair(&(actual_nv_pairs_2[i])) < 0 )
             TEST_ERROR;
     }
 
@@ -1198,7 +3138,7 @@ cl_parser_smoke_check(void)
 
     for ( i = 0; i < num_nv_pairs_2; i++ ) {
 
-        if ( H5CL__take_down_nv_pair(&(actual_nv_pairs_2[i])) < 0 )
+        if ( H5CL_take_down_nv_pair(&(actual_nv_pairs_2[i])) < 0 )
             TEST_ERROR;
     }
 
@@ -1217,7 +3157,7 @@ cl_parser_smoke_check(void)
 
         actual_nv_pairs_3[i].struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
 
-        if ( H5CL__init_nv_pair(&(actual_nv_pairs_3[i])) < 0 )
+        if ( H5CL_init_nv_pair(&(actual_nv_pairs_3[i])) < 0 )
             TEST_ERROR;
     }
 
@@ -1233,7 +3173,7 @@ cl_parser_smoke_check(void)
 
     for ( i = 0; i < num_nv_pairs_3; i++ ) {
 
-        if ( H5CL__take_down_nv_pair(&(actual_nv_pairs_3[i])) < 0 )
+        if ( H5CL_take_down_nv_pair(&(actual_nv_pairs_3[i])) < 0 )
             TEST_ERROR;
     }
 
@@ -1252,7 +3192,7 @@ cl_parser_smoke_check(void)
 
         actual_nv_pairs_4[i].struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
 
-        if ( H5CL__init_nv_pair(&(actual_nv_pairs_4[i])) < 0 )
+        if ( H5CL_init_nv_pair(&(actual_nv_pairs_4[i])) < 0 )
             TEST_ERROR;
     }
 
@@ -1268,7 +3208,7 @@ cl_parser_smoke_check(void)
 
     for ( i = 0; i < num_nv_pairs_4; i++ ) {
 
-        if ( H5CL__take_down_nv_pair(&(actual_nv_pairs_4[i])) < 0 )
+        if ( H5CL_take_down_nv_pair(&(actual_nv_pairs_4[i])) < 0 )
             TEST_ERROR;
     }
 
@@ -1287,12 +3227,12 @@ cl_parser_smoke_check(void)
 
         actual_nv_pairs_5[i].struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
 
-        if ( H5CL__init_nv_pair(&(actual_nv_pairs_5[i])) < 0 )
+        if ( H5CL_init_nv_pair(&(actual_nv_pairs_5[i])) < 0 )
             TEST_ERROR;
 
         expected_nv_pairs_5[i].struct_tag = H5CL_NV_PAIR_STRUCT_TAG;
 
-        if ( H5CL__init_nv_pair(&(expected_nv_pairs_5[i])) < 0 )
+        if ( H5CL_init_nv_pair(&(expected_nv_pairs_5[i])) < 0 )
             TEST_ERROR;
     }
 
@@ -1338,8 +3278,23 @@ main(void)
     printf("Testing Virtual File Driver Configuration Language functionality.\n");
 
     nerrors += cl_lexer_smoke_check() < 0 ? 1 : 0;
+    nerrors += cl_lexer_detail_check() < 0 ? 1 : 0;
+    nerrors += cl_lexer_error_check_1() < 0 ? 1 : 0;
+    nerrors += cl_lexer_error_check_2() < 0 ? 1 : 0;
+    nerrors += cl_lexer_error_check_3() < 0 ? 1 : 0;
+    nerrors += cl_lexer_error_check_4() < 0 ? 1 : 0;
     nerrors += cl_parse_name_val_pair_smoke_check() < 0 ? 1 : 0;
+    nerrors += cl_parse_nv_pair_error_check_1() < 0 ? 1 : 0;
+    nerrors += cl_parse_nv_pair_error_check_2() < 0 ? 1 : 0;
+    nerrors += cl_parse_nv_pair_error_check_3() < 0 ? 1 : 0;
+    nerrors += cl_parse_nv_pair_error_check_4() < 0 ? 1 : 0;
+    nerrors += cl_parse_nv_pair_error_check_5() < 0 ? 1 : 0;
+    nerrors += cl_parse_nv_pair_error_check_6() < 0 ? 1 : 0;
+    nerrors += cl_parse_nv_pair_error_check_7() < 0 ? 1 : 0;
     nerrors += cl_parse_name_val_pair_list_smoke_check() < 0 ? 1 : 0;
+    nerrors += cl_parse_name_val_pair_list_err_check_1() < 0 ? 1 : 0;
+    nerrors += cl_parse_name_val_pair_list_err_check_2() < 0 ? 1 : 0;
+    nerrors += cl_parse_name_val_pair_list_err_check_3() < 0 ? 1 : 0;
     nerrors += cl_parser_smoke_check() < 0 ? 1 : 0;
 
     if (nerrors) {


### PR DESCRIPTION
1) Updated configuration language to generate useful
   error messages integrated with the HDF5 error reporting
   code.  Added associated test code to test/vfd_cl.c and
   minor bugfixes in passing.

2) Ported page buffer and encryption VFDs to 1.14.6 along
   with recent bug fixes and associated test code.

3) integrated configuration langaage into the page buffer
   and encryption VFDs, and minimally into the VFD code
   as well.  Updated the page buffer and encryption test
   code in test/vfd.c to run tests twice -- once with
   normal binary configuration, and again with configuration
   language strings.

Known Issues:

1) Skiping the underlying fapl compare in compare_pb_config_info()
   results in a seg fault on library shutdown.  To reproduce this
   search for "BUG" in run_crypt_test() and modify the code as
   directed.  Note that this appears to be a pre-existing issue
   that was detected while integrating the configuration language.

2) Syntax error reporting code in H5CL.c should be modified to
   move repeated code to a function call.

3) If the configuaration language is integrated into the HDF5
   library, we should review the error codes used in the
   configuration language and modify if appropriate.

Tested debug only on Charis