### PR TITLE
Updated encryption VFD to store keys in secure memory and get config str and keys from files.

### DIFF
--- a/hdf5/hdf5-1.14.6/src/H5FDcrypt.c
+++ b/hdf5/hdf5-1.14.6/src/H5FDcrypt.c
@@ -165,25 +165,6 @@ typedef struct H5FD_crypt_t {
 } H5FD_crypt_t;
 
 
-H5FD_crypt_vfd_config_t test_vfd_config = {
-    /* magic                  = */ H5FD_CRYPT_CONFIG_MAGIC,
-    /* version                = */ H5FD_CURR_CRYPT_VFD_CONFIG_VERSION,
-    /* plaintext_page_size    = */ H5FD_CRYPT_DEFAULT_PLAINTEXT_PAGE_SIZE,
-    /* ciphertext_page_size   = */ H5FD_CRYPT_DEFAULT_CIPHERTEXT_PAGE_SIZE,
-    /* encryption_buffer_size = */ H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE,
-    /* cipher                 = */ H5FD_CRYPT_DEFAULT_CIPHER,
-    /* cipher_block_size      = */ H5FD_CRYPT_DEFAULT_CIPHER_BLOCK_SIZE,
-    /* key_size               = */ H5FD_CRYPT_DEFAULT_KEY_SIZE,
-    /* key                    = */ H5FD_CRYPT_TEST_KEY,
-    /* iv_size                = */ H5FD_CRYPT_DEFAULT_IV_SIZE,
-    /* mode                   = */ H5FD_CRYPT_DEFAULT_MODE,
-    /* fapl_id                = */ H5P_DEFAULT,
-};
-
-
-bool secure_memory_allocated_g = FALSE;
-
-
 /*
  * These macros check for overflow of various quantities.  These macros
  * assume that HDoff_t is signed and haddr_t and size_t are unsigned.
@@ -220,6 +201,19 @@ bool secure_memory_allocated_g = FALSE;
 #endif                               /* H5FD_CRYPT_DEBUG_OP_CALLS */
     
 
+/**
+ * secure_memory_allocated_g:
+ *      Global flag for if the libgcrypt's secure memory pool has been allocated
+ *      to avoid double allocating
+ * 
+ * key_in_secure_memory_g:
+ *      Global flag for if the key has been stored in secure memory allocated 
+ *      from libgcrypt's secure memory pool.
+ */
+bool secure_memory_allocated_g = FALSE;
+bool key_in_secure_memory_g    = FALSE;
+
+
 /* Private functions */
 
 /* Prototypes */
@@ -235,9 +229,9 @@ static herr_t  H5FD__crypt_fapl_free(void *_fapl);
 static H5FD_t *H5FD__crypt_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr);
 static herr_t  H5FD__crypt_load_config(H5FD_crypt_t * file_ptr, hid_t crypt_fapl_id);
 static herr_t  H5FD__crypt_parse_config(const char * config_str, H5FD_crypt_vfd_config_t * config_ptr);
-#if 1
-static herr_t  H5FD__crypt_get_key_from_file(H5FD_crypt_vfd_config_t * config_ptr, const char *file_path);
-#endif
+static herr_t  H5FD__crypt_init_def_config(H5FD_crypt_vfd_config_t *config_ptr);
+static herr_t  H5FD__crypt_get_key_from_file(H5FD_crypt_vfd_config_t *config_ptr);
+static herr_t  H5FD__crypt_store_key_in_smp(H5FD_crypt_vfd_config_t *config_ptr, void *key_ptr);
 static herr_t  H5FD__crypt_verify_config(const H5FD_crypt_vfd_config_t * config_ptr);
 static herr_t  H5FD__crypt_close(H5FD_t *_file);
 static int     H5FD__crypt_cmp(const H5FD_t *_f1, const H5FD_t *_f2);
@@ -280,7 +274,7 @@ static herr_t  H5FD__crypt_decrypt_page(H5FD_crypt_t *file_ptr, unsigned char *c
 static herr_t  H5FD__crypt_write_first_page(H5FD_crypt_t *file_ptr);
 static herr_t  H5FD__crypt_write_second_page(H5FD_crypt_t *file_ptr);
 static herr_t  H5FD__crypt_init_gcrypt_library(void);
-static herr_t  H5FD__crypt_close_gcrypt_memory(void);
+static herr_t  H5FD__crypt_free_key(H5FD_crypt_vfd_config_t *config_ptr);
 
 static const H5FD_class_t H5FD_crypt_g = {
     H5FD_CLASS_VERSION,              /* struct version       */
@@ -355,9 +349,10 @@ H5FL_DEFINE_STATIC(H5FD_crypt_vfd_config_t);
  *              disk and can be wiped in a secure manner. Useful for storing 
  *              sensitive data like keys.
  * 
- *              NOTE: This iteration doesn't use the secure memory pool. More 
- *              investigation on how to handle key management is needed before
- *              this can be implemented.
+ *              NOTE: the secure memory pool created by ligbcrypt can only
+ *              be allocated once and is done so globally for the program. Thus
+ *              once allocated the global flag secure_memory_allocated_g is set
+ *              and the secure memory won't be allocated again.
  *
  * Return:      SUCCEED/FAIL
  *-----------------------------------------------------------------------------
@@ -369,30 +364,33 @@ H5FD__crypt_init_gcrypt_library(void)
 
     FUNC_ENTER_PACKAGE
 
-    if (!gcry_check_version(GCRYPT_VERSION)) {
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "libgcrypt version mismatch");
+    if ( ! secure_memory_allocated_g )
+    {
+        if (!gcry_check_version(GCRYPT_VERSION)) {
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "libgcrypt version mismatch");
+        }
+
+        /**
+         * Suspend warnings about secure memory not being initialized 
+         * This is necessary because we haven't initialized secure memory yet
+         */ 
+        gcry_control(GCRYCTL_SUSPEND_SECMEM_WARN);
+
+        /* Initialize secure memory */
+        gcry_control(GCRYCTL_INIT_SECMEM, 1, 0);
+
+        /**
+         * Resume warnings about secure memory not being initialized
+         * So if the secure memory pool was not initialized successfully, we will
+         * get a warning
+         */ 
+        gcry_control(GCRYCTL_RESUME_SECMEM_WARN);
+
+        /* Let libgcrypt know that initialization is finished */
+        gcry_control(GCRYCTL_INITIALIZATION_FINISHED, 0);
+
+        secure_memory_allocated_g = TRUE;
     }
-
-    /**
-     * Suspend warnings about secure memory not being initialized 
-     * This is necessary because we haven't initialized secure memory yet
-     */ 
-    gcry_control(GCRYCTL_SUSPEND_SECMEM_WARN);
-
-    /* Initialize secure memory */
-    gcry_control(GCRYCTL_INIT_SECMEM, 4096, 0);
-
-    /**
-     * Resume warnings about secure memory not being initialized
-     * So if the secure memory pool was not initialized successfully, we will
-     * get a warning
-     */ 
-    gcry_control(GCRYCTL_RESUME_SECMEM_WARN);
-
-    /* Let libgcrypt know that initialization is finished */
-    gcry_control(GCRYCTL_INITIALIZATION_FINISHED, 0);
-
-    secure_memory_allocated_g = TRUE;
 
 done:
 
@@ -538,15 +536,6 @@ H5Pset_fapl_crypt(hid_t fapl_id, H5FD_crypt_vfd_config_t *vfd_config)
         HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, 
                     "can't setup driver configuration");
 
-    /**
-     * TODO: I think I search the for the key file here.
-     * make it so the key is all 0's until it's stored so we know it's 'empty'
-     */
-
-    /* Verifies valid config data */
-    if ( H5FD__crypt_verify_config(vfd_config) < 0 )
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "Invalid encryption configuration data");
-
     ret_value = H5P_set_driver(plist_ptr, H5FD_CRYPT, info, NULL);
 
 done:
@@ -624,28 +613,17 @@ H5Pget_fapl_crypt(hid_t fapl_id, H5FD_crypt_vfd_config_t *config /*out*/)
         fapl_ptr = default_fapl;
     }
 
-    /* Copy scalar data */
+    /* Copy data */
     config->plaintext_page_size      = fapl_ptr->plaintext_page_size;
     config->ciphertext_page_size     = fapl_ptr->ciphertext_page_size;
     config->encryption_buffer_size   = fapl_ptr->encryption_buffer_size;
     config->cipher                   = fapl_ptr->cipher;
     config->cipher_block_size        = fapl_ptr->cipher_block_size;
     config->key_size                 = fapl_ptr->key_size;
+    config->key_path                 = fapl_ptr->key_path;
+    config->key                      = fapl_ptr->key;
     config->iv_size                  = fapl_ptr->iv_size;
     config->mode                     = fapl_ptr->mode;
-
-
-    /* copy Key */
-    if ( fapl_ptr->key_size > 0 ) {
-
-        memcpy((void *)config->key, (const void *)fapl_ptr->key, 
-                (size_t)fapl_ptr->key_size);
-    }
-
-    /* Verifies valid config data */
-    if ( H5FD__crypt_verify_config(config) < 0 )
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "Invalid encryption configuration data");
-
 
     /* Copy FAPL */
     if (H5FD__copy_plist(fapl_ptr->fapl_id, &(config->fapl_id)) < 0)
@@ -676,6 +654,7 @@ H5FD__crypt_populate_config(H5FD_crypt_vfd_config_t *vfd_config,
     H5P_genplist_t *def_plist;
     H5P_genplist_t *plist;
     bool            free_config = false;
+
     herr_t          ret_value   = SUCCEED;
 
     FUNC_ENTER_PACKAGE
@@ -699,28 +678,19 @@ H5FD__crypt_populate_config(H5FD_crypt_vfd_config_t *vfd_config,
 
     memset(fapl_out, 0, sizeof(H5FD_crypt_vfd_config_t));
 
-    if ( NULL == vfd_config ) {
-
+    if ( NULL == vfd_config ) 
+    {
         vfd_config = H5MM_calloc(sizeof(H5FD_crypt_vfd_config_t));
 
         if (NULL == vfd_config)
             HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, FAIL, 
                         "unable to allocate file access property list struct");
 
-        vfd_config->magic                  = H5FD_CRYPT_CONFIG_MAGIC;
-        vfd_config->version                = H5FD_CURR_CRYPT_VFD_CONFIG_VERSION;
-        vfd_config->plaintext_page_size    = H5FD_CRYPT_DEFAULT_PLAINTEXT_PAGE_SIZE;
-        vfd_config->ciphertext_page_size   = H5FD_CRYPT_DEFAULT_CIPHERTEXT_PAGE_SIZE;
-        vfd_config->encryption_buffer_size = H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE;
-        vfd_config->cipher                 = H5FD_CRYPT_DEFAULT_CIPHER;
-        vfd_config->cipher_block_size      = H5FD_CRYPT_DEFAULT_CIPHER_BLOCK_SIZE;
-
-        vfd_config->key_size               = 0;
-
-        vfd_config->iv_size                = H5FD_CRYPT_DEFAULT_IV_SIZE;
-        vfd_config->mode                   = H5FD_CRYPT_DEFAULT_MODE;
-
-        vfd_config->fapl_id                = H5P_DEFAULT;
+        /**
+         * Initializes vfd_config to defaults
+         * H5FD__crypt_init_def_config() can't fail so no need to check ret_value.
+         */
+        H5FD__crypt_init_def_config(vfd_config);
 
         free_config = true;
     }
@@ -733,15 +703,27 @@ H5FD__crypt_populate_config(H5FD_crypt_vfd_config_t *vfd_config,
     fapl_out->cipher                 = vfd_config->cipher;
     fapl_out->cipher_block_size      = vfd_config->cipher_block_size;
     fapl_out->key_size               = vfd_config->key_size;
+    fapl_out->key_path               = vfd_config->key_path;
+    fapl_out->key                    = vfd_config->key;
     fapl_out->iv_size                = vfd_config->iv_size;
     fapl_out->mode                   = vfd_config->mode;
 
-    /* copy Key */
-    if ( vfd_config->key_size > 0 ) {
-
-        memcpy((void *)fapl_out->key, (const void *)vfd_config->key, 
-                                            (size_t)vfd_config->key_size);
+    /* Get key if don't already have it */
+    if ( ! fapl_out->key )
+    {
+        /* Get key from key file */
+        if ( H5FD__crypt_get_key_from_file(fapl_out) < 0 )
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, 
+                                "Failed to get key from key file");
     }
+
+    if ( vfd_config ) 
+    {
+        /* Verifies valid config data */
+        if ( H5FD__crypt_verify_config(fapl_out) < 0 )
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "Invalid encryption configuration data");
+    }
+
 
     /* pre-set value */
     fapl_out->fapl_id               = H5P_FILE_ACCESS_DEFAULT; 
@@ -980,10 +962,11 @@ H5FD__crypt_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type,
 
 done:
 
+    /* If an error occurs, zero and free the key */
     if ( ret_value == FAIL )
     {
-        /* Free the secure memory */
-        H5FD__crypt_close_gcrypt_memory();
+        /* Free the key from secure memory */
+        H5FD__crypt_free_key(&file_ptr->fa);
     }
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1123,10 +1106,11 @@ H5FD__crypt_write(H5FD_t *_file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr,
 
 done:
 
+    /* If an error occurs, zero and free the key */
     if ( ret_value == FAIL )
     {
-        /* Free the secure memory */
-        H5FD__crypt_close_gcrypt_memory();
+        /* Free the key from secure memory */
+        H5FD__crypt_free_key(&file_ptr->fa);
     }
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1268,8 +1252,8 @@ H5FD__crypt_open(const char *name, unsigned flags, hid_t crypt_fapl_id,
                         haddr_t maxaddr)
 {
     /* encryption VFD info */
-    H5FD_crypt_t                  *file_ptr     = NULL; 
-    H5FD_t                        *ret_value    = NULL;
+    H5FD_crypt_t    *file_ptr  = NULL; 
+    H5FD_t          *ret_value = NULL;
 
     FUNC_ENTER_PACKAGE
 
@@ -1383,8 +1367,8 @@ done:
             H5FL_FREE(H5FD_crypt_t, file_ptr);
         }
 
-        /* Free the secure memory */
-        H5FD__crypt_close_gcrypt_memory();
+        /* Free the key from secure memory */
+        H5FD__crypt_free_key(&file_ptr->fa);
 
     } /* end if error */
 
@@ -1413,9 +1397,10 @@ done:
 herr_t
 H5FD__crypt_load_config(H5FD_crypt_t * file_ptr, hid_t crypt_fapl_id)
 {
-    const char * config_str = NULL;
-    H5P_genplist_t  * plist_ptr  = NULL;
-    const H5FD_crypt_vfd_config_t * config_ptr = NULL;
+    const char *config_str = NULL;
+    H5P_genplist_t  *plist_ptr  = NULL;
+    const H5FD_crypt_vfd_config_t *config_ptr = NULL;
+
     herr_t ret_value = SUCCEED;
 
     FUNC_ENTER_PACKAGE
@@ -1464,24 +1449,11 @@ H5FD__crypt_load_config(H5FD_crypt_t * file_ptr, hid_t crypt_fapl_id)
 
         /* first, load the configuration with default values. 
          * must do this, as the configuration string may not define all values -- which 
-         * means that the initial values must be reasonable where possible. 
-         * The exception is key size, because it is either defined, or calculated
-         * from the key itself.  
+         * means that the initial values must be reasonable where possible.   
+         *
+         * H5FD__crypt_init_def_config() can't fail so no need to check ret_value.
          */
-        file_ptr->fa.magic                  = H5FD_CRYPT_CONFIG_MAGIC;
-        file_ptr->fa.version                = H5FD_CURR_CRYPT_VFD_CONFIG_VERSION;
-        file_ptr->fa.plaintext_page_size    = H5FD_CRYPT_DEFAULT_PLAINTEXT_PAGE_SIZE;
-        file_ptr->fa.ciphertext_page_size   = H5FD_CRYPT_DEFAULT_CIPHERTEXT_PAGE_SIZE;
-        file_ptr->fa.encryption_buffer_size = H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE;
-        file_ptr->fa.cipher                 = H5FD_CRYPT_DEFAULT_CIPHER;
-        file_ptr->fa.cipher_block_size      = H5FD_CRYPT_DEFAULT_CIPHER_BLOCK_SIZE;
-        file_ptr->fa.key_size               = 0;
-        file_ptr->fa.iv_size                = H5FD_CRYPT_DEFAULT_IV_SIZE;
-        file_ptr->fa.mode                   = H5FD_CRYPT_DEFAULT_MODE;
-        file_ptr->fa.fapl_id                = H5P_DEFAULT;
-
-        /* zero out file_ptr->fa.key */
-        memset(&(file_ptr->fa.key[0]), 0, H5FD_CRYPT_MAX_KEY_SIZE);
+        H5FD__crypt_init_def_config(&file_ptr->fa);
 
         /* now call H5FD__crypt_parse_config() to parse the configuration string
          * and overwrite any field in file_ptr->fa with values that appear in 
@@ -1489,10 +1461,6 @@ H5FD__crypt_load_config(H5FD_crypt_t * file_ptr, hid_t crypt_fapl_id)
          */
         if ( H5FD__crypt_parse_config(config_str, &(file_ptr->fa)) < 0 )
             HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "can't parse configuration string");
-#if 0
-        if ( H5FD__crypt_get_key_from_file(&(file_ptr->fa)) < 0 )
-            HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "can't get key from key file");
-#endif
 
         /* save a copy of the configuration string */
         file_ptr->config_str = H5MM_strdup(config_str);
@@ -1526,7 +1494,6 @@ done:
  *
  *-------------------------------------------------------------------------
  */
-
 herr_t
 H5FD__crypt_parse_config(const char * config_str, H5FD_crypt_vfd_config_t * config_ptr)
 {
@@ -1657,7 +1624,8 @@ H5FD__crypt_parse_config(const char * config_str, H5FD_crypt_vfd_config_t * conf
                     if ( H5FD_CRYPT_MAX_KEY_SIZE < reported_key_size ) 
                         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "Actual key size > H5FD_CRYPT_MAX_KEY_SIZE.");
 
-                    memcpy(&(config_ptr->key[0]), (nv_pairs[i].vlen_val_ptr), reported_key_size);
+                    if ( H5FD__crypt_store_key_in_smp(config_ptr, nv_pairs[i].vlen_val_ptr) < 0)
+                        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "Failed to store key in secure memory pool");
 
                     have_key = TRUE;
 
@@ -1673,7 +1641,11 @@ H5FD__crypt_parse_config(const char * config_str, H5FD_crypt_vfd_config_t * conf
                     if ( have_key )
                         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "Already have key.");
 
-                    if ( H5FD__crypt_get_key_from_file(config_ptr, nv_pairs[i].vlen_val_ptr) < 0 )
+                    config_ptr->key_path = malloc(nv_pairs[i].len);
+
+                    memcpy(config_ptr->key_path, nv_pairs[i].vlen_val_ptr, nv_pairs[i].len);
+
+                    if ( H5FD__crypt_get_key_from_file(config_ptr) < 0 )
                         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "Failed getting key from path");
 
                     have_key = TRUE;
@@ -1758,6 +1730,18 @@ H5FD__crypt_parse_config(const char * config_str, H5FD_crypt_vfd_config_t * conf
         }
     }
 
+    /* If don't have the key and key_size, check key_path environment variable */
+    if ( ! have_key && ! have_key_size )
+    {
+        if ( H5FD__crypt_get_key_from_file(config_ptr) < 0 )
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "Failed to get key from key file");
+        else
+        {
+            have_key      = TRUE;
+            have_key_size = TRUE;
+        }
+    }
+
     /* check for missing required values */
     if ( ! have_key_size ) 
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "config string lacks key_size name value pair.");
@@ -1824,16 +1808,74 @@ done:
 
 } /* H5FD__crypt_parse_config() */
 
-#if 1
-/**
- * 
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__crypt_init_def_config
+ *
+ * Purpose:     Initializes a H5FD_crypt_vfd_config_t struct with default
+ *              values. 
+ *
+ *              NOTE: Fields key_path and key are initialized to NULL, and
+ *              key_size is initialized to 0. This is because they are set
+ *              elsewhere and having them initialized to these values helps
+ *              ensure the configuration is correct or not.
+ *
+ * Return:      Success:    SUCCEED
+ *              Failure:    FAIL
+ *
+ *-------------------------------------------------------------------------
  */
 static herr_t
-H5FD__crypt_get_key_from_file(H5FD_crypt_vfd_config_t * config_ptr, const char *file_path)
+H5FD__crypt_init_def_config(H5FD_crypt_vfd_config_t *config_ptr)
 {
-    //const char *file_path = NULL;
-    FILE       *file      = NULL;
+    FUNC_ENTER_PACKAGE_NOERR
+
+    config_ptr->magic                  = H5FD_CRYPT_CONFIG_MAGIC;
+    config_ptr->version                = H5FD_CURR_CRYPT_VFD_CONFIG_VERSION;
+    config_ptr->plaintext_page_size    = H5FD_CRYPT_DEFAULT_PLAINTEXT_PAGE_SIZE;
+    config_ptr->ciphertext_page_size   = H5FD_CRYPT_DEFAULT_CIPHERTEXT_PAGE_SIZE;
+    config_ptr->encryption_buffer_size = H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE;
+    config_ptr->cipher                 = H5FD_CRYPT_DEFAULT_CIPHER;
+    config_ptr->cipher_block_size      = H5FD_CRYPT_DEFAULT_CIPHER_BLOCK_SIZE;
+
+    config_ptr->key_size               = 0;
+    config_ptr->key_path               = NULL;
+    config_ptr->key                    = NULL;
+
+    config_ptr->iv_size                = H5FD_CRYPT_DEFAULT_IV_SIZE;
+    config_ptr->mode                   = H5FD_CRYPT_DEFAULT_MODE;
+
+    config_ptr->fapl_id                = H5P_DEFAULT;
+
+    FUNC_LEAVE_NOAPI(SUCCEED)
+
+} /* H5FD__crypt_init_def_config() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__crypt_get_key_from_file
+ *
+ * Purpose:     Opens a key file using config_ptr->key_path or the
+ *              environment variable H5FD_CRYPT_KEY_PATH, to then read the
+ *              key from the key file, storing it in secure memory allocated
+ *              from the libgcrypt's secure memory pool.
+ * 
+ *              NOTE: current the key_size is set based on the size of the
+ *              file, however, that will need to be changed when the 
+ *              password protected key files are set up to be used. 
+ *
+ * Return:      Success:    SUCCEED
+ *              Failure:    FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5FD__crypt_get_key_from_file(H5FD_crypt_vfd_config_t * config_ptr)
+{
+    FILE       *file = NULL;
+    const char *file_path = NULL;
     struct stat st;
+    size_t      read = 0;
 
     herr_t      ret_value = SUCCEED;
 
@@ -1842,12 +1884,22 @@ H5FD__crypt_get_key_from_file(H5FD_crypt_vfd_config_t * config_ptr, const char *
     assert(config_ptr);
     assert(config_ptr->magic == H5FD_CRYPT_CONFIG_MAGIC);
 
-    /* If the file path is NULL, get the path from the environment variable */
-    if ( ! file_path )
+    /* Get file path to key file */
+    if ( config_ptr->key_size > 0 )
+    {
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, 
+                                    "Already have key_size but no key");
+    }
+    else if ( config_ptr->key_path )
+    {
+        file_path = config_ptr->key_path;
+    }
+    else
     {
         file_path = getenv(HDF5_CRYPT_KEY_PATH);
     }
 
+    /* Open file */
     if ( file_path == NULL || file_path[0] == '\0' )
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "file_path cannot be blank");
 
@@ -1864,14 +1916,24 @@ H5FD__crypt_get_key_from_file(H5FD_crypt_vfd_config_t * config_ptr, const char *
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "key size > H5FD_CRYPT_MAX_KEY_SIZE");
 
 
+    /* Allocate the secure memory for the key from libgcrypt's secure memory pool */
+    config_ptr->key_size = (size_t)st.st_size;
+    config_ptr->key = gcry_malloc_secure(config_ptr->key_size);
+
+    if ( NULL == config_ptr->key )
+        HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL, 
+                        "unable to allocate secure memory pool for key");
+
+    key_in_secure_memory_g = TRUE;
+
     /* Open the file */
     file = fopen(file_path, "rb");
     if ( !file ) {
         HGOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, FAIL, "unable to open file");
     }
 
-    if( (config_ptr->key_size = fread(config_ptr->key, 1, (size_t)st.st_size, file)) != 
-                                                                    (size_t)st.st_size )
+    read = fread(config_ptr->key, 1, (size_t)st.st_size, file);
+    if( read != config_ptr->key_size )
     {
         if (ferror(file)) {
             HGOTO_ERROR(H5E_FILE, H5E_READERROR, FAIL, "I/O error during read");
@@ -1883,10 +1945,67 @@ H5FD__crypt_get_key_from_file(H5FD_crypt_vfd_config_t * config_ptr, const char *
 
 done:
 
+    if ( file )
+    {
+        fclose(file);
+    }
+
+    if ( ret_value == FAIL && config_ptr->key )
+    {
+        H5FD__crypt_free_key(config_ptr);
+    }
+
     FUNC_LEAVE_NOAPI(ret_value);
 
 } /* H5FD__crypt_get_key_from_file() */
-#endif
+
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__crypt_store_key_in_smp
+ *
+ * Purpose:     Given a key_ptr, allocates memory in libgcrypt's secure
+ *              memory pool to store the key. 
+ * 
+ *              NOTE: currently this function is only called by 
+ *              H5FD__crypt_parse_config() and only if the configuration
+ *              string contains a hex expression of the key. Which means
+ *              that even though this function stores the key in secure 
+ *              memory, the configuration string does contain an 
+ *              un-encrypted copy of the key making this method of passing
+ *              the key to the Encryption VFD not very secure.
+ *
+ * Return:      Success:    SUCCEED
+ *              Failure:    FAIL
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t  
+H5FD__crypt_store_key_in_smp(H5FD_crypt_vfd_config_t *config_ptr, void *key_ptr)
+{
+    herr_t      ret_value = SUCCEED;
+
+    assert(config_ptr);
+    assert(config_ptr->magic == H5FD_CRYPT_CONFIG_MAGIC);
+    assert(key_ptr);
+
+    FUNC_ENTER_PACKAGE
+
+    config_ptr->key = gcry_malloc_secure(config_ptr->key_size);
+
+    if ( ! config_ptr->key )
+        HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL, 
+                        "unable to allocate key from libgcrypt's secure memory pool");
+
+    memcpy(config_ptr->key, key_ptr, config_ptr->key_size);
+
+    key_in_secure_memory_g = TRUE;
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+
+} /* H5FD__crypt_store_key_in_smp() */
+
 
 /*-------------------------------------------------------------------------
  * Function:    H5FD__crypt_verify_config
@@ -1964,6 +2083,11 @@ H5FD__crypt_verify_config(const H5FD_crypt_vfd_config_t *config_ptr)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid mode");
     }
 
+    /**
+     * TODO: will most likely need to increase the minimum size of plaintext and
+     * ciphertext pages to ensure they are large enough to store the configuration
+     * data required on the first page of the hdf5 file.
+     */
     /* Verify plaintext page size */
     if ( plaintext_size >= 512 && plaintext_size <= 33554432 )
     {
@@ -2040,6 +2164,10 @@ H5FD__crypt_close(H5FD_t *_file)
         file_ptr->ciphertext_buf = NULL;
     }
 
+    /* Zero and free the key from secure memory */
+    H5FD__crypt_free_key(&file_ptr->fa);
+
+
     /* Discard the configuration string if present */
     if ( file_ptr->config_str ) {
 
@@ -2052,37 +2180,48 @@ H5FD__crypt_close(H5FD_t *_file)
 
 done:
 
-    /* Free the secure memory */
-    H5FD__crypt_close_gcrypt_memory();
+    /** 
+     * If an error occurs and the key isn't zero'd 
+     * and freed during the function, do so here.
+     */
+    if ( file_ptr )
+    {
+        H5FD__crypt_free_key(&file_ptr->fa);
+    }
 
     FUNC_LEAVE_NOAPI(ret_value)
 
 } /* end H5FD__crypt_close() */
 
 /*-----------------------------------------------------------------------------
- * Function:    H5FD__crypt_close_gcrypt_memory
+ * Function:    H5FD__crypt_free_key
  *
- * Purpose:     Calls the libgcrypt function to zero and free the secure memory
- *              pool. If the secure memory was already free'd or was never 
- *              allocated, the libgcrypt function does nothing.
+ * Purpose:     Calls the libgcrypt function to zero the allocated memory of 
+ *              the secure memory pool where the key is stored and frees that 
+ *              memory back to being usable in the secure memory pool.
  *
  * Return:      SUCCEED (can't fail)
  *-----------------------------------------------------------------------------
  */
 static herr_t
-H5FD__crypt_close_gcrypt_memory(void)
+H5FD__crypt_free_key(H5FD_crypt_vfd_config_t *config_ptr)
 {
     FUNC_ENTER_PACKAGE_NOERR 
 
     if ( secure_memory_allocated_g )
     {
-        /* Freeing the secure memory */
-        gcry_control(GCRYCTL_TERM_SECMEM);
+        if ( config_ptr->key && key_in_secure_memory_g )
+        {
+            /* Zero and free the key from secure memory */
+            gcry_free(config_ptr->key);
+            config_ptr->key = NULL;
+            config_ptr->key_size = 0;
+        }
     }
 
     FUNC_LEAVE_NOAPI(SUCCEED);
 
-} /* end H5FD__crypt_close_gcrypt_memory() */
+} /* end H5FD__crypt_free_key() */
 
 /*-----------------------------------------------------------------------------
  * Function:    H5FD__crypt_get_eoa
@@ -3203,8 +3342,8 @@ H5FD__crypt_decrypt_page(H5FD_crypt_t *file_ptr, unsigned char *ciphertext_buf,
         HGOTO_ERROR(H5E_VFL, H5E_SYSTEM, FAIL, "Unknown mode");
 
 
-    /* Initializes the handle with the cipher and mode (AES256, CBC) */
-    if ( 0 != (err = gcry_cipher_open(&handle, cipher, mode, 0)) ) {
+    /* Initializes the handle with the cipher and mode in the secure memory pool */
+    if ( 0 != (err = gcry_cipher_open(&handle, cipher, mode, GCRY_CIPHER_SECURE)) ) {
 
         snprintf(error_string, (size_t)256, "gcrypt error: %s", 
                         gcry_strerror(err));
@@ -3316,7 +3455,7 @@ H5FD__crypt_encrypt_page(H5FD_crypt_t *file_ptr, unsigned char *ciphertext_buf,
 
 
 
-    /* Initializes the handle with the cipher and mode (AES256, CBC) */
+    /* Initializes the handle with the cipher and mode in the secure memory pool */
     if ( 0 != (err = gcry_cipher_open(&handle, cipher, mode, GCRY_CIPHER_SECURE)) ) {
 
         snprintf(error_string, (size_t)256, "gcrypt error: %s", 

--- a/hdf5/hdf5-1.14.6/src/H5FDcrypt.h
+++ b/hdf5/hdf5-1.14.6/src/H5FDcrypt.h
@@ -110,9 +110,12 @@
  *      key sizes. An example is AES128 and AES256 which are both AES 
  *      ciphers but have a 128 key size and a 256 key size respectively.
  * 
- * unit8_t key[H5FD_CRYPT_MAX_KEY_SIZE]:
- *      Buffer to hold the key. Next iteration the key will be in a secure
- *      memory pool made by the libgcrypt library.
+ * key_path (char *):
+ *      Path to a file that stores the encryption key to encrypt/decrypt
+ *      the hdf5 file.
+ * 
+ * key (uint8_t *):
+ *      Pointer to the encryption key stored in libgcrypt's secure memory pool.
  * 
  * iv_size (size_t):
  *      Size of the initialization vector (IV) in bytes. The mode determines 
@@ -132,21 +135,20 @@
 typedef struct H5FD_crypt_vfd_config_t {
     int32_t      magic;            
     unsigned int version;          
-    size_t plaintext_page_size;     
-    size_t ciphertext_page_size;    
-    size_t encryption_buffer_size;       
-    int cipher;                     
+    size_t       plaintext_page_size;     
+    size_t       ciphertext_page_size;    
+    size_t       encryption_buffer_size;       
+    int          cipher;                     
+    size_t       cipher_block_size;
 
-    /* add fields for key, etc */
-    size_t cipher_block_size;        
-    size_t key_size;                
+    size_t       key_size;
+    char        *key_path;
+    uint8_t     *key;
 
-    uint8_t key[H5FD_CRYPT_MAX_KEY_SIZE];
+    size_t       iv_size;                 
+    int          mode;          
 
-    size_t iv_size;                 
-    int mode;          
-
-    hid_t fapl_id;                 
+    hid_t        fapl_id;                 
 } H5FD_crypt_vfd_config_t;
 //! <!-- [H5FD_crypt_vfd_config_t_snip] -->
 

--- a/hdf5/hdf5-1.14.6/src/hdf5.h
+++ b/hdf5/hdf5-1.14.6/src/hdf5.h
@@ -40,6 +40,8 @@
 #include "H5VLpublic.h" /* Virtual Object Layer                     */
 #include "H5Zpublic.h"  /* Data filters                             */
 
+#include "H5CLpublic.h"
+
 /* Plugin/component developer headers */
 #include "H5ESdevelop.h" /* Event Sets */
 #include "H5FDdevelop.h" /* File drivers */

--- a/hdf5/hdf5-1.14.6/test/vfd.c
+++ b/hdf5/hdf5-1.14.6/test/vfd.c
@@ -97,7 +97,7 @@ static const char *FILENAME[] = {"sec2_file",            /*0*/
  */
 #define PB_TEST_ALL_SIZES 0
 #define PB_TEST_4M        0
-#define PB_DEBUG_QUICK    1
+#define PB_DEBUG_QUICK    0
 
 #define CRYPT_DS_SIZE     8
 #define CRYPT_DATASET_NAME "dataset"
@@ -105,7 +105,7 @@ static const char *FILENAME[] = {"sec2_file",            /*0*/
  * Used to quickly go through the tests with a single set of plaintext and ciphertext
  * sizes and buffer for faster debugger, instead of testing multiple sizes.
  */
-#define CRYPT_DEBUG_QUICK 1
+#define CRYPT_DEBUG_QUICK 0
 
 /* Macro: HEXPRINT()
  * Helper macro to pretty-print hexadecimal output of a buffer of known size.
@@ -260,8 +260,11 @@ static int crypt_test_invalid_config(bool cl_config);
 static int crypt_test_invalid_config_helper(bool cl_config, size_t pt_size, size_t ct_size, size_t buf_size, 
                             int32_t cipher, size_t block_size, size_t key_size, size_t iv_size, int32_t mode);
 static int crypt_test_invalid_addrs_and_buffs(bool cl_config);
-static int crypt_test_using_env_var(void);
-static int crypt_test_invalid_config_using_env_var(void);
+static int crypt_test_with_cl_using_env(void);
+static int crypt_test_invalid_config_using_env(void);
+static int crypt_test_with_cl_and_key_from_files(void);
+static int crypt_test_using_key_path_env(bool cl_config);
+static int create_files_for_crypt(const char *file_name, const char *config_str, char *file_path, int file_type);
 static int run_crypt_test(const struct crypt_dataset_def *data, const hid_t sub_fapl_id, bool cl_config);
 static int crypt_RO_test(const struct crypt_dataset_def *data, hid_t child_fapl_id, bool cl_config);
 static int crypt_create_single_file_at(const char *filename, hid_t fapl_id, const struct crypt_dataset_def *data);
@@ -6839,12 +6842,12 @@ pb_test_invalid_addrs_and_buffs(bool cl_config)
     }
 
 
-    if (H5Pclose(fapl_id) < 0) {
-        PB_TEST_FAULT("can't close fapl\n");
-    }
-
     if (H5FDclose(file_ptr) < 0) {
         PB_TEST_FAULT("can't close file\n");
+    }
+
+    if (H5Pclose(fapl_id) < 0) {
+        PB_TEST_FAULT("can't close fapl\n");
     }
 
 done:
@@ -6852,8 +6855,8 @@ done:
     if (ret_value < 0) {
         H5E_BEGIN_TRY
         {
-            H5Pclose(fapl_id);
             H5FDclose(file_ptr);
+            H5Pclose(fapl_id);
         }
         H5E_END_TRY
     }
@@ -7020,16 +7023,16 @@ pb_test_using_env_var(void)
      * Close fapl_id and file_ptr, before closing library 
      * to set environment variables to default values.
      */
-    if ( fapl_id != H5I_INVALID_HID )
-    {
-        H5Pclose(fapl_id);
-        fapl_id = H5I_INVALID_HID;
-    }
-    
     if ( file_ptr )
     {
         H5FDclose(file_ptr);
         file_ptr = NULL;
+    }
+
+    if ( fapl_id != H5I_INVALID_HID )
+    {
+        H5Pclose(fapl_id);
+        fapl_id = H5I_INVALID_HID;
     }
 
     /* Close the library */
@@ -7060,14 +7063,14 @@ pb_test_using_env_var(void)
 
 done:
 
-    if ( fapl_id != H5I_INVALID_HID )
-    {
-        H5Pclose(fapl_id);
-    }
-    
     if ( file_ptr )
     {
         H5FDclose(file_ptr);
+    }
+
+    if ( fapl_id != H5I_INVALID_HID )
+    {
+        H5Pclose(fapl_id);
     }
 
     if (page) 
@@ -7196,16 +7199,17 @@ pb_test_invalid_config_using_env_var(void)
      * Close fapl_id and file_ptr, before closing library 
      * to set environment variables to default values.
      */
-    if ( fapl_id != H5I_INVALID_HID )
-    {
-        H5Pclose(fapl_id);
-        fapl_id = H5I_INVALID_HID;
-    }
-    
     if ( file_ptr )
     {
         H5FDclose(file_ptr);
         file_ptr = NULL;
+    }
+
+
+    if ( fapl_id != H5I_INVALID_HID )
+    {
+        H5Pclose(fapl_id);
+        fapl_id = H5I_INVALID_HID;
     }
 
     /* Close the library */
@@ -7237,14 +7241,14 @@ pb_test_invalid_config_using_env_var(void)
 
 done:
 
-    if ( fapl_id != H5I_INVALID_HID )
-    {
-        H5Pclose(fapl_id);
-    }
-    
     if ( file_ptr )
     {
         H5FDclose(file_ptr);
+    }
+
+    if ( fapl_id != H5I_INVALID_HID )
+    {
+        H5Pclose(fapl_id);
     }
 
     if ( env_set )
@@ -7662,10 +7666,41 @@ compare_crypt_config_info(hid_t fapl_id, H5FD_crypt_vfd_config_t *info)
         CRYPT_TEST_FAULT("cipher_block_size mismatch\n");
     }
 
-    if (info->key_size != fetched_info->key_size) {
-        fprintf(stderr, "key_size mismatch: expected %zu, got %zu\n",
-                info->key_size, fetched_info->key_size);
-        CRYPT_TEST_FAULT("key_size mismatch\n");
+    if (info->key_size != fetched_info->key_size) 
+    {
+        /**
+         * If info->key_size == 0 and info->key == NULL, the configuration 
+         * is being tested that it can load the key and key size from a file
+         * and these fields won't have been set in info.
+         */
+        if ( info->key_size != 0 && info->key )
+        {
+            fprintf(stderr, "key_size mismatch: expected %zu, got %zu\n",
+                    info->key_size, fetched_info->key_size);
+            CRYPT_TEST_FAULT("key_size mismatch\n");
+        }
+    }
+
+    /**
+     * If not NULL, ensure it matches,
+     * but if NULL, ensure info->key_path is also NULL.
+     */
+    if ( fetched_info->key_path )
+    {
+        if ( strcmp(info->key_path, fetched_info->key_path) != 0 ) {
+            fprintf(stderr, "key_path mismatch: expected %s, got %s\n",
+                    info->key_path, fetched_info->key_path);
+            CRYPT_TEST_FAULT("key_path mismatch\n");
+        }
+    }
+    else
+    {
+        if ( info->key_path )
+        {
+            fprintf(stderr, "key_path mismatch: expected %s, got %s\n",
+                    info->key_path, fetched_info->key_path);
+            CRYPT_TEST_FAULT("key_path mismatch\n");
+        }
     }
 
     if (info->iv_size != fetched_info->iv_size) {
@@ -7804,12 +7839,16 @@ test_crypt_fapl(bool cl_config)
         /* cipher                 = */ 0,
         /* cipher_block_size      = */ 16,
         /* key_size               = */ 32,
-        /* key                    = */ H5FD_CRYPT_TEST_KEY,
+        /* key_path               = */ NULL,
+        /* key                    = */ NULL,
         /* iv_size                = */ 16,
         /* mode                   = */ 0,
         /* fapl_id                = */ H5P_DEFAULT
     };
     int                      ret_value    = 0;
+
+    vfd_cfg_0.key = gcry_malloc_secure(vfd_cfg_0.key_size);
+    memcpy(vfd_cfg_0.key, H5FD_CRYPT_TEST_KEY, vfd_cfg_0.key_size);
 
 #if 0 /* debug code -- keep for a while */
     /* dump hex expression of the key */
@@ -7985,12 +8024,12 @@ crypt_test_create(char *config_str, H5FD_crypt_vfd_config_t vfd_config)
         CRYPT_TEST_FAULT("couldn't get pointer to H5FD_t structure");
 
 
-    if (H5Pclose(fapl_id) < 0) {
-        CRYPT_TEST_FAULT("can't close fapl\n");
-    }
-
     if (H5FDclose(file_ptr) < 0) {
         CRYPT_TEST_FAULT("can't close file\n");
+    }
+
+    if (H5Pclose(fapl_id) < 0) {
+        CRYPT_TEST_FAULT("can't close fapl\n");
     }
 
 
@@ -7999,8 +8038,8 @@ done:
     if (ret_value < 0) {
         H5E_BEGIN_TRY
         {
-            H5Pclose(fapl_id);
             H5FDclose(file_ptr);
+            H5Pclose(fapl_id);
         }
         H5E_END_TRY
     }
@@ -8062,6 +8101,7 @@ crypt_test_verify_create_and_encryption(char *config_str, H5FD_crypt_vfd_config_
     size_t           iv_size           = vfd_config.iv_size;
     size_t           file_size         = 3 * ciphertext_size;
     int              cipher            = vfd_config.cipher;
+    uint8_t          bad_key[]         = "test when this key isnt correct";
     
     int              ret_value         = 0;
 
@@ -8077,11 +8117,15 @@ crypt_test_verify_create_and_encryption(char *config_str, H5FD_crypt_vfd_config_
         /* cipher                 = */ vfd_config.cipher,  
         /* cipher_block_size      = */ 16,
         /* key_size               = */ 32,
-        /* key                    = */ "test when this key isn't correct",
+        /* key_path               = */ NULL,
+        /* key                    = */ NULL,
         /* iv_size                = */ 16,
         /* mode                   = */ 0,
         /* fapl_id                = */ H5P_DEFAULT
     };
+    wrong_key_config.key = malloc(wrong_key_config.key_size);
+    memcpy(wrong_key_config.key, bad_key, 32);
+
     if ( config_str )
     {
         snprintf(wrong_key_str, sizeof(wrong_key_str),
@@ -8432,11 +8476,14 @@ done:
     if (ret_value < 0) {
         H5E_BEGIN_TRY
         {
-            H5Pclose(fapl_id);
             H5FDclose(file_ptr);
+            H5Pclose(fapl_id);
         }
         H5E_END_TRY
     }
+
+    if ( wrong_key_config.key )
+        free(wrong_key_config.key);
 
     if (setup_buf)
         free(setup_buf);
@@ -8542,7 +8589,7 @@ crypt_test_write_and_read(size_t num_pages, char *config_str, H5FD_crypt_vfd_con
     /* Buffer to hold the data that will be used to test the write function */
     write_buf = malloc(size_of_pages);
     if (NULL == write_buf)
-        CRYPT_TEST_FAULT("couldn't allocate memory for six_page_write_buf\n");
+        CRYPT_TEST_FAULT("couldn't allocate memory for write_buf\n");
 
     /* Fill the buffer with random characters to simulate data */
     for (size_t i = 0; i < (size_of_pages); i++)
@@ -8560,7 +8607,7 @@ crypt_test_write_and_read(size_t num_pages, char *config_str, H5FD_crypt_vfd_con
     /* Buffer for the read test to try to store the page that was just written */
     read_buf = malloc(size_of_pages);
     if (NULL == read_buf)
-        CRYPT_TEST_FAULT("couldn't allocate memory for one_page_write_buf\n");
+        CRYPT_TEST_FAULT("couldn't allocate memory for read_buf\n");
 
     /* Reads the data back that was just written */
     if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, size_of_pages, 
@@ -8889,16 +8936,20 @@ crypt_test_invalid_config_helper(bool cl_config, size_t pt_size, size_t ct_size,
         /* cipher                 = */ cipher,  
         /* cipher_block_size      = */ block_size,
         /* key_size               = */ key_size,
-        /* key                    = */ H5FD_CRYPT_TEST_KEY,
+        /* key_path               = */ NULL,
+        /* key                    = */ NULL,
         /* iv_size                = */ iv_size,
         /* mode                   = */ mode,
         /* fapl_id                = */ H5P_DEFAULT
     };
 
+    vfd_config.key = malloc(vfd_config.key_size);
+    memcpy(vfd_config.key, H5FD_CRYPT_TEST_KEY, vfd_config.key_size);
 
-/* setup the target file name */
+    /* setup the target file name */
     
     h5_fixname(FILENAME[17], vfd_config.fapl_id, filename, 1024);
+    HDremove(filename);
 
     /* create and initialize FAPL for the encryption VFD */
     
@@ -9013,6 +9064,8 @@ done:
         H5E_END_TRY
     }
 
+    if ( vfd_config.key )
+        free(vfd_config.key);
 
     return ret_value;
 
@@ -9076,7 +9129,8 @@ crypt_test_invalid_addrs_and_buffs(bool cl_config)
         /* cipher                 = */ 0,  
         /* cipher_block_size      = */ 16,
         /* key_size               = */ 32,
-        /* key                    = */ H5FD_CRYPT_TEST_KEY,
+        /* key_path               = */ NULL,
+        /* key                    = */ NULL,
         /* iv_size                = */ 16,
         /* mode                   = */ 0,
         /* fapl_id                = */ H5P_DEFAULT
@@ -9086,7 +9140,10 @@ crypt_test_invalid_addrs_and_buffs(bool cl_config)
     unsigned char        *zero_buf          = NULL;
     size_t                size              = vfd_config.plaintext_page_size;
     herr_t                ret; 
-    int                   ret_value    = 0;
+    int                   ret_value         = 0;
+
+    vfd_config.key = malloc(vfd_config.key_size);
+    memcpy(vfd_config.key, H5FD_CRYPT_TEST_KEY, vfd_config.key_size);
 
     /* setup the target file name, and delete any existing instance */
     h5_fixname(FILENAME[17], vfd_config.fapl_id, filename, 1024);
@@ -9249,6 +9306,55 @@ crypt_test_invalid_addrs_and_buffs(bool cl_config)
         CRYPT_TEST_FAULT("Did not handle invalid ID error correctly\n");
 
 
+    /********************************************************************************/
+    /***** TEST READ WHEN SIZE IS 0, SHOULD SUCCEED BUT BUFFER WILL BE EMPTY *****/
+    /********************************************************************************/
+
+    if (( ret = H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, 0, zero_buf)) < 0 )
+    {
+        CRYPT_TEST_FAULT("Zero sized read failed\n");
+    }
+
+    /* Ensure no data was read into zero_buf */
+    if (memcmp(setup_buf, zero_buf, size) != 0) 
+    {
+        for ( size_t i = 0; i < size; i++ )
+        {
+            if ( zero_buf[i] != 0 )
+            {
+                CRYPT_TEST_FAULT("zero_buf modified during zero-size read\n");
+            }
+        }
+    }
+    else
+    {
+        CRYPT_TEST_FAULT("Data read when size of read is 0\n");
+    }
+
+
+    /***********************************************************************************/
+    /***** TEST WRITE WHEN SIZE IS 0, SHOULD SUCCEED BUT NOTHING WILL BE WRITTEN *****/
+    /***********************************************************************************/
+
+    if (( ret = H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, 0, zero_buf)) < 0 )
+    {
+        CRYPT_TEST_FAULT("Zero sized write failed\n");
+    }
+
+    /* Verify the zero sized write didn't actually write any data */
+    if (( ret = H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, size, valid_buf)) < 0 )
+    {
+        CRYPT_TEST_FAULT("Zero sized read failed\n");
+    }
+    else
+    {
+        if (memcmp(setup_buf, valid_buf, size) != 0) 
+        {
+            CRYPT_TEST_FAULT("Data was written when size of write was 0\n");
+        }
+    }
+
+
     /**********************************************************************/
     /***** TEST READ WHEN ADDR IS NOT ON A PAGE BOUNDARY, SHOULD FAIL *****/
     /**********************************************************************/
@@ -9391,54 +9497,8 @@ crypt_test_invalid_addrs_and_buffs(bool cl_config)
         CRYPT_TEST_FAULT("Did not handle addr overflow error correctly\n");
 
 
-    /********************************************************************************/
-    /***** TEST READ WHEN SIZE IS 0, SHOULD SUCCEED BUT BUFFER WILL BE EMPTY *****/
-    /********************************************************************************/
 
-    if (( ret = H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, 0, zero_buf)) < 0 )
-    {
-        CRYPT_TEST_FAULT("Zero sized read failed\n");
-    }
-
-    /* Ensure no data was read into zero_buf */
-    if (memcmp(setup_buf, zero_buf, size) != 0) 
-    {
-        for ( size_t i = 0; i < size; i++ )
-        {
-            if ( zero_buf[i] != 0 )
-            {
-                CRYPT_TEST_FAULT("zero_buf modified during zero-size read\n");
-            }
-        }
-    }
-    else
-    {
-        CRYPT_TEST_FAULT("Data read when size of read is 0\n");
-    }
-
-
-    /***********************************************************************************/
-    /***** TEST WRITE WHEN SIZE IS 0, SHOULD SUCCEED BUT NOTHING WILL BE WRITTEN *****/
-    /***********************************************************************************/
-
-    if (( ret = H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, 0, zero_buf)) < 0 )
-    {
-        CRYPT_TEST_FAULT("Zero sized write failed\n");
-    }
-
-    /* Verify the zero sized write didn't actually write any data */
-    if (( ret = H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, size, valid_buf)) < 0 )
-    {
-        CRYPT_TEST_FAULT("Zero sized read failed\n");
-    }
-    else
-    {
-        if (memcmp(setup_buf, valid_buf, size) != 0) 
-        {
-            CRYPT_TEST_FAULT("Data was written when size of write was 0\n");
-        }
-    }
-
+    /***** Tests end *****/
 
     if (H5Pclose(fapl_id) < 0) {
         CRYPT_TEST_FAULT("can't close fapl\n");
@@ -9472,17 +9532,20 @@ done:
         free(zero_buf);
     }
 
+    if ( vfd_config.key )
+        free(vfd_config.key);
+
     return ret_value;
 
 } /* end crypt_test_invalid_addrs_and_buffs() */
 
 
 /*-------------------------------------------------------------------------
- * Function:    crypt_test_using_env_var
+ * Function:    crypt_test_with_cl_using_env
  *
- * Purpose:     Creates a file and does a write and read test by using the
- *              configuration language set by the environment variables,
- *              HDF5_DRIVER and HDF5_DRIVER_CONFIG.
+ * Purpose:     Tests that the encryption VFD works using configuration 
+ *              language set by the environment variables HDF5_DRIVER and 
+ *              HDF5_DRIVER_CONFIG. 
  *
  * Return:      Success:        0
  *              Failure:        -1
@@ -9505,7 +9568,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static int 
-crypt_test_using_env_var(void)
+crypt_test_with_cl_using_env(void)
 {
     char             filename[1024];
     hid_t            fapl_id          = H5I_INVALID_HID;
@@ -9530,8 +9593,52 @@ crypt_test_using_env_var(void)
     int              cipher; 
     int              fd               = -1;
     bool             env_set          = FALSE;
+    uint8_t         *test_key         = NULL;
 
     int              ret_value        = 0;
+
+    test_key = malloc(H5FD_CRYPT_DEFAULT_KEY_SIZE);
+    memcpy(test_key, H5FD_CRYPT_TEST_KEY, H5FD_CRYPT_DEFAULT_KEY_SIZE);
+
+
+    /* setup the target file name, and delete any existing instance */
+    h5_fixname(FILENAME[17], H5P_DEFAULT, filename, 1024);
+    HDremove(filename);
+
+    /* Buffer to hold the data that will be used to test the write function */
+    setup_buf = malloc(plaintext_size);
+    if (NULL == setup_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for setup_buf\n");
+
+    /* Fill the buffer with random characters to simulate data */
+    for (size_t i = 0; i < plaintext_size; i++)
+        setup_buf[i] = (unsigned char)rand() % 256;
+
+    /**
+     * Allocate read buffer.
+     * 
+     * NOTE: read buffer is the size of 3 ciphertext pages, due to 
+     * the using POSIX calls to read the entire file, including the 
+     * first two configuration pages and the IV blocks of the 
+     * ciphertext pages, to ensure correct data.
+     */
+    read_buf = malloc(3 * ciphertext_size);
+    if (NULL == read_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for read_buf\n");
+
+    /* Allocate buffer to store the data for comparison */
+    compare_buf = malloc(file_size);
+    if (NULL == compare_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for compare_buf\n");
+
+    /* Allocate buffer to store the IVs for the second and third pages */
+    iv_second_page = malloc(iv_size);
+    if (NULL == iv_second_page)
+        CRYPT_TEST_FAULT("couldn't allocate memory for iv_second_page\n");
+    
+    iv_third_page = malloc(iv_size);
+    if (NULL == iv_third_page)
+        CRYPT_TEST_FAULT("couldn't allocate memory for iv_third_page\n");
 
 
     for ( int c = 0; c < num_ciphers; c++ )
@@ -9574,16 +9681,10 @@ crypt_test_using_env_var(void)
         if ( setenv(HDF5_DRIVER_CONFIG, config_str, 1) != 0 )
             CRYPT_TEST_FAULT("failed to set environment variable\n");
 
-
         env_set = TRUE;
 
         /* Re-open the library */
         H5open();
-
-
-        /* setup the target file name, and delete any existing instance */
-        h5_fixname(FILENAME[17], H5P_DEFAULT, filename, 1024);
-        HDremove(filename);
 
 
         /* Double check the environment variables were set correctly */
@@ -9604,12 +9705,6 @@ crypt_test_using_env_var(void)
         if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) == H5I_INVALID_HID) {
             CRYPT_TEST_FAULT("can't create FAPL ID\n");
         }
-
-#if 0
-        if (H5CL_load_vfd_config_str_into_fapl(fapl_id, returned_env_var) < 0) {
-            CRYPT_TEST_FAULT("can't load config string into fapl\n");
-        }
-#endif
 
         /**
          * The driver returned should be the page buffer, because it is the
@@ -9636,15 +9731,6 @@ crypt_test_using_env_var(void)
         /***** Simple Write and Read Test *****/
         /**************************************/
 
-        /* Buffer to hold the data that will be used to test the write function */
-        setup_buf = malloc(plaintext_size);
-        if (NULL == setup_buf)
-            CRYPT_TEST_FAULT("couldn't allocate memory for setup_buf\n");
-
-        /* Fill the buffer with random characters to simulate data */
-        for (size_t i = 0; i < plaintext_size; i++)
-            setup_buf[i] = (unsigned char)rand() % 256;
-
         /* set the eoa so we can write the page of data */
         if ( H5FDset_eoa(file_ptr, H5FD_MEM_DEFAULT, (haddr_t)plaintext_size) < 0 )
             CRYPT_TEST_FAULT("couldn't set file eoa\n");
@@ -9653,19 +9739,6 @@ crypt_test_using_env_var(void)
 
         if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, plaintext_size, setup_buf) < 0)
             CRYPT_TEST_FAULT("couldn't write data to file\n");
-
-        
-        /**
-         * Allocate read buffer.
-         * 
-         * NOTE: read buffer is the size of 3 ciphertext pages, due to 
-         * the using POSIX calls to read the entire file, including the 
-         * first two configuration pages and the IV blocks of the 
-         * ciphertext pages, to ensure correct data.
-         */
-        read_buf = malloc(3 * ciphertext_size);
-        if (NULL == read_buf)
-            CRYPT_TEST_FAULT("couldn't allocate memory for read_buf\n");
         
 
         /***** Read the data back that was just written, should be decrypted *****/
@@ -9701,15 +9774,6 @@ crypt_test_using_env_var(void)
         if (pread(fd, read_buf, file_size, 0) != (ssize_t)file_size)
             CRYPT_TEST_FAULT("couldn't read file using POSIX calls\n");
 
-        /* Allocate buffer to store the IVs for the second and third pages */
-        iv_second_page = malloc(iv_size);
-        if (NULL == iv_second_page)
-            CRYPT_TEST_FAULT("couldn't allocate memory for iv_second_page\n");
-        
-        iv_third_page = malloc(iv_size);
-        if (NULL == iv_third_page)
-            CRYPT_TEST_FAULT("couldn't allocate memory for iv_third_page\n");
-
         /* Copies the IV for the second page to encrypt the manually made second page */
         if (memcpy(iv_second_page, read_buf + ciphertext_size, iv_size) == NULL)
             CRYPT_TEST_FAULT("couldn't copy second page's IV from read_buf\n");
@@ -9727,12 +9791,6 @@ crypt_test_using_env_var(void)
          * Manually creating the data of the three pages into a buffer to compare
          * the read_buf with to ensure the data in the file is correct.
          */
-
-        /* Allocate buffer to store the data for comparison */
-        compare_buf = malloc(file_size);
-        if (NULL == compare_buf)
-            CRYPT_TEST_FAULT("couldn't allocate memory for compare_buf\n");
-
 
         /* Manually create the first page and store it in the compare buf */
 
@@ -9788,7 +9846,7 @@ crypt_test_using_env_var(void)
         }
 
         
-        if ( gcry_cipher_setkey(handle, H5FD_CRYPT_TEST_KEY, 32) != 0 )
+        if ( gcry_cipher_setkey(handle, test_key, 32) != 0 )
             CRYPT_TEST_FAULT("couldn't set key\n");
 
         /* Stores the second page's IV into the compare buf */
@@ -9824,7 +9882,7 @@ crypt_test_using_env_var(void)
                 CRYPT_TEST_FAULT("couldn't open cipher handle for page 3 (TWOFISH)\n");
         }
 
-        if ( gcry_cipher_setkey(handle, H5FD_CRYPT_TEST_KEY, 32) != 0 )
+        if ( gcry_cipher_setkey(handle, test_key, 32) != 0 )
             CRYPT_TEST_FAULT("couldn't set key the for page 3\n");
 
         /* Stores the third page's IV into the compare buf */
@@ -9892,19 +9950,6 @@ crypt_test_using_env_var(void)
             CRYPT_TEST_FAULT("environment variable not default\n");
 
 
-        free(setup_buf);
-        setup_buf = NULL;
-        free(compare_buf);
-        compare_buf = NULL;
-        free(read_buf);
-        read_buf = NULL;
-        free(test_phrase_buf);
-        test_phrase_buf = NULL;
-        free(iv_second_page);
-        iv_second_page = NULL;
-        free(iv_third_page);
-        iv_third_page = NULL;
-
     } /* end for ( int c = 0; c < num_ciphers; c++ ) */
 
 done:
@@ -9937,6 +9982,9 @@ done:
     if (iv_third_page)
         free(iv_third_page);
 
+    if ( test_key )
+        free(test_key);
+
     if ( env_set )
     {
         H5close();
@@ -9947,11 +9995,11 @@ done:
 
     return ret_value;
 
-} /* end crypt_test_using_env_var() */
+} /* end crypt_test_with_cl_using_env() */
 
 
 /*-------------------------------------------------------------------------
- * Function:    crypt_test_invalid_config_using_env_var
+ * Function:    crypt_test_invalid_config_using_env
  *
  * Purpose:     Tests that if the configuration data is set via the 
  *              environment variables, HDF5_DRIVER and HDF5_DRIVER_CONFIG,
@@ -9976,7 +10024,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static int 
-crypt_test_invalid_config_using_env_var(void)
+crypt_test_invalid_config_using_env(void)
 {
     char             filename[1024];
     hid_t            fapl_id          = H5I_INVALID_HID;
@@ -9989,12 +10037,12 @@ crypt_test_invalid_config_using_env_var(void)
 
     char config_str[] =
         "( page_buffer "
-        "  ( ( page_size 4000 )"
+        "  ( ( page_size 4096 )"
         "    ( max_num_pages 16 )"
         "    ( replacement_policy 0 )"
         "    ( underlying_VFD "
         "      ( encryption_VFD "
-        "        ( ( plaintext_page_size  4096 )"
+        "        ( ( plaintext_page_size  4000 )"
         "          ( ciphertext_page_size 4112 )"
         "          ( encryption_buffer_size 65792 )"
         "          ( cipher 0 )"
@@ -10086,14 +10134,10 @@ crypt_test_invalid_config_using_env_var(void)
      */
     if ( fapl_id != H5I_INVALID_HID )
     {
-        H5Pclose(fapl_id);
+        if (H5Pclose(fapl_id) < 0) {
+            CRYPT_TEST_FAULT("can't close fapl\n");
+        }
         fapl_id = H5I_INVALID_HID;
-    }
-    
-    if ( file_ptr )
-    {
-        H5FDclose(file_ptr);
-        file_ptr = NULL;
     }
 
     /* Close the library */
@@ -10125,14 +10169,14 @@ crypt_test_invalid_config_using_env_var(void)
 
 done:
 
-    if ( fapl_id != H5I_INVALID_HID )
-    {
-        H5Pclose(fapl_id);
-    }
-    
     if ( file_ptr )
     {
         H5FDclose(file_ptr);
+    }
+
+    if ( fapl_id != H5I_INVALID_HID )
+    {
+        H5Pclose(fapl_id);
     }
 
     if ( env_set )
@@ -10145,7 +10189,590 @@ done:
 
     return ret_value;
 
-} /* end crypt_test_invalid_config_using_env_var() */
+} /* end crypt_test_invalid_config_using_env() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    crypt_test_with_cl_and_key_from_files
+ *
+ * Purpose:     Tests that the encryption VFD's configuration can be set 
+ *              via a config file (simple .txt file) and that the encryption
+ *              key can be set via separate key file (simple .txt file for
+ *              this test)
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ * Description: Creates the key file with the test key and mallocs buffers
+ *              needed for the test writes and reads.
+ * 
+ *              Iterates between all valid ciphers, creating a config file,
+ *              then sets up the encryption VFD, creates a new file and 
+ *              opens it, writes a page to it, reads that page back, 
+ *              compares what was read and written to ensure they are 
+ *              correct. 
+ * 
+ *              Closes and deletes the key and config files.
+ *
+ *-------------------------------------------------------------------------
+ */
+static int 
+crypt_test_with_cl_and_key_from_files(void)
+{
+    char             filename[1024];
+    hid_t            fapl_id          = H5I_INVALID_HID;
+    H5FD_t          *file_ptr         = NULL;
+    char             config_str[1024];
+    unsigned char   *write_buf        = NULL;
+    unsigned char   *read_buf         = NULL;
+    size_t           plaintext_size   = H5FD_CRYPT_DEFAULT_PLAINTEXT_PAGE_SIZE;
+    int32_t          cipher_array[]   = {0, 1};
+    int32_t          num_ciphers      = sizeof(cipher_array) / sizeof(cipher_array[0]);
+    int              cipher; 
+    const char      *key_file_name    = "test_key_file.txt";
+    char             key_file_path[512];
+    const char      *cl_file_name    = "test_crypt_cl_file.txt";
+    char             cl_file_path[512];
+    bool             key_file_created = FALSE;
+    bool             cl_file_created  = FALSE;
+
+    int              ret_value        = 0;
+
+    /* zero out config_str */
+    memset(&(config_str[0]), 0, sizeof(config_str));
+
+    /* Create a key file */
+    if ( create_files_for_crypt(key_file_name, NULL, key_file_path, 1) != 0 )
+        CRYPT_TEST_FAULT("failed to create and write test key to key file\n");
+
+    key_file_created = TRUE;
+
+
+    /* Buffer to hold the data that will be used to test the write function */
+    write_buf = malloc(plaintext_size);
+    if (NULL == write_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for write_buf\n");
+
+    /* Fill the buffer with random characters to simulate data */
+    for (size_t i = 0; i < (plaintext_size); i++)
+        write_buf[i] = (unsigned char)rand() % 256;
+
+    /* Buffer for the read test to try to store the page that was just written */
+    read_buf = malloc(plaintext_size);
+    if (NULL == read_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for read_buf\n");
+
+
+    /**
+     * Tests creating, opening, writing and reading an encrypted file with the
+     * encryption key stored in a separate key file, and the configuration string
+     * stored in a separate config file that contains the path to the key file, 
+     * for all supported ciphers.
+     */
+    for ( int c = 0; c < num_ciphers; c++ )
+    {
+        cipher = cipher_array[c];
+
+        snprintf(config_str, sizeof(config_str),
+            "( page_buffer "
+            "  ( ( page_size 4096 )"
+            "    ( max_num_pages 16 )"
+            "    ( replacement_policy 0 )"
+            "    ( underlying_VFD "
+            "      ( encryption_VFD "
+            "        ( ( plaintext_page_size  4096 )"
+            "          ( ciphertext_page_size 4112 )"
+            "          ( encryption_buffer_size 65792 )"
+            "          ( cipher %d )"
+            "          ( cipher_block_size 16 )"
+            "          ( key_path \"%s\" )"
+            "          ( iv_size 16 )"
+            "          ( mode 0 )"
+            "          ( underlying_VFD ( sec2 () ) )"
+            "        )"
+            "      )"
+            "    )"
+            "  )"
+            ")",
+            cipher,
+            key_file_path
+        );
+
+        /* Create a key file */
+        if ( create_files_for_crypt(cl_file_name, config_str, cl_file_path, 0) != 0 )
+            CRYPT_TEST_FAULT("failed to create and write test key to key file\n");
+
+        cl_file_created = TRUE;
+
+        /* setup the target file name, and delete any existing instance */
+        h5_fixname(FILENAME[17], H5P_DEFAULT, filename, 1024);
+        HDremove(filename);
+
+
+        /* create and initialize FAPL for the encryption VFD */
+
+        if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) == H5I_INVALID_HID) {
+            CRYPT_TEST_FAULT("can't create FAPL ID\n");
+        }
+
+        if ( H5CLset_config_from_file(fapl_id, cl_file_path) < 0 ) {
+            CRYPT_TEST_FAULT("can't read config str from file and load it into fapl\n");
+        }
+
+        /**
+         * The driver returned should be the page buffer, because it is the
+         * top most VFD in the VFD stack set by the environment variables.
+         */
+        if (H5Pget_driver(fapl_id) != H5FD_PB) {
+            CRYPT_TEST_FAULT("set FAPL not encryption VFD\n");
+        }
+
+        if (compare_crypt_config_str(fapl_id, config_str) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+
+
+        /* Opens a file that doesn't exist, should create the file */
+
+        if (NULL == (file_ptr = H5FDopen(filename, H5F_ACC_RDWR | H5F_ACC_CREAT,
+                        fapl_id, HADDR_UNDEF))) 
+            CRYPT_TEST_FAULT("couldn't get pointer to H5FD_t structure\n");
+
+
+        /********** Buffer setup to test write data to the file  **********/
+
+        /* set the eoa so we can write the page of data */
+        if ( H5FDset_eoa(file_ptr, H5FD_MEM_DEFAULT, (haddr_t)(plaintext_size)) < 0 )
+            CRYPT_TEST_FAULT("couldn't set file eoa\n");
+        
+        /* Write the data to the file */
+        if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, plaintext_size, 
+                        write_buf) < 0)
+            CRYPT_TEST_FAULT("couldn't write data to file\n");
+
+        /* Reads the data back that was just written */
+        if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, plaintext_size, 
+                        read_buf) < 0)
+            CRYPT_TEST_FAULT("couldn't read data from file\n");
+
+        if (memcmp(write_buf, read_buf, plaintext_size) != 0)
+            CRYPT_TEST_FAULT("data read from file does not match data written\n");
+
+
+        if (H5Pclose(fapl_id) < 0) {
+            CRYPT_TEST_FAULT("can't close fapl\n");
+        }
+        fapl_id = H5I_INVALID_HID;
+
+        if (H5FDclose(file_ptr) < 0) {
+            CRYPT_TEST_FAULT("can't close file\n");
+        }
+        file_ptr = NULL;
+
+
+    } /* end for ( int c = 0; c < num_ciphers; c++ ) */
+
+    if ( key_file_created )
+    {
+        if ( remove(key_file_path) != 0 )
+            CRYPT_TEST_FAULT("failed to delete key file\n");
+    }
+
+    if ( cl_file_created )
+    {
+        if ( remove(cl_file_path) != 0 )
+            CRYPT_TEST_FAULT("failed to delete cl file\n");
+    }
+
+done:
+
+    if ( fapl_id != H5I_INVALID_HID )
+    {
+        H5Pclose(fapl_id);
+    }
+    
+    if ( file_ptr )
+    {
+        H5FDclose(file_ptr);
+    }
+
+    if ( write_buf )
+        free(write_buf);
+
+    if ( read_buf )
+        free(read_buf);
+
+
+    return ret_value;
+
+}/* end crypt_test_with_cl_and_key_from_files() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    create_files_for_crypt
+ *
+ * Purpose:     Helper function for crypt_test_with_cl_and_key_from_files()
+ *              to create the files needed for that test and sets parameter
+ *              char *file_path to the path of the created file.
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+create_files_for_crypt(const char *file_name, const char *config_str, char *file_path,  int file_type)
+{
+    size_t  written;
+    uint8_t *test_key = NULL;
+
+    int    ret_value = 0;
+
+    test_key = malloc(H5FD_CRYPT_DEFAULT_KEY_SIZE);
+    memcpy(test_key, H5FD_CRYPT_TEST_KEY, H5FD_CRYPT_DEFAULT_KEY_SIZE);
+
+    /* Open the file and truncate if it already exists */
+    FILE *fp = fopen(file_name, "w");
+    if ( !fp ) 
+    {
+        CRYPT_TEST_FAULT("fopen failed to open/create key_file\n");
+    }
+
+    if ( file_type == 0 )
+    {
+        assert(config_str);
+
+        written = fwrite(config_str, 1, strlen(config_str), fp);
+        if ( written == 0 )
+        {
+            CRYPT_TEST_FAULT("fwrite failed to write config_str to config file\n");
+        }
+    }
+    else if ( file_type == 1 )
+    {
+        /* Write the test key to the file */
+        written = fwrite(test_key, 1, H5FD_CRYPT_DEFAULT_KEY_SIZE, fp);
+        if ( written != H5FD_CRYPT_DEFAULT_KEY_SIZE)
+        {
+            CRYPT_TEST_FAULT("fwrite failed to write crypt key to key file\n");
+        }
+    }
+
+
+    /* Get the absolute path to the file */
+    if ( realpath(file_name, file_path) == NULL )
+        CRYPT_TEST_FAULT("failed to get absolute path to file \n");
+
+
+done:
+
+    if ( fp )
+    {
+        fclose(fp);
+    }
+
+    free(test_key);
+
+    return ret_value;
+
+} /* end create_key_file() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    crypt_test_using_key_path_env
+ *
+ * Purpose:     Tests that the encryption VFD can use a path to a key file
+ *              to access the key via the environment variable 
+ *              H5FD_CRYPT_KEY_PATH
+ *
+ * Return:      Success:        0
+ *              Failure:        -1
+ *
+ * Description: Creates a key file and mallocs the necessary buffers for the
+ *              test.
+ * 
+ *              Closes the library to set the environment varaible
+ *              H5FD_CRYPT_KEY_PATH to the path of the key file, then re-opens
+ *              the library.
+ * 
+ *              Uses either config_str or vfd_config depending on the
+ *              parameter bool cl_config to set the encryption VFD's 
+ *              configuration.
+ * 
+ *              Creates and opens a new file and performs a write to it, then
+ *              reads that back and compares to ensure what was written and
+ *              read is correct.
+ * 
+ *              Closes the library to reset the environment variable back
+ *              to default, and closes and deletes the key file.
+ *
+ *-------------------------------------------------------------------------
+ */
+static int 
+crypt_test_using_key_path_env(bool cl_config)
+{
+    char             filename[1024];
+    hid_t            fapl_id          = H5I_INVALID_HID;
+    H5FD_t          *file_ptr         = NULL;
+    unsigned char   *write_buf        = NULL;
+    unsigned char   *read_buf         = NULL;
+    size_t           plaintext_size   = H5FD_CRYPT_DEFAULT_PLAINTEXT_PAGE_SIZE;
+    const char      *key_file_name    = "test_key_file.txt";
+    char             key_file_path[512];
+    char            *returned_env_var = NULL;
+    bool             env_set          = FALSE;
+    bool             key_file_created = FALSE;
+
+    int              ret_value        = 0;
+
+
+    /* Create a key file */
+    if ( create_files_for_crypt(key_file_name, NULL, key_file_path, 1) != 0 )
+        CRYPT_TEST_FAULT("failed to create and write test key to key file\n");
+
+    key_file_created = TRUE;
+
+    /* Buffer to hold the data that will be used to test the write function */
+    write_buf = malloc(plaintext_size);
+    if (NULL == write_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for write_buf\n");
+
+    /* Fill the buffer with random characters to simulate data */
+    for (size_t i = 0; i < (plaintext_size); i++)
+        write_buf[i] = (unsigned char)rand() % 256;
+
+    /* Buffer for the read test to try to store the page that was just written */
+    read_buf = malloc(plaintext_size);
+    if (NULL == read_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for read_buf\n");
+
+
+    /**
+     * Tests creating, opening, writing and reading an encrypted file with the
+     * encryption key stored in a separate key file with the path to the key file
+     * set to an environment variable.
+     */
+    char config_str[] =
+        "( page_buffer "
+        "  ( ( page_size 4096 )"
+        "    ( max_num_pages 16 )"
+        "    ( replacement_policy 0 )"
+        "    ( underlying_VFD "
+        "      ( encryption_VFD "
+        "        ( ( plaintext_page_size  4096 )"
+        "          ( ciphertext_page_size 4112 )"
+        "          ( encryption_buffer_size 65792 )"
+        "          ( cipher 0 )"
+        "          ( cipher_block_size 16 )"
+        "          ( iv_size 16 )"
+        "          ( mode 0 )"
+        "          ( underlying_VFD ( sec2 () ) )"
+        "        )"
+        "      )"
+        "    )"
+        "  )"
+        ")";
+
+    H5FD_crypt_vfd_config_t vfd_config = 
+    {
+        /* magic                  = */ H5FD_CRYPT_CONFIG_MAGIC,
+        /* version                = */ H5FD_CURR_CRYPT_VFD_CONFIG_VERSION,
+        /* plaintext_page_size    = */ H5FD_CRYPT_DEFAULT_PLAINTEXT_PAGE_SIZE,
+        /* ciphertext_page_size   = */ H5FD_CRYPT_DEFAULT_CIPHERTEXT_PAGE_SIZE,
+        /* encryption_buffer_size = */ H5FD_CRYPT_DEFAULT_ENCRYPTION_BUFFER_SIZE,
+        /* cipher                 = */ H5FD_CRYPT_DEFAULT_CIPHER,  
+        /* cipher_block_size      = */ H5FD_CRYPT_DEFAULT_CIPHER_BLOCK_SIZE,
+        /* key_size               = */ 0,
+        /* key_path               = */ NULL,
+        /* key                    = */ NULL,
+        /* iv_size                = */ H5FD_CRYPT_DEFAULT_IV_SIZE,
+        /* mode                   = */ H5FD_CRYPT_DEFAULT_MODE,
+        /* fapl_id                = */ H5P_DEFAULT
+    };
+
+    /* setup the target file name, and delete any existing instance */
+    h5_fixname(FILENAME[17], H5P_DEFAULT, filename, 1024);
+    HDremove(filename);
+
+    /* Set the key path environment variable */
+    
+    /* Close the library to set the environment variables before reopening the library */
+    H5close();
+
+    /* Set environment variable */
+    if ( setenv(HDF5_CRYPT_KEY_PATH, key_file_path, 1) != 0 )
+        CRYPT_TEST_FAULT("failed to set environment variable\n");
+
+    env_set = TRUE;
+
+    /* Re-open the library */
+    H5open();
+
+
+    /* Double check the environment variables were set correctly */
+
+    returned_env_var = getenv(HDF5_CRYPT_KEY_PATH);
+
+    if ( strcmp(key_file_path, returned_env_var) != 0 )
+        CRYPT_TEST_FAULT("returned environment variable doesn't match\n");
+
+
+
+    /* create and initialize FAPL for the encryption VFD */
+
+    if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) == H5I_INVALID_HID) {
+        CRYPT_TEST_FAULT("can't create FAPL ID\n");
+    }
+
+    if ( cl_config ) {
+
+        if (H5CL_load_vfd_config_str_into_fapl(fapl_id, config_str) < 0) {
+            CRYPT_TEST_FAULT("can't load config string into fapl\n");
+        }
+
+        /**
+         * Returns H5FD_PB, because the page_buffer is set as the top
+         * most VFD in a stack (page_buffer->encryption->sec2)
+         */
+        if (H5Pget_driver(fapl_id) != H5FD_PB) {
+            CRYPT_TEST_FAULT("set FAPL not encryption VFD\n");
+        }
+    } 
+    else {
+
+        if (H5Pset_fapl_crypt(fapl_id, &vfd_config) < 0) {
+            CRYPT_TEST_FAULT("can't set enryption VFD FAPL\n");
+        }
+
+        if (H5Pget_driver(fapl_id) != H5FD_CRYPT) {
+            CRYPT_TEST_FAULT("set FAPL not encryption VFD\n");
+        }
+    }
+
+
+
+    if ( cl_config ) {
+
+        if (compare_crypt_config_str(fapl_id, config_str) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+
+    } else {
+
+        if (compare_crypt_config_info(fapl_id, &vfd_config) < 0) {
+            CRYPT_TEST_FAULT("information mismatch\n");
+        }
+    }
+
+
+    /* Opens a file that doesn't exist, should create the file */
+    if (NULL == (file_ptr = H5FDopen(filename, H5F_ACC_RDWR | H5F_ACC_CREAT,
+                    fapl_id, HADDR_UNDEF))) 
+        CRYPT_TEST_FAULT("couldn't get pointer to H5FD_t structure\n");
+
+
+
+    /********** Buffer setup to test write data to the file  **********/
+
+    /* Buffer to hold the data that will be used to test the write function */
+    write_buf = malloc(plaintext_size);
+    if (NULL == write_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for write_buf\n");
+
+    /* Fill the buffer with random characters to simulate data */
+    for (size_t i = 0; i < (plaintext_size); i++)
+        write_buf[i] = (unsigned char)rand() % 256;
+
+    /* set the eoa so we can write the page of data */
+    if ( H5FDset_eoa(file_ptr, H5FD_MEM_DEFAULT, (haddr_t)(plaintext_size)) < 0 )
+        CRYPT_TEST_FAULT("couldn't set file eoa\n");
+    
+    /* Write the data to the file */
+    if (H5FDwrite(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, plaintext_size, 
+                    write_buf) < 0)
+        CRYPT_TEST_FAULT("couldn't write data to file\n");
+
+    /* Buffer for the read test to try to store the page that was just written */
+    read_buf = malloc(plaintext_size);
+    if (NULL == read_buf)
+        CRYPT_TEST_FAULT("couldn't allocate memory for read_buf\n");
+
+    /* Reads the data back that was just written */
+    if (H5FDread(file_ptr, H5FD_MEM_DEFAULT, H5P_DEFAULT, 0, plaintext_size, 
+                    read_buf) < 0)
+        CRYPT_TEST_FAULT("couldn't read data from file\n");
+
+    if (memcmp(write_buf, read_buf, plaintext_size) != 0)
+        CRYPT_TEST_FAULT("data read from file does not match data written\n");
+
+
+    if (H5Pclose(fapl_id) < 0) {
+        CRYPT_TEST_FAULT("can't close fapl\n");
+    }
+    fapl_id = H5I_INVALID_HID;
+
+    if (H5FDclose(file_ptr) < 0) {
+        CRYPT_TEST_FAULT("can't close file\n");
+    }
+    file_ptr = NULL;
+
+
+    /* Close the library */
+    H5close();
+
+    /* Set environment variable back to default values */
+    if ( unsetenv(HDF5_CRYPT_KEY_PATH) != 0 )
+        CRYPT_TEST_FAULT("failed to clear environment variable\n");
+
+    env_set = FALSE;
+
+    /* Re-open the library */
+    H5open();
+
+    /* Double check the environment variables were set correctly */
+    returned_env_var = getenv(HDF5_CRYPT_KEY_PATH);
+
+    if ( returned_env_var )
+        CRYPT_TEST_FAULT("environment variable not default\n");
+
+
+    if ( key_file_created )
+    {
+        if ( remove(key_file_path) != 0 )
+            CRYPT_TEST_FAULT("failed to delete key file\n");
+    }
+
+
+done:
+
+    if ( fapl_id != H5I_INVALID_HID )
+    {
+        H5Pclose(fapl_id);
+    }
+    
+    if ( file_ptr )
+    {
+        H5FDclose(file_ptr);
+    }
+
+    if ( write_buf )
+        free(write_buf);
+
+    if ( read_buf )
+        free(read_buf);
+
+
+    if ( env_set )
+    {
+        H5close();
+        unsetenv(HDF5_CRYPT_KEY_PATH);
+        H5open();
+    }
+
+
+    return ret_value;
+
+} /* end crypt_test_using_key_path_env() */
 
 
 /*-------------------------------------------------------------------------
@@ -10171,16 +10798,16 @@ done:
 static int
 run_crypt_test(const struct crypt_dataset_def *data, const hid_t child_fapl_id, bool cl_config)
 {
-    hid_t                    file_id           = H5I_INVALID_HID;
-    hid_t                    dset_id           = H5I_INVALID_HID;
-    hid_t                    space_id          = H5I_INVALID_HID;
-    hid_t                    fapl_id_out       = H5I_INVALID_HID;
-    hid_t                    pb_fapl_id_cpy    = H5I_INVALID_HID;
-    hid_t                    crypt_fapl_id_cpy = H5I_INVALID_HID;
-    hid_t                    pb_fapl_id        = H5I_INVALID_HID;
-    hid_t                    crypt_fapl_id     = H5I_INVALID_HID;
-    char                     filename[1024];
-    char                  config_str_sub_sec2[] =
+    hid_t file_id           = H5I_INVALID_HID;
+    hid_t dset_id           = H5I_INVALID_HID;
+    hid_t space_id          = H5I_INVALID_HID;
+    hid_t fapl_id_out       = H5I_INVALID_HID;
+    hid_t pb_fapl_id_cpy    = H5I_INVALID_HID;
+    hid_t crypt_fapl_id_cpy = H5I_INVALID_HID;
+    hid_t pb_fapl_id        = H5I_INVALID_HID;
+    hid_t crypt_fapl_id     = H5I_INVALID_HID;
+    char  filename[1024];
+    char  config_str_sub_sec2[] =
         "( page_buffer "
         "  ( ( page_size 4096 )"
         "    ( max_num_pages 64 )"
@@ -10202,7 +10829,7 @@ run_crypt_test(const struct crypt_dataset_def *data, const hid_t child_fapl_id, 
         "    )"
         "  )"
         ")";
-    char                  config_str_sub_default[] =
+    char  config_str_sub_default[] =
         "( page_buffer "
         "  ( ( page_size 4096 )"
         "    ( max_num_pages 64 )"
@@ -10243,13 +10870,16 @@ run_crypt_test(const struct crypt_dataset_def *data, const hid_t child_fapl_id, 
         /* cipher                 = */ 0,  
         /* cipher_block_size      = */ 16,
         /* key_size               = */ 32,
-        /* key                    = */ H5FD_CRYPT_TEST_KEY,
+        /* key_path               = */ NULL,
+        /* key                    = */ NULL,
         /* iv_size                = */ 16,
         /* mode                   = */ 0,
         /* fapl_id                = */ H5P_DEFAULT
     };
     int                   ret_value        = 0;
 
+    crypt_vfd_config.key = malloc(crypt_vfd_config.key_size);
+    memcpy(crypt_vfd_config.key, H5FD_CRYPT_TEST_KEY, crypt_vfd_config.key_size);
 
     /* setup the target file name, and delete any existing instance */
 
@@ -10516,6 +11146,9 @@ done:
         H5E_END_TRY
     }
 
+    if ( crypt_vfd_config.key )
+        free(crypt_vfd_config.key);
+
     return ret_value;
 
 } /* end run_crypt_test() */
@@ -10602,7 +11235,8 @@ crypt_RO_test(const struct crypt_dataset_def *data, hid_t child_fapl_id, bool cl
         /* cipher                 = */ 0,  
         /* cipher_block_size      = */ 16,
         /* key_size               = */ 32,
-        /* key                    = */ H5FD_CRYPT_TEST_KEY,
+        /* key_path               = */ NULL,
+        /* key                    = */ NULL,
         /* iv_size                = */ 16,
         /* mode                   = */ 0,
         /* fapl_id                = */ H5P_DEFAULT
@@ -10611,6 +11245,9 @@ crypt_RO_test(const struct crypt_dataset_def *data, hid_t child_fapl_id, bool cl
     hid_t                    crypt_fapl_id    = H5I_INVALID_HID;
     hid_t                    file_id          = H5I_INVALID_HID;
     int                      ret_value        = 0;
+
+    crypt_vfd_config.key = malloc(crypt_vfd_config.key_size);
+    memcpy((void *)crypt_vfd_config.key, (const void *)H5FD_CRYPT_TEST_KEY, crypt_vfd_config.key_size);
 
     /* setup the target file name, and delete any existing instance */
 
@@ -10746,6 +11383,9 @@ done:
         }
         H5E_END_TRY
     }
+
+    if ( crypt_vfd_config.key )
+        free(crypt_vfd_config.key);
 
     return ret_value;
 
@@ -10960,13 +11600,27 @@ test_crypt(bool cl_config)
     size_t                   num_buf_sizes;
     int32_t                  num_ciphers      = sizeof(cipher_array) / sizeof(cipher_array[0]);
     size_t                   num_pages;
-    bool                     test_quick       = FALSE;   
+    bool                     test_quick       = FALSE;  
+    uint8_t                 *test_key         = NULL;
 
 #if CRYPT_DEBUG_QUICK
     test_quick = TRUE;
 #endif
 
     testExpress = GetTestExpress();
+
+
+    /**
+     * Sets up the encryption tests based on the TestExpress level, and
+     * the global flag CRYPT_DEBUG_QUICK.
+     * 
+     * The lower TestExpress the more and larger page sizes, encryption
+     * buffer size, and number of pages tested.
+     * 
+     * If CRYPT_DEBUG_QUICK is set, only one page size and buffer size
+     * is tested, to quickly run through all encryption tests for 
+     * faster debugging.
+     */
 
     /* testExpress = 0*/
                                /* 1/2 KB 4 KB  128 KB   1 MB     4 MB     16 MB */
@@ -10984,7 +11638,7 @@ test_crypt(bool cl_config)
     static size_t  pt_array_3[]  = {512, 4096, 1048576};
     static size_t  buf_array_3[] = {1, 16};
 
-    /* testExpress == 3 */
+    /* CRYPT_DEBUG_QUICK */
     static size_t  pt_array_quick[]  = {4096};
     static size_t  buf_array_quick[] = {16};
 
@@ -11069,6 +11723,7 @@ test_crypt(bool cl_config)
         TEST_ERROR;
     }
 
+
     /* Test Read-Only access, including when the file does not exist.
      */
 
@@ -11098,6 +11753,9 @@ test_crypt(bool cl_config)
 
     if ( test_crypt_fapl(cl_config) != 0 )
         TEST_ERROR;
+
+    /* Allocate the test key */
+    test_key = malloc(H5FD_CRYPT_DEFAULT_KEY_SIZE);
 
     /* Run tests iterating through page sizes */
     for ( size_t p = 0; p < num_page_sizes; p++ )
@@ -11142,12 +11800,15 @@ test_crypt(bool cl_config)
                     /* encryption_buffer_size = */ crypt_buf_sizes[b] * (16 + plaintext_sizes[p]),
                     /* cipher                 = */ cipher_array[c],  
                     /* cipher_block_size      = */ 16,
-                    /* key_size               = */ 32,
-                    /* key                    = */ H5FD_CRYPT_TEST_KEY,
+                    /* key_size               = */ H5FD_CRYPT_DEFAULT_KEY_SIZE,
+                    /* key_path               = */ NULL,
+                    /* key                    = */ NULL,
                     /* iv_size                = */ 16,
                     /* mode                   = */ 0,
                     /* fapl_id                = */ H5P_DEFAULT
                 };
+                vfd_config.key = test_key;
+                memcpy(vfd_config.key, H5FD_CRYPT_TEST_KEY, vfd_config.key_size);
 
                 /* Tests creating a file with the encryption VFD */
                 if ( crypt_test_create(config_str_ptr, vfd_config) != 0 )
@@ -11181,24 +11842,38 @@ test_crypt(bool cl_config)
     if ( crypt_test_invalid_addrs_and_buffs(cl_config) < 0 ) 
         TEST_ERROR;
 
+    /* Tests using an environment variable to store the path to a key file */
+    if ( crypt_test_using_key_path_env(cl_config) < 0 )
+        TEST_ERROR;
 
     if ( cl_config )
     {
-        if ( crypt_test_using_env_var() < 0 )
+        /* Tests setting config with environment variables */
+        if ( crypt_test_with_cl_using_env() < 0 )
             TEST_ERROR;
 
-        if ( crypt_test_invalid_config_using_env_var() < 0 ) 
+        if ( crypt_test_invalid_config_using_env() < 0 ) 
             TEST_ERROR;
 
+        /**
+         * Tests setting config data and retrieving 
+         * encryption key from separate files.
+         */
+        if ( crypt_test_with_cl_and_key_from_files() < 0 )
+            TEST_ERROR;
     }
 
+    if ( test_key )
+        free(test_key);
 
     PASSED();
-
 
     return 0;
 
 error:
+
+    if ( test_key )
+        free(test_key);
 
     return -1;
 


### PR DESCRIPTION
Encryption VFD now stores keys in secure memory pool (with the exception of calling H5Pset_fapl_crypt() with an instance of H5FD_crypt_vfd_config_t that has the key field set to point to the key already, this will be updated next). Upon close or error during open, read, or write zeros the key and frees the allocated memory.
Can read a configuration string from a file and set the encryption VFD config from it.
Can pass keys to encryption VFD from a key file. Either by having the path to the key file in the configuration string, or by setting the environment variable H5FD_CRYPT_KEY_PATH to the key file path.